### PR TITLE
Add cmd/ layer tests (closes #13)

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 // TestAddCmdArgsValidation exercises the cobra-level argument validation
@@ -15,16 +13,7 @@ import (
 // argument — zero args and two args must fail; one arg must pass.
 func TestAddCmdArgsValidation(t *testing.T) {
 	// Locate the actual command instance via rootCmd so we match what users hit.
-	var addC *cobra.Command
-	for _, c := range rootCmd.Commands() {
-		if c.Name() == "add" {
-			addC = c
-			break
-		}
-	}
-	if addC == nil {
-		t.Fatal("add command not registered on rootCmd")
-	}
+	addC := findTopLevelCmd(t, "add")
 
 	tests := []struct {
 		name    string
@@ -60,7 +49,7 @@ func TestAddCmdDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
@@ -69,7 +58,9 @@ func TestAddCmdDispatch(t *testing.T) {
 		t.Fatalf("rootCmd.Execute(add): %v", err)
 	}
 
-	if atomic.LoadInt64(&patched) == 0 {
-		t.Error("add command did not PATCH /blocks/pageID/children")
+	// AddNewToDoItem should issue exactly one PATCH — a count > 1 would
+	// indicate an accidental retry regression.
+	if got := atomic.LoadInt64(&patched); got != 1 {
+		t.Errorf("add command PATCH count = %d, want 1", got)
 	}
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestAddCmdArgsValidation exercises the cobra-level argument validation
+// without invoking the Run function. `add` requires exactly one positional
+// argument — zero args and two args must fail; one arg must pass.
+func TestAddCmdArgsValidation(t *testing.T) {
+	// Locate the actual command instance via rootCmd so we match what users hit.
+	var addC *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "add" {
+			addC = c
+			break
+		}
+	}
+	if addC == nil {
+		t.Fatal("add command not registered on rootCmd")
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"zero args rejected", []string{}, true},
+		{"one arg accepted", []string{"buy milk"}, false},
+		{"two args rejected", []string{"buy", "milk"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := addC.Args(addC, tt.args); (err != nil) != tt.wantErr {
+				t.Errorf("addCmd.Args(%v) err=%v wantErr=%v", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestAddCmdDispatch runs `notioncli add "hello world"` end-to-end against
+// the mock Notion API and asserts a PATCH fired at /blocks/pageID/children
+// (the Notion endpoint that appends new children, which is what
+// utils.AddNewToDoItem calls).
+func TestAddCmdDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			atomic.AddInt64(&patched, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"add", "buy milk"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(add): %v", err)
+	}
+
+	if atomic.LoadInt64(&patched) == 0 {
+		t.Error("add command did not PATCH /blocks/pageID/children")
+	}
+}

--- a/cmd/blocks_test.go
+++ b/cmd/blocks_test.go
@@ -14,16 +14,7 @@ import (
 // child matching name, or fails the test.
 func findBlocksSubcommand(t *testing.T, name string) *cobra.Command {
 	t.Helper()
-	var blocksC *cobra.Command
-	for _, c := range rootCmd.Commands() {
-		if c.Name() == "blocks" {
-			blocksC = c
-			break
-		}
-	}
-	if blocksC == nil {
-		t.Fatal("blocks command not registered on rootCmd")
-	}
+	blocksC := findTopLevelCmd(t, "blocks")
 	for _, c := range blocksC.Commands() {
 		if c.Name() == name {
 			return c
@@ -36,16 +27,7 @@ func findBlocksSubcommand(t *testing.T, name string) *cobra.Command {
 // TestBlocksCmdRegistered verifies `blocks` is a top-level command and
 // owns its three subcommands (list, add, delete).
 func TestBlocksCmdRegistered(t *testing.T) {
-	var blocksC *cobra.Command
-	for _, c := range rootCmd.Commands() {
-		if c.Name() == "blocks" {
-			blocksC = c
-			break
-		}
-	}
-	if blocksC == nil {
-		t.Fatal("blocks command not registered on rootCmd")
-	}
+	blocksC := findTopLevelCmd(t, "blocks")
 
 	want := map[string]bool{"list": false, "add": false, "delete": false}
 	for _, c := range blocksC.Commands() {
@@ -139,7 +121,7 @@ func TestBlocksListDispatch(t *testing.T) {
 	// is a package-level variable; a stale "to_do" here would narrow results.
 	blockType = ""
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
@@ -170,7 +152,7 @@ func TestBlocksAddDispatch(t *testing.T) {
 	// Reset block type so the add command falls back to paragraph.
 	blockType = ""
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
@@ -203,7 +185,7 @@ func TestBlocksDeleteDispatch(t *testing.T) {
 
 	blockType = ""
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)

--- a/cmd/blocks_test.go
+++ b/cmd/blocks_test.go
@@ -1,0 +1,221 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// findBlocksSubcommand walks the blocks command's children and returns the
+// child matching name, or fails the test.
+func findBlocksSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	var blocksC *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "blocks" {
+			blocksC = c
+			break
+		}
+	}
+	if blocksC == nil {
+		t.Fatal("blocks command not registered on rootCmd")
+	}
+	for _, c := range blocksC.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("blocks subcommand %q not found", name)
+	return nil
+}
+
+// TestBlocksCmdRegistered verifies `blocks` is a top-level command and
+// owns its three subcommands (list, add, delete).
+func TestBlocksCmdRegistered(t *testing.T) {
+	var blocksC *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "blocks" {
+			blocksC = c
+			break
+		}
+	}
+	if blocksC == nil {
+		t.Fatal("blocks command not registered on rootCmd")
+	}
+
+	want := map[string]bool{"list": false, "add": false, "delete": false}
+	for _, c := range blocksC.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("blocks subcommand %q not registered", name)
+		}
+	}
+}
+
+// TestBlocksListFlags asserts the list subcommand declares a --type/-t flag
+// whose default is the empty string (no filter).
+func TestBlocksListFlags(t *testing.T) {
+	list := findBlocksSubcommand(t, "list")
+
+	long := list.Flag("type")
+	if long == nil {
+		t.Fatal("blocks list: --type flag not registered")
+	}
+	if long.Shorthand != "t" {
+		t.Errorf("blocks list: --type shorthand = %q, want %q", long.Shorthand, "t")
+	}
+	if long.DefValue != "" {
+		t.Errorf("blocks list: --type default = %q, want empty", long.DefValue)
+	}
+	if long.Value.Type() != "string" {
+		t.Errorf("blocks list: --type type = %q, want string", long.Value.Type())
+	}
+}
+
+// TestBlocksAddFlags asserts the add subcommand declares --type/-t with
+// default "paragraph" and that it takes at least one positional arg.
+func TestBlocksAddFlags(t *testing.T) {
+	add := findBlocksSubcommand(t, "add")
+
+	long := add.Flag("type")
+	if long == nil {
+		t.Fatal("blocks add: --type flag not registered")
+	}
+	if long.Shorthand != "t" {
+		t.Errorf("blocks add: --type shorthand = %q, want %q", long.Shorthand, "t")
+	}
+	if long.DefValue != "paragraph" {
+		t.Errorf("blocks add: --type default = %q, want %q", long.DefValue, "paragraph")
+	}
+
+	// MinimumNArgs(1) means zero args must error.
+	if err := add.Args(add, []string{}); err == nil {
+		t.Error("blocks add: expected error on zero args, got nil")
+	}
+	if err := add.Args(add, []string{"hello"}); err != nil {
+		t.Errorf("blocks add: expected no error on one arg, got %v", err)
+	}
+}
+
+// TestBlocksDeleteArgs asserts the delete subcommand requires exactly one
+// positional arg.
+func TestBlocksDeleteArgs(t *testing.T) {
+	del := findBlocksSubcommand(t, "delete")
+
+	if err := del.Args(del, []string{}); err == nil {
+		t.Error("blocks delete: expected error on zero args, got nil")
+	}
+	if err := del.Args(del, []string{"1"}); err != nil {
+		t.Errorf("blocks delete: expected no error on one arg, got %v", err)
+	}
+	if err := del.Args(del, []string{"1", "2"}); err == nil {
+		t.Error("blocks delete: expected error on two args, got nil")
+	}
+}
+
+// TestBlocksListDispatch runs `notioncli blocks list` and confirms the
+// listing call hit the mock server.
+func TestBlocksListDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var listed int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			atomic.AddInt64(&listed, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	// Reset any --type filter that a previous test may have set. blockType
+	// is a package-level variable; a stale "to_do" here would narrow results.
+	blockType = ""
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(blocks list): %v", err)
+	}
+
+	if atomic.LoadInt64(&listed) == 0 {
+		t.Error("blocks list did not hit /blocks/pageID/children")
+	}
+}
+
+// TestBlocksAddDispatch runs `notioncli blocks add "hi" -t paragraph` and
+// asserts the add PATCH was issued.
+func TestBlocksAddDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			atomic.AddInt64(&patched, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	// Reset block type so the add command falls back to paragraph.
+	blockType = ""
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "hello world", "-t", "paragraph"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(blocks add): %v", err)
+	}
+
+	if atomic.LoadInt64(&patched) == 0 {
+		t.Error("blocks add did not PATCH /blocks/pageID/children")
+	}
+}
+
+// TestBlocksDeleteDispatch runs `notioncli blocks delete 1` and asserts
+// that both a listing (to resolve the target id) and a DELETE were issued.
+func TestBlocksDeleteDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var listed, deleted int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blocks/pageID/children"):
+			atomic.AddInt64(&listed, 1)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/blocks/"):
+			atomic.AddInt64(&deleted, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	blockType = ""
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "delete", "1"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(blocks delete): %v", err)
+	}
+
+	if atomic.LoadInt64(&listed) == 0 {
+		t.Error("blocks delete did not list children")
+	}
+	if atomic.LoadInt64(&deleted) == 0 {
+		t.Error("blocks delete did not DELETE a block")
+	}
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestCheckCmdArgsAndFlags asserts that `check` requires exactly one
+// positional arg, and that the declared `--order` flag exists with its
+// default of 0.
+func TestCheckCmdArgsAndFlags(t *testing.T) {
+	var c *cobra.Command
+	for _, cc := range rootCmd.Commands() {
+		if cc.Name() == "check" {
+			c = cc
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("check command not registered on rootCmd")
+	}
+
+	// Args validation.
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"zero rejected", []string{}, true},
+		{"one accepted", []string{"1"}, false},
+		{"two rejected", []string{"1", "2"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := c.Args(c, tc.args); (err != nil) != tc.wantErr {
+				t.Errorf("checkCmd.Args(%v) err=%v wantErr=%v", tc.args, err, tc.wantErr)
+			}
+		})
+	}
+
+	// Flag declaration: --order Int, default 0.
+	f := c.Flag("order")
+	if f == nil {
+		t.Fatal("check: --order flag not registered")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("check: --order default = %q, want %q", f.DefValue, "0")
+	}
+	if f.Value.Type() != "int" {
+		t.Errorf("check: --order type = %q, want %q", f.Value.Type(), "int")
+	}
+}
+
+// TestCheckCmdDispatch runs `notioncli check 1` and asserts the expected
+// request shape hit the mock Notion API: a GET to list children followed
+// by a PATCH to the target block id.
+func TestCheckCmdDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var listed, patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blocks/pageID/children"):
+			atomic.AddInt64(&listed, 1)
+		case r.Method == http.MethodPatch && r.URL.Path == "/blocks/blockID":
+			atomic.AddInt64(&patched, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"check", "1"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(check 1): %v", err)
+	}
+
+	if atomic.LoadInt64(&listed) == 0 {
+		t.Error("check command did not list children to resolve the block id")
+	}
+	if atomic.LoadInt64(&patched) == 0 {
+		t.Error("check command did not PATCH /blocks/blockID")
+	}
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -6,24 +6,13 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 // TestCheckCmdArgsAndFlags asserts that `check` requires exactly one
 // positional arg, and that the declared `--order` flag exists with its
 // default of 0.
 func TestCheckCmdArgsAndFlags(t *testing.T) {
-	var c *cobra.Command
-	for _, cc := range rootCmd.Commands() {
-		if cc.Name() == "check" {
-			c = cc
-			break
-		}
-	}
-	if c == nil {
-		t.Fatal("check command not registered on rootCmd")
-	}
+	c := findTopLevelCmd(t, "check")
 
 	// Args validation.
 	cases := []struct {
@@ -74,7 +63,7 @@ func TestCheckCmdDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 // TestDeleteCmdArgsAndFlags asserts ExactArgs(1) and the --order flag
@@ -15,16 +13,7 @@ import (
 // blocks delete subcommand is tested in blocks_test.go).
 func TestDeleteCmdArgsAndFlags(t *testing.T) {
 	// Walk top-level rootCmd children only — don't descend into blocksCmd.
-	var c *cobra.Command
-	for _, cc := range rootCmd.Commands() {
-		if cc.Name() == "delete" {
-			c = cc
-			break
-		}
-	}
-	if c == nil {
-		t.Fatal("delete command not registered on rootCmd")
-	}
+	c := findTopLevelCmd(t, "delete")
 
 	cases := []struct {
 		name    string
@@ -72,7 +61,7 @@ func TestDeleteCmdDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestDeleteCmdArgsAndFlags asserts ExactArgs(1) and the --order flag
+// declaration. `delete` is the to-do deletion wired onto rootCmd (the
+// blocks delete subcommand is tested in blocks_test.go).
+func TestDeleteCmdArgsAndFlags(t *testing.T) {
+	// Walk top-level rootCmd children only — don't descend into blocksCmd.
+	var c *cobra.Command
+	for _, cc := range rootCmd.Commands() {
+		if cc.Name() == "delete" {
+			c = cc
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("delete command not registered on rootCmd")
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"zero rejected", []string{}, true},
+		{"one accepted", []string{"1"}, false},
+		{"two rejected", []string{"1", "2"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := c.Args(c, tc.args); (err != nil) != tc.wantErr {
+				t.Errorf("deleteCmd.Args(%v) err=%v wantErr=%v", tc.args, err, tc.wantErr)
+			}
+		})
+	}
+
+	f := c.Flag("order")
+	if f == nil {
+		t.Fatal("delete: --order flag not registered")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("delete: --order default = %q, want %q", f.DefValue, "0")
+	}
+	if f.Value.Type() != "int" {
+		t.Errorf("delete: --order type = %q, want %q", f.Value.Type(), "int")
+	}
+}
+
+// TestDeleteCmdDispatch runs `notioncli delete 1` and confirms the listing
+// + DELETE pair hit the mock server.
+func TestDeleteCmdDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var listed, deleted int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blocks/pageID/children"):
+			atomic.AddInt64(&listed, 1)
+		case r.Method == http.MethodDelete && r.URL.Path == "/blocks/blockID":
+			atomic.AddInt64(&deleted, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"delete", "1"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(delete 1): %v", err)
+	}
+
+	if atomic.LoadInt64(&listed) == 0 {
+		t.Error("delete command did not list children")
+	}
+	if atomic.LoadInt64(&deleted) == 0 {
+		t.Error("delete command did not DELETE /blocks/blockID")
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -51,7 +51,7 @@ func TestListCmdDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestListCmdMetadata asserts the listCmd is registered and wears its
+// documented Use/Short strings. Flag-parsing assertions for list are thin
+// because list has no flags today — this test guards against a regression
+// that silently drops the command or strips its help text.
+func TestListCmdMetadata(t *testing.T) {
+	var found bool
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "list" {
+			found = true
+			if c.Short == "" {
+				t.Error("list: Short description is empty")
+			}
+			if c.Long == "" {
+				t.Error("list: Long description is empty")
+			}
+			if c.Run == nil {
+				t.Error("list: Run function not set")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("list command not registered on rootCmd")
+	}
+}
+
+// TestListCmdDispatch invokes `notioncli list` end-to-end with the HTTP
+// client redirected at a mock Notion API. The mock handler is wrapped to
+// tally hits so we can assert the list path was actually exercised —
+// output goes to fmt.Println (stdout), which cmd.SetOut cannot intercept,
+// so we rely on mock-hit counts rather than captured stdout.
+func TestListCmdDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var hits int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			atomic.AddInt64(&hits, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"list"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(list): %v", err)
+	}
+
+	if atomic.LoadInt64(&hits) == 0 {
+		t.Error("list command did not hit /blocks/pageID/children")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,10 @@ var rootCmd = &cobra.Command{
 		  help (get some help)`,
 }
 
+// osExit is indirected through a package-level var so tests can swap in a
+// no-op and assert on the exit decision without terminating the test binary.
+var osExit = os.Exit
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -34,7 +38,7 @@ func Execute() {
 	fmt.Println(boldBlue("----=[ NotionCLI ]=----"))
 	err := rootCmd.Execute()
 	if err != nil {
-		os.Exit(1)
+		osExit(1)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -38,3 +38,19 @@ func TestRootCmdSubcommandsRegistered(t *testing.T) {
 		}
 	}
 }
+
+// TestExecuteHappyPath drives the exported Execute() function through the
+// --help branch so its happy path is covered without tripping the os.Exit
+// that fires on error. The function prints a color banner to stdout — we
+// don't assert banner contents, only that Execute returns without exiting.
+func TestExecuteHappyPath(t *testing.T) {
+	rootCmd.SetArgs([]string{"--help"})
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	// Execute() calls os.Exit(1) on error. --help never errors, so this
+	// completes cleanly. If --help ever starts returning non-nil from
+	// cobra, this test will terminate the test binary — at which point
+	// the CI log will make the breakage obvious.
+	Execute()
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -40,17 +40,52 @@ func TestRootCmdSubcommandsRegistered(t *testing.T) {
 }
 
 // TestExecuteHappyPath drives the exported Execute() function through the
-// --help branch so its happy path is covered without tripping the os.Exit
-// that fires on error. The function prints a color banner to stdout — we
-// don't assert banner contents, only that Execute returns without exiting.
+// --help branch so its happy path is covered. osExit is swapped out for a
+// recorder so an unexpected error path cannot terminate the test binary.
 func TestExecuteHappyPath(t *testing.T) {
+	var exited bool
+	var code int
+	origExit := osExit
+	osExit = func(c int) {
+		exited = true
+		code = c
+	}
+	t.Cleanup(func() { osExit = origExit })
+
 	rootCmd.SetArgs([]string{"--help"})
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
-	// Execute() calls os.Exit(1) on error. --help never errors, so this
-	// completes cleanly. If --help ever starts returning non-nil from
-	// cobra, this test will terminate the test binary — at which point
-	// the CI log will make the breakage obvious.
 	Execute()
+
+	if exited {
+		t.Errorf("Execute() unexpectedly called osExit(%d) on happy path", code)
+	}
+}
+
+// TestExecuteErrorPath verifies the Execute wrapper forwards a non-nil
+// rootCmd error to osExit(1). We force the error by passing an unknown
+// subcommand and intercept osExit to avoid killing the test process.
+func TestExecuteErrorPath(t *testing.T) {
+	var exited bool
+	var code int
+	origExit := osExit
+	osExit = func(c int) {
+		exited = true
+		code = c
+	}
+	t.Cleanup(func() { osExit = origExit })
+
+	rootCmd.SetArgs([]string{"definitely-not-a-real-subcommand"})
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	Execute()
+
+	if !exited {
+		t.Fatal("Execute() did not call osExit on error path")
+	}
+	if code != 1 {
+		t.Errorf("Execute() osExit code = %d, want 1", code)
+	}
 }

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -1,13 +1,19 @@
+// Tests in this package must not call t.Parallel(): several helpers mutate
+// package-level state (utils.baseURL, blockType, cwd) that cannot safely be
+// shared across concurrent sub-tests. Running serially is the explicit design.
 package cmd
 
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"notioncli/utils"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
 )
 
 // cmdMockServer returns an httptest.Server that answers every Notion endpoint
@@ -106,13 +112,14 @@ func cmdMockServer(t *testing.T) *httptest.Server {
 func withCmdEnv(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	// 1. Mock server + redirect utils package baseURL.
+	// 1. Mock server + redirect utils package baseURL. Snapshot the prior
+	// value so a later test running in the same process without going
+	// through withCmdEnv doesn't inherit a pointer to a closed server.
 	srv := cmdMockServer(t)
+	priorBaseURL := utils.GetBaseURL()
 	utils.SetBaseURL(srv.URL)
 	t.Cleanup(func() {
-		// Restore to something harmless. The utils package default would be
-		// https://api.notion.com/v1 but we don't export it; pointing at the
-		// (now-closed) mock server URL is safe because no further calls run.
+		utils.SetBaseURL(priorBaseURL)
 		srv.Close()
 	})
 
@@ -142,7 +149,20 @@ func withCmdEnv(t *testing.T) *httptest.Server {
 
 // resetRootCmdArgs clears any args previously set on rootCmd. cobra retains
 // args across calls, so tests that share rootCmd must reset between runs.
-func resetRootCmdArgs(t *testing.T) {
-	t.Helper()
+func resetRootCmdArgs() {
 	rootCmd.SetArgs(nil)
+}
+
+// findTopLevelCmd returns the rootCmd child with the given Name, or fails
+// the test. Used by command-specific test files to locate the real *cobra.Command
+// instance without duplicating the linear scan across files.
+func findTopLevelCmd(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("%q command not registered on rootCmd", name)
+	return nil
 }

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"notioncli/utils"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cmdMockServer returns an httptest.Server that answers every Notion endpoint
+// the cmd/ package indirectly hits through utils. It mirrors the enhanced mock
+// in utils/block_extra_test.go but lives here so the cmd tests stay
+// self-contained and don't depend on test-package internals across directories.
+//
+// Supported page fixtures:
+//   - pageID              : one unchecked to_do "buy milk"
+//   - emptyPage           : no results
+//
+// Supported block id:
+//   - blockID             : any PATCH/DELETE to /blocks/blockID → 200
+func cmdMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	todo := func(id, text string, checked bool) utils.Block {
+		return utils.Block{
+			Object:         "block",
+			ID:             id,
+			Type:           "to_do",
+			LastEditedTime: "2026-04-22T10:00:00.000Z",
+			ToDo:           &utils.ToDo{Checked: checked, RichText: []utils.RichText{{PlainText: text}}},
+		}
+	}
+	paragraph := func(id, text string) utils.Block {
+		return utils.Block{
+			Object:         "block",
+			ID:             id,
+			Type:           "paragraph",
+			LastEditedTime: "2026-04-22T11:00:00.000Z",
+			Paragraph:      &utils.RichTextBlock{RichText: []utils.RichText{{PlainText: text}}},
+		}
+	}
+	heading1 := func(id, text string) utils.Block {
+		return utils.Block{
+			Object:         "block",
+			ID:             id,
+			Type:           "heading_1",
+			LastEditedTime: "2026-04-22T12:00:00.000Z",
+			Heading1:       &utils.RichTextBlock{RichText: []utils.RichText{{PlainText: text}}},
+		}
+	}
+
+	writeJSON := func(w http.ResponseWriter, v interface{}) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// GET children: default page has one to_do item.
+		case r.Method == http.MethodGet && r.URL.Path == "/blocks/pageID/children":
+			writeJSON(w, utils.BlockList{Results: []utils.Block{
+				todo("blockID", "buy milk", false),
+			}})
+
+		// GET children: mixed page for blocks subcommand tests.
+		case r.Method == http.MethodGet && r.URL.Path == "/blocks/mixedPage/children":
+			writeJSON(w, utils.BlockList{Results: []utils.Block{
+				heading1("m1", "Title"),
+				paragraph("m2", "Body"),
+				todo("m3", "A task", false),
+			}})
+
+		// GET children: empty page.
+		case r.Method == http.MethodGet && r.URL.Path == "/blocks/emptyPage/children":
+			writeJSON(w, utils.BlockList{Results: []utils.Block{}})
+
+		// PATCH to /blocks/{id}/children (AddNewToDoItem, AddBlock) → 200
+		// PATCH to /blocks/{id} (MarkChecked, MarkUnchecked) → 200
+		case r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+
+		// DELETE any block → 200
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+
+		default:
+			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+		}
+	}))
+}
+
+// withCmdEnv wires up everything a cmd-layer test needs:
+//   - an httptest mock server, with utils.baseURL pointed at it
+//   - NOTION_API_KEY / NOTION_PAGE_ID / LOCAL_TIMEZONE set to sane defaults
+//   - a temp cwd containing an empty .env, and an empty HOME, so that
+//     godotenv.Load in utils.SetAPIConfig succeeds without picking up the
+//     developer's real ~/.config/notioncli/.env
+//
+// Returns the mock server so tests can inspect request counts if they want.
+// All state is restored by t.Cleanup.
+func withCmdEnv(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	// 1. Mock server + redirect utils package baseURL.
+	srv := cmdMockServer(t)
+	utils.SetBaseURL(srv.URL)
+	t.Cleanup(func() {
+		// Restore to something harmless. The utils package default would be
+		// https://api.notion.com/v1 but we don't export it; pointing at the
+		// (now-closed) mock server URL is safe because no further calls run.
+		srv.Close()
+	})
+
+	// 2. Isolated cwd with an empty .env so godotenv.Load returns nil.
+	emptyCwd := t.TempDir()
+	emptyHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(emptyCwd, ".env"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(emptyCwd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	// 3. Env vars.
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("NOTION_API_KEY", "test-key")
+	t.Setenv("NOTION_PAGE_ID", "pageID")
+	t.Setenv("LOCAL_TIMEZONE", "UTC")
+
+	return srv
+}
+
+// resetRootCmdArgs clears any args previously set on rootCmd. cobra retains
+// args across calls, so tests that share rootCmd must reset between runs.
+func resetRootCmdArgs(t *testing.T) {
+	t.Helper()
+	rootCmd.SetArgs(nil)
+}

--- a/cmd/uncheck_test.go
+++ b/cmd/uncheck_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestUncheckCmdArgsAndFlags asserts argument arity and that the --order
+// flag is declared as int with a default of 0.
+func TestUncheckCmdArgsAndFlags(t *testing.T) {
+	var c *cobra.Command
+	for _, cc := range rootCmd.Commands() {
+		if cc.Name() == "uncheck" {
+			c = cc
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("uncheck command not registered on rootCmd")
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"zero rejected", []string{}, true},
+		{"one accepted", []string{"1"}, false},
+		{"three rejected", []string{"1", "2", "3"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := c.Args(c, tc.args); (err != nil) != tc.wantErr {
+				t.Errorf("uncheckCmd.Args(%v) err=%v wantErr=%v", tc.args, err, tc.wantErr)
+			}
+		})
+	}
+
+	f := c.Flag("order")
+	if f == nil {
+		t.Fatal("uncheck: --order flag not registered")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("uncheck: --order default = %q, want %q", f.DefValue, "0")
+	}
+	if f.Value.Type() != "int" {
+		t.Errorf("uncheck: --order type = %q, want %q", f.Value.Type(), "int")
+	}
+}
+
+// TestUncheckCmdDispatch drives `notioncli uncheck 1` and confirms the
+// expected GET (resolve block id) + PATCH (clear checked) pair hits the
+// mock Notion API.
+func TestUncheckCmdDispatch(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var listed, patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blocks/pageID/children"):
+			atomic.AddInt64(&listed, 1)
+		case r.Method == http.MethodPatch && r.URL.Path == "/blocks/blockID":
+			atomic.AddInt64(&patched, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetRootCmdArgs(t)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"uncheck", "1"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(uncheck 1): %v", err)
+	}
+
+	if atomic.LoadInt64(&listed) == 0 {
+		t.Error("uncheck command did not list children to resolve the block id")
+	}
+	if atomic.LoadInt64(&patched) == 0 {
+		t.Error("uncheck command did not PATCH /blocks/blockID")
+	}
+}
+
+// TestUncheckCmdNonNumericArg is a negative dispatch test: passing a
+// non-integer positional arg should trip the strconv.Atoi branch. The
+// command prints an error and calls os.Exit(1) in that path, so we cannot
+// safely call Execute() here. Instead, exercise the ParseArgs code path by
+// confirming cobra still accepts the arg shape (cobra.ExactArgs(1) only
+// checks count), leaving the conversion to Run.
+func TestUncheckCmdNonNumericArgAcceptedByCobra(t *testing.T) {
+	var c *cobra.Command
+	for _, cc := range rootCmd.Commands() {
+		if cc.Name() == "uncheck" {
+			c = cc
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("uncheck command not registered on rootCmd")
+	}
+	// Cobra's ExactArgs doesn't type-check positionals — that's the Run
+	// function's job. This test pins that contract so a future refactor
+	// that adds a type validator still preserves the expected error
+	// surface.
+	if err := c.Args(c, []string{"not-a-number"}); err != nil {
+		t.Errorf("uncheck: expected cobra.Args to accept any single positional, got %v", err)
+	}
+}

--- a/cmd/uncheck_test.go
+++ b/cmd/uncheck_test.go
@@ -6,23 +6,12 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 // TestUncheckCmdArgsAndFlags asserts argument arity and that the --order
 // flag is declared as int with a default of 0.
 func TestUncheckCmdArgsAndFlags(t *testing.T) {
-	var c *cobra.Command
-	for _, cc := range rootCmd.Commands() {
-		if cc.Name() == "uncheck" {
-			c = cc
-			break
-		}
-	}
-	if c == nil {
-		t.Fatal("uncheck command not registered on rootCmd")
-	}
+	c := findTopLevelCmd(t, "uncheck")
 
 	cases := []struct {
 		name    string
@@ -71,7 +60,7 @@ func TestUncheckCmdDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	resetRootCmdArgs(t)
+	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
@@ -85,31 +74,5 @@ func TestUncheckCmdDispatch(t *testing.T) {
 	}
 	if atomic.LoadInt64(&patched) == 0 {
 		t.Error("uncheck command did not PATCH /blocks/blockID")
-	}
-}
-
-// TestUncheckCmdNonNumericArg is a negative dispatch test: passing a
-// non-integer positional arg should trip the strconv.Atoi branch. The
-// command prints an error and calls os.Exit(1) in that path, so we cannot
-// safely call Execute() here. Instead, exercise the ParseArgs code path by
-// confirming cobra still accepts the arg shape (cobra.ExactArgs(1) only
-// checks count), leaving the conversion to Run.
-func TestUncheckCmdNonNumericArgAcceptedByCobra(t *testing.T) {
-	var c *cobra.Command
-	for _, cc := range rootCmd.Commands() {
-		if cc.Name() == "uncheck" {
-			c = cc
-			break
-		}
-	}
-	if c == nil {
-		t.Fatal("uncheck command not registered on rootCmd")
-	}
-	// Cobra's ExactArgs doesn't type-check positionals — that's the Run
-	// function's job. This test pins that contract so a future refactor
-	// that adds a type validator still preserves the expected error
-	// surface.
-	if err := c.Args(c, []string{"not-a-number"}); err != nil {
-		t.Errorf("uncheck: expected cobra.Args to accept any single positional, got %v", err)
 	}
 }

--- a/scripts/test-coverage-skip.txt
+++ b/scripts/test-coverage-skip.txt
@@ -7,3 +7,4 @@
 #
 # Legitimate skips (test-only helpers exported so tests across files can use them):
 utils.SetBaseURL
+utils.GetBaseURL

--- a/utils/block.go
+++ b/utils/block.go
@@ -19,8 +19,20 @@ var baseURL = "https://api.notion.com/v1"
 // SetBaseURL redirects the Notion API client to an arbitrary URL. Intended
 // for tests (especially the cmd/ layer, which cannot reach test-only symbols
 // defined in utils/*_test.go). Production callers should not use this.
+//
+// Deprecated: use WithBaseURL on Client — this exists only for legacy
+// cmd-layer tests and will be removed after #17 lands.
 func SetBaseURL(url string) {
 	baseURL = url
+}
+
+// GetBaseURL returns the current Notion API base URL. Exposed only so tests
+// can snapshot and restore the value around SetBaseURL calls.
+//
+// Deprecated: use WithBaseURL on Client — this exists only for legacy
+// cmd-layer tests and will be removed after #17 lands.
+func GetBaseURL() string {
+	return baseURL
 }
 
 // BlockTypeInfo contains display information for a block type

--- a/utils/block.go
+++ b/utils/block.go
@@ -16,6 +16,13 @@ import (
 
 var baseURL = "https://api.notion.com/v1"
 
+// SetBaseURL redirects the Notion API client to an arbitrary URL. Intended
+// for tests (especially the cmd/ layer, which cannot reach test-only symbols
+// defined in utils/*_test.go). Production callers should not use this.
+func SetBaseURL(url string) {
+	baseURL = url
+}
+
 // BlockTypeInfo contains display information for a block type
 type BlockTypeInfo struct {
 	Icon  string

--- a/utils/block_test.go
+++ b/utils/block_test.go
@@ -13,10 +13,6 @@ var (
 	deletedBlocks map[string]bool
 )
 
-func SetBaseURL(url string) {
-	baseURL = url
-}
-
 func mockBlock(texts []string) Block {
 
 	richTexts := make([]RichText, len(texts))


### PR DESCRIPTION
## Summary

Brings cobra-command coverage to the `cmd/` package, which had only a `--help` smoke test before this branch. Closes #13.

- **`cmd/testhelpers_test.go`** — shared harness. `cmdMockServer` wires an `httptest.Server` that answers every Notion endpoint the cmd layer indirectly hits through `utils/`. `withCmdEnv` installs a sandboxed cwd + empty `.env` + the three env vars (`NOTION_API_KEY`, `NOTION_PAGE_ID`, `LOCAL_TIMEZONE`) so `utils.SetAPIConfig` / `utils.GetLocalTimeZone` return cleanly without tripping their `os.Exit` paths.
- Per-command tests (`list`, `add`, `check`, `uncheck`, `delete`, `blocks`) — each file pairs a flag/args validation test with a happy-path dispatch test. Dispatch tests assert against **mock-server hits** (rather than captured stdout) because the commands use `fmt.Println`, which `cmd.SetOut` cannot intercept.
- `utils.SetBaseURL` moved from `utils/block_test.go` (test-only) into `utils/block.go` so cross-package tests can call it. Function is already in the gap-gate skip list.

## Coverage delta (cmd/ package)

| | coverage |
|---|---|
| Before (feature/foundation tip) | **12.6%** |
| After | **68.1%** |

Well above the 50% gate from issue #13. Total module coverage ticks from 72.4% → 73.6%.

## Test evidence

`make ci` tail:

```
go test -coverprofile=coverage.out -covermode=atomic ./...
	notioncli		coverage: 0.0% of statements
ok  	notioncli/cmd	(cached)	coverage: 68.1% of statements
ok  	notioncli/utils	(cached)	coverage: 72.5% of statements
...
total:				(statements)			73.6%
Total coverage: 73.6% (gate: 70%)
✓ Every exported function has a matching Test* (skips honored).
```

- `go test ./...` — pass
- `go test -race ./...` — pass
- `go vet ./...` — pass
- `gofmt -l .` — empty
- Gap gate — green

## Commits

1. `fb9087c` — refactor(utils): promote SetBaseURL to production code
2. `b10c22c` — test(cmd): add shared test harness for cobra command tests
3. `a3d6f8a` — test(cmd): cover list and add commands
4. `1399589` — test(cmd): cover check, uncheck, and delete to-do commands
5. `7139527` — test(cmd): cover blocks command tree (list/add/delete subcommands)

## Follow-ups / gaps

- Negative dispatch paths that invoke `os.Exit` (bad integer arg, Notion 4xx on PATCH/DELETE) are not covered from the cmd layer because the Run functions terminate the test process. These already have equivalent coverage in `utils/`; a future refactor that returns errors up the cobra tree (instead of `os.Exit`-ing in `Run`) would let us assert on exit codes from the cmd layer too.
- `cmd/root.go:init()` remains at 0% because it's empty.

## Test plan

- [x] `make ci` green end-to-end
- [x] `go test -race ./...` passes
- [x] `cmd/` coverage > 50% (68.1%)
- [ ] CI workflow on PR (awaiting CI run)