### PR TITLE
Refactor utils/ into Client + BlockClient (refs #1)

### DIFF
--- a/utils/block.go
+++ b/utils/block.go
@@ -5,15 +5,14 @@
 package utils
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"sort"
 	"time"
 )
 
+// baseURL is the legacy package-level base URL. It is kept as the source of
+// truth for the default Client so that SetBaseURL (used by tests) continues
+// to redirect every legacy top-level call. New code should build its own
+// *Client via NewClient and not reach for this variable.
 var baseURL = "https://api.notion.com/v1"
 
 // SetBaseURL redirects the Notion API client to an arbitrary URL. Intended
@@ -21,7 +20,8 @@ var baseURL = "https://api.notion.com/v1"
 // defined in utils/*_test.go). Production callers should not use this.
 //
 // Deprecated: use WithBaseURL on Client — this exists only for legacy
-// cmd-layer tests and will be removed after #17 lands.
+// cmd-layer tests and will be removed in a follow-up once cmd/ migrates
+// to NewClient(WithBaseURL(...)).
 func SetBaseURL(url string) {
 	baseURL = url
 }
@@ -30,18 +30,19 @@ func SetBaseURL(url string) {
 // can snapshot and restore the value around SetBaseURL calls.
 //
 // Deprecated: use WithBaseURL on Client — this exists only for legacy
-// cmd-layer tests and will be removed after #17 lands.
+// cmd-layer tests and will be removed in a follow-up once cmd/ migrates
+// to NewClient(WithBaseURL(...)).
 func GetBaseURL() string {
 	return baseURL
 }
 
-// BlockTypeInfo contains display information for a block type
+// BlockTypeInfo contains display information for a block type.
 type BlockTypeInfo struct {
 	Icon  string
 	Color string
 }
 
-// SupportedBlockTypes defines all supported block types with their display info
+// SupportedBlockTypes defines all supported block types with their display info.
 var SupportedBlockTypes = map[string]BlockTypeInfo{
 	"paragraph":          {Icon: "¶", Color: "white"},
 	"heading_1":          {Icon: "H1", Color: "cyan"},
@@ -57,7 +58,7 @@ var SupportedBlockTypes = map[string]BlockTypeInfo{
 	"code":               {Icon: "<>", Color: "blue"},
 }
 
-// GetSupportedBlockTypeNames returns a sorted list of supported block type names
+// GetSupportedBlockTypeNames returns a sorted list of supported block type names.
 func GetSupportedBlockTypeNames() []string {
 	names := make([]string, 0, len(SupportedBlockTypes))
 	for name := range SupportedBlockTypes {
@@ -67,19 +68,20 @@ func GetSupportedBlockTypeNames() []string {
 	return names
 }
 
-// IsValidBlockType checks if a block type is supported
+// IsValidBlockType checks if a block type is supported.
 func IsValidBlockType(blockType string) bool {
 	_, ok := SupportedBlockTypes[blockType]
 	return ok
 }
 
+// ToDo is the Notion to-do block body.
 type ToDo struct {
 	Checked  bool       `json:"checked"`
 	Color    string     `json:"color"`
 	RichText []RichText `json:"rich_text"`
 }
 
-// RichTextBlock represents a block with rich_text content
+// RichTextBlock represents a block with rich_text content.
 type RichTextBlock struct {
 	RichText []RichText `json:"rich_text"`
 	Color    string     `json:"color,omitempty"`
@@ -87,6 +89,7 @@ type RichTextBlock struct {
 	Checked  bool       `json:"checked,omitempty"`  // for to_do blocks
 }
 
+// RichText is a single rich-text run returned by the Notion API.
 type RichText struct {
 	Annotations Annotation  `json:"annotations"`
 	Href        interface{} `json:"href"`
@@ -95,6 +98,7 @@ type RichText struct {
 	Type        string      `json:"type"`
 }
 
+// Annotation captures the Notion text-run annotation flags.
 type Annotation struct {
 	Bold          bool   `json:"bold"`
 	Code          bool   `json:"code"`
@@ -104,11 +108,13 @@ type Annotation struct {
 	Underline     bool   `json:"underline"`
 }
 
+// Text is the text payload inside a RichText run.
 type Text struct {
 	Content string      `json:"content"`
 	Link    interface{} `json:"link"`
 }
 
+// Block is the Notion block envelope covering every supported block type.
 type Block struct {
 	Object           string         `json:"object"`
 	ID               string         `json:"id"`
@@ -130,6 +136,8 @@ type Block struct {
 	Divider          *struct{}      `json:"divider,omitempty"`
 }
 
+// BlockList is a single page of block results, as returned by
+// /blocks/{id}/children.
 type BlockList struct {
 	Object          string   `json:"object"`
 	Results         []Block  `json:"results"`
@@ -140,308 +148,94 @@ type BlockList struct {
 	DeveloperSurvey string   `json:"developer_survey"`
 }
 
+// defaultBlockClient returns a BlockClient bound to the default client, but
+// reconfigured to the latest baseURL / apiKey so existing top-level calls
+// that take apiKey arguments keep working.
+func defaultBlockClient(apiKey string) *BlockClient {
+	// Clone the default client with a per-call apiKey; baseURL follows the
+	// package-level variable so SetBaseURL continues to redirect tests.
+	return NewBlockClient(NewClient(apiKey, WithBaseURL(baseURL)))
+}
+
+// GetBlocks delegates to BlockClient.GetBlocks on a default client.
+//
+// Deprecated: new callers should build a *Client and *BlockClient via
+// NewClient/NewBlockClient and pass context.Context explicitly.
 func GetBlocks(notionAPIKey, pageID string) ([]Block, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", baseURL+"/blocks/"+pageID+"/children", nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("accept", "application/json")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var blockList BlockList
-
-	err = json.NewDecoder(resp.Body).Decode(&blockList)
-	if err != nil {
-		return nil, err
-	}
-
-	var blocks []Block
-	for _, result := range blockList.Results {
-		if result.Object == "block" && result.ToDo != nil && len(result.ToDo.RichText) > 0 {
-			blocks = append(blocks, result)
-		}
-	}
-	return blocks, nil
+	return defaultBlockClient(notionAPIKey).GetBlocks(defaultCtx(), pageID)
 }
 
+// GetToDoBlocks delegates to BlockClient.GetToDoBlocks on a default client.
+//
+// Deprecated: prefer BlockClient.GetToDoBlocks.
 func GetToDoBlocks(notionAPIKey, blockID string, localTimezone *time.Location) ([]string, error) {
-	blocks, err := GetBlocks(notionAPIKey, blockID)
-	if err != nil {
-		return nil, err
-	}
-	var todoBlocks []string
-	for _, block := range blocks {
-		if block.ToDo != nil {
-			var checked string
-			if block.ToDo.Checked {
-				checked = "X"
-			} else {
-				checked = " "
-			}
-			lastEditedTime, err := time.Parse(time.RFC3339, block.LastEditedTime)
-			if err != nil {
-				return nil, err
-			}
-			truncatedTime := lastEditedTime.In(localTimezone).Truncate(time.Minute)
-
-			element := fmt.Sprintf("%d [%s] %s (%s)", len(todoBlocks)+1, checked, block.ToDo.RichText[0].PlainText, truncatedTime.Format("2006-01-02 15:04"))
-			todoBlocks = append(todoBlocks, element)
-		}
-	}
-
-	return todoBlocks, nil
+	return defaultBlockClient(notionAPIKey).GetToDoBlocks(defaultCtx(), blockID, localTimezone)
 }
 
+// AddNewToDoItem delegates to BlockClient.AddNewToDoItem on a default client.
+//
+// Deprecated: prefer BlockClient.AddNewToDoItem.
 func AddNewToDoItem(notionAPIKey, pageID, text string) error {
-	client := &http.Client{}
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"children": []map[string]interface{}{
-			{
-				"object": "block",
-				"type":   "to_do",
-				"to_do": map[string]interface{}{
-					"rich_text": []map[string]interface{}{
-						{
-							"type": "text",
-							"text": map[string]interface{}{
-								"content": text,
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("error marshalling request body: %v", err)
-	}
-
-	req, err := http.NewRequest("PATCH", baseURL+"/blocks/"+pageID+"/children", bytes.NewBuffer(reqBody))
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	return nil
+	return defaultBlockClient(notionAPIKey).AddNewToDoItem(defaultCtx(), pageID, text)
 }
 
+// GetBlockID delegates to BlockClient.GetBlockID on a default client.
+//
+// Deprecated: prefer BlockClient.GetBlockID.
 func GetBlockID(notionAPIKey, pageID string, order int) (string, error) {
-	if order < 1 {
-		return "", fmt.Errorf("order must be greater than 0")
-	}
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", baseURL+"/blocks/"+pageID+"/children", nil)
-	if err != nil {
-		return "", fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("accept", "application/json")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	var blockList BlockList
-	err = json.NewDecoder(resp.Body).Decode(&blockList)
-	if err != nil {
-		return "", err
-	}
-
-	if order > len(blockList.Results) {
-		return "", fmt.Errorf("order number exceeds the number of blocks")
-	}
-
-	return blockList.Results[order-1].ID, nil
-
+	return defaultBlockClient(notionAPIKey).GetBlockID(defaultCtx(), pageID, order)
 }
 
+// MarkToDoBlockChecked delegates to BlockClient.MarkToDoBlockChecked on a default client.
+//
+// Deprecated: prefer BlockClient.MarkToDoBlockChecked.
 func MarkToDoBlockChecked(notionAPIKey, pageID string, order int) error {
-
-	blockID, err := GetBlockID(notionAPIKey, pageID, order)
-	if err != nil {
-		return err
-	}
-	client := &http.Client{}
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"to_do": map[string]interface{}{
-			"checked": true,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("error marshalling request body: %v", err)
-	}
-
-	req, err := http.NewRequest("PATCH", baseURL+"/blocks/"+blockID, bytes.NewBuffer(reqBody))
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	return nil
+	return defaultBlockClient(notionAPIKey).MarkToDoBlockChecked(defaultCtx(), pageID, order)
 }
 
+// MarkToDoBlockUnChecked delegates to BlockClient.MarkToDoBlockUnChecked on a default client.
+//
+// Deprecated: prefer BlockClient.MarkToDoBlockUnChecked.
 func MarkToDoBlockUnChecked(notionAPIKey, pageID string, order int) error {
-
-	blockID, err := GetBlockID(notionAPIKey, pageID, order)
-	if err != nil {
-		return err
-	}
-	client := &http.Client{}
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"to_do": map[string]interface{}{
-			"checked": false,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("error marshalling request body: %v", err)
-	}
-
-	req, err := http.NewRequest("PATCH", baseURL+"/blocks/"+blockID, bytes.NewBuffer(reqBody))
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	return nil
+	return defaultBlockClient(notionAPIKey).MarkToDoBlockUnChecked(defaultCtx(), pageID, order)
 }
 
+// DeleteToDoBlock delegates to BlockClient.DeleteToDoBlock on a default client.
+//
+// Deprecated: prefer BlockClient.DeleteToDoBlock.
 func DeleteToDoBlock(notionAPIKey, pageID string, order int) error {
-	blockID, err := GetBlockID(notionAPIKey, pageID, order)
-	if err != nil {
-		return err
-	}
-	client := &http.Client{}
-	req, err := http.NewRequest("DELETE", baseURL+"/blocks/"+blockID, nil)
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	return nil
+	return defaultBlockClient(notionAPIKey).DeleteToDoBlock(defaultCtx(), pageID, order)
 }
 
-// GetAllBlocks retrieves all blocks under a page, optionally filtered by type
-// Handles pagination for pages with more than 100 blocks
+// GetAllBlocks delegates to BlockClient.GetAllBlocks on a default client.
+//
+// Deprecated: prefer BlockClient.GetAllBlocks.
 func GetAllBlocks(notionAPIKey, pageID string, filterType string) ([]Block, error) {
-	client := &http.Client{}
-	var result []Block
-	var cursor string
-
-	for {
-		url := baseURL + "/blocks/" + pageID + "/children"
-		if cursor != "" {
-			url += "?start_cursor=" + cursor
-		}
-
-		req, err := http.NewRequest("GET", url, nil)
-		if err != nil {
-			return nil, fmt.Errorf("error creating request: %v", err)
-		}
-
-		req.Header.Add("accept", "application/json")
-		req.Header.Add("Notion-Version", "2022-06-28")
-		req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		var blockList BlockList
-		err = json.NewDecoder(resp.Body).Decode(&blockList)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		for _, block := range blockList.Results {
-			if block.Object == "block" {
-				// If no filter or matches filter, include block
-				if filterType == "" || block.Type == filterType {
-					result = append(result, block)
-				}
-			}
-		}
-
-		// Check if there are more pages
-		if !blockList.HasMore || blockList.NextCursor == "" {
-			break
-		}
-		cursor = blockList.NextCursor
-	}
-
-	return result, nil
+	return defaultBlockClient(notionAPIKey).GetAllBlocks(defaultCtx(), pageID, filterType)
 }
 
-// GetBlockContent extracts text content from any block type
+// FormatAllBlocks delegates to BlockClient.FormatAllBlocks on a default client.
+//
+// Deprecated: prefer BlockClient.FormatAllBlocks.
+func FormatAllBlocks(notionAPIKey, pageID string, localTimezone *time.Location, filterType string) ([]string, map[string]int, error) {
+	return defaultBlockClient(notionAPIKey).FormatAllBlocks(defaultCtx(), pageID, localTimezone, filterType)
+}
+
+// AddBlock delegates to BlockClient.AddBlock on a default client.
+//
+// Deprecated: prefer BlockClient.AddBlock.
+func AddBlock(notionAPIKey, pageID, blockType, text string) error {
+	return defaultBlockClient(notionAPIKey).AddBlock(defaultCtx(), pageID, blockType, text)
+}
+
+// DeleteBlock delegates to BlockClient.DeleteBlock on a default client.
+//
+// Deprecated: prefer BlockClient.DeleteBlock.
+func DeleteBlock(notionAPIKey, pageID string, order int) error {
+	return defaultBlockClient(notionAPIKey).DeleteBlock(defaultCtx(), pageID, order)
+}
+
+// GetBlockContent extracts text content from any block type.
 func GetBlockContent(block Block) string {
 	switch block.Type {
 	case "divider":
@@ -494,167 +288,17 @@ func GetBlockContent(block Block) string {
 	return "(empty)"
 }
 
-// GetBlockIcon returns the display icon for a block
+// GetBlockIcon returns the display icon for a block.
 func GetBlockIcon(block Block) string {
-	// Special case for to_do: show checked/unchecked
+	// Special case for to_do: show checked/unchecked.
 	if block.Type == "to_do" && block.ToDo != nil {
 		if block.ToDo.Checked {
 			return "☑"
 		}
 		return "☐"
 	}
-
 	if info, ok := SupportedBlockTypes[block.Type]; ok {
 		return info.Icon
 	}
 	return "?"
-}
-
-// FormatAllBlocks returns formatted strings for all blocks
-func FormatAllBlocks(notionAPIKey, pageID string, localTimezone *time.Location, filterType string) ([]string, map[string]int, error) {
-	blocks, err := GetAllBlocks(notionAPIKey, pageID, filterType)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var formatted []string
-	typeCounts := make(map[string]int)
-
-	for index, block := range blocks {
-		lastEditedTime, err := time.Parse(time.RFC3339, block.LastEditedTime)
-		if err != nil {
-			return nil, nil, err
-		}
-		truncatedTime := lastEditedTime.In(localTimezone).Truncate(time.Minute)
-
-		icon := GetBlockIcon(block)
-		content := GetBlockContent(block)
-
-		// Truncate long content
-		if len(content) > 50 {
-			content = content[:47] + "..."
-		}
-
-		element := fmt.Sprintf("%4d %s  [%-20s] %s (%s)",
-			index+1,
-			icon,
-			block.Type,
-			content,
-			truncatedTime.Format("2006-01-02 15:04"))
-		formatted = append(formatted, element)
-		typeCounts[block.Type]++
-	}
-
-	return formatted, typeCounts, nil
-}
-
-// AddBlock adds a new block of any supported type
-func AddBlock(notionAPIKey, pageID, blockType, text string) error {
-	if !IsValidBlockType(blockType) {
-		return fmt.Errorf("unsupported block type: %s", blockType)
-	}
-
-	client := &http.Client{}
-
-	var blockContent map[string]interface{}
-
-	if blockType == "divider" {
-		blockContent = map[string]interface{}{
-			"object":  "block",
-			"type":    "divider",
-			"divider": map[string]interface{}{},
-		}
-	} else {
-		// Most blocks use rich_text
-		richText := []map[string]interface{}{
-			{
-				"type": "text",
-				"text": map[string]interface{}{
-					"content": text,
-				},
-			},
-		}
-
-		innerContent := map[string]interface{}{
-			"rich_text": richText,
-		}
-
-		// Add language for code blocks
-		if blockType == "code" {
-			innerContent["language"] = "plain text"
-		}
-
-		blockContent = map[string]interface{}{
-			"object":  "block",
-			"type":    blockType,
-			blockType: innerContent,
-		}
-	}
-
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"children": []map[string]interface{}{blockContent},
-	})
-	if err != nil {
-		return fmt.Errorf("error marshalling request body: %v", err)
-	}
-
-	req, err := http.NewRequest("PATCH", baseURL+"/blocks/"+pageID+"/children", bytes.NewBuffer(reqBody))
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	return nil
-}
-
-// DeleteBlock deletes any block by its index (1-based)
-func DeleteBlock(notionAPIKey, pageID string, order int) error {
-	// Get all blocks to find the one at the given index
-	blocks, err := GetAllBlocks(notionAPIKey, pageID, "")
-	if err != nil {
-		return err
-	}
-
-	if order < 1 || order > len(blocks) {
-		return fmt.Errorf("block number %d out of range (1-%d)", order, len(blocks))
-	}
-
-	blockID := blocks[order-1].ID
-
-	client := &http.Client{}
-	req, err := http.NewRequest("DELETE", baseURL+"/blocks/"+blockID, nil)
-	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	return nil
 }

--- a/utils/block.go
+++ b/utils/block.go
@@ -148,12 +148,18 @@ type BlockList struct {
 	DeveloperSurvey string   `json:"developer_survey"`
 }
 
-// defaultBlockClient returns a BlockClient bound to the default client, but
-// reconfigured to the latest baseURL / apiKey so existing top-level calls
-// that take apiKey arguments keep working.
+// defaultBlockClient returns a BlockClient configured with the caller's
+// apiKey and the current package-level baseURL.
+//
+// A fresh *Client is allocated on every call rather than cached as a
+// package-level singleton, and that is intentional for now: the legacy
+// top-level entry points accept apiKey per call, and baseURL is mutable
+// via SetBaseURL (tests today, prod after PR #16). Caching without
+// reconciling both of those would either break httptest wiring or silently
+// mix credentials across calls. Once #16 lands and SetBaseURL is promoted
+// to a proper Client option, this can collapse to a sync.Once-guarded
+// singleton. Tracked alongside the #1 follow-ups.
 func defaultBlockClient(apiKey string) *BlockClient {
-	// Clone the default client with a per-call apiKey; baseURL follows the
-	// package-level variable so SetBaseURL continues to redirect tests.
 	return NewBlockClient(NewClient(apiKey, WithBaseURL(baseURL)))
 }
 

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -1,0 +1,325 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// BlockClient provides typed access to the Notion blocks API. Construct one
+// with NewBlockClient and pass it into callers that need block operations.
+// Every method takes a context.Context so requests can be cancelled or
+// deadlined from the caller.
+type BlockClient struct {
+	c *Client
+}
+
+// NewBlockClient wraps a *Client with block-resource methods.
+func NewBlockClient(c *Client) *BlockClient {
+	return &BlockClient{c: c}
+}
+
+// GetBlocks returns to-do blocks (and only to-dos with non-empty rich text)
+// for the given page. Preserves the pre-refactor filtering behavior so the
+// legacy top-level GetBlocks continues to match.
+func (b *BlockClient) GetBlocks(ctx context.Context, pageID string) ([]Block, error) {
+	req, err := b.c.newRequest(ctx, http.MethodGet, "/blocks/"+pageID+"/children", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	var blockList BlockList
+	if err := decodeInto(resp, &blockList); err != nil {
+		return nil, err
+	}
+
+	var blocks []Block
+	for _, result := range blockList.Results {
+		if result.Object == "block" && result.ToDo != nil && len(result.ToDo.RichText) > 0 {
+			blocks = append(blocks, result)
+		}
+	}
+	return blocks, nil
+}
+
+// GetToDoBlocks returns formatted to-do strings (index, check state, text,
+// last-edited time) for the given page, in the supplied timezone.
+func (b *BlockClient) GetToDoBlocks(ctx context.Context, pageID string, localTimezone *time.Location) ([]string, error) {
+	blocks, err := b.GetBlocks(ctx, pageID)
+	if err != nil {
+		return nil, err
+	}
+	var todoBlocks []string
+	for _, block := range blocks {
+		if block.ToDo == nil {
+			continue
+		}
+		checked := " "
+		if block.ToDo.Checked {
+			checked = "X"
+		}
+		lastEditedTime, err := time.Parse(time.RFC3339, block.LastEditedTime)
+		if err != nil {
+			return nil, err
+		}
+		truncatedTime := lastEditedTime.In(localTimezone).Truncate(time.Minute)
+		element := fmt.Sprintf("%d [%s] %s (%s)", len(todoBlocks)+1, checked, block.ToDo.RichText[0].PlainText, truncatedTime.Format("2006-01-02 15:04"))
+		todoBlocks = append(todoBlocks, element)
+	}
+	return todoBlocks, nil
+}
+
+// AddNewToDoItem appends a to-do block with the given text to the given
+// page.
+func (b *BlockClient) AddNewToDoItem(ctx context.Context, pageID, text string) error {
+	body := map[string]interface{}{
+		"children": []map[string]interface{}{
+			{
+				"object": "block",
+				"type":   "to_do",
+				"to_do": map[string]interface{}{
+					"rich_text": []map[string]interface{}{
+						{
+							"type": "text",
+							"text": map[string]interface{}{
+								"content": text,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	req, err := b.c.newRequest(ctx, http.MethodPatch, "/blocks/"+pageID+"/children", body)
+	if err != nil {
+		return err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return err
+	}
+	return expectStatus(resp, http.StatusOK)
+}
+
+// GetBlockID resolves a 1-based block index on the given page into the
+// block's Notion ID.
+func (b *BlockClient) GetBlockID(ctx context.Context, pageID string, order int) (string, error) {
+	if order < 1 {
+		return "", fmt.Errorf("order must be greater than 0")
+	}
+	req, err := b.c.newRequest(ctx, http.MethodGet, "/blocks/"+pageID+"/children", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return "", err
+	}
+	var blockList BlockList
+	if err := decodeInto(resp, &blockList); err != nil {
+		return "", err
+	}
+	if order > len(blockList.Results) {
+		return "", fmt.Errorf("order number exceeds the number of blocks")
+	}
+	return blockList.Results[order-1].ID, nil
+}
+
+// MarkToDoBlockChecked flips the to-do at the given index to checked=true.
+func (b *BlockClient) MarkToDoBlockChecked(ctx context.Context, pageID string, order int) error {
+	return b.setToDoChecked(ctx, pageID, order, true)
+}
+
+// MarkToDoBlockUnChecked flips the to-do at the given index to checked=false.
+func (b *BlockClient) MarkToDoBlockUnChecked(ctx context.Context, pageID string, order int) error {
+	return b.setToDoChecked(ctx, pageID, order, false)
+}
+
+func (b *BlockClient) setToDoChecked(ctx context.Context, pageID string, order int, checked bool) error {
+	blockID, err := b.GetBlockID(ctx, pageID, order)
+	if err != nil {
+		return err
+	}
+	body := map[string]interface{}{
+		"to_do": map[string]interface{}{
+			"checked": checked,
+		},
+	}
+	req, err := b.c.newRequest(ctx, http.MethodPatch, "/blocks/"+blockID, body)
+	if err != nil {
+		return err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return err
+	}
+	return expectStatus(resp, http.StatusOK)
+}
+
+// DeleteToDoBlock removes the to-do at the given 1-based index.
+func (b *BlockClient) DeleteToDoBlock(ctx context.Context, pageID string, order int) error {
+	blockID, err := b.GetBlockID(ctx, pageID, order)
+	if err != nil {
+		return err
+	}
+	req, err := b.c.newRequest(ctx, http.MethodDelete, "/blocks/"+blockID, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return err
+	}
+	return expectStatus(resp, http.StatusOK)
+}
+
+// GetAllBlocks retrieves every block under a page, following pagination.
+// When filterType is non-empty, only blocks whose Type matches are
+// returned.
+func (b *BlockClient) GetAllBlocks(ctx context.Context, pageID, filterType string) ([]Block, error) {
+	var result []Block
+	var cursor string
+
+	for {
+		path := "/blocks/" + pageID + "/children"
+		if cursor != "" {
+			path += "?start_cursor=" + cursor
+		}
+		req, err := b.c.newRequest(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := b.c.do(req)
+		if err != nil {
+			return nil, err
+		}
+		var blockList BlockList
+		if err := decodeInto(resp, &blockList); err != nil {
+			return nil, err
+		}
+		for _, block := range blockList.Results {
+			if block.Object != "block" {
+				continue
+			}
+			if filterType == "" || block.Type == filterType {
+				result = append(result, block)
+			}
+		}
+		if !blockList.HasMore || blockList.NextCursor == "" {
+			break
+		}
+		cursor = blockList.NextCursor
+	}
+	return result, nil
+}
+
+// FormatAllBlocks returns human-readable lines plus a by-type count for
+// every block under pageID, optionally filtered by filterType.
+func (b *BlockClient) FormatAllBlocks(ctx context.Context, pageID string, localTimezone *time.Location, filterType string) ([]string, map[string]int, error) {
+	blocks, err := b.GetAllBlocks(ctx, pageID, filterType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var formatted []string
+	typeCounts := make(map[string]int)
+	for index, block := range blocks {
+		lastEditedTime, err := time.Parse(time.RFC3339, block.LastEditedTime)
+		if err != nil {
+			return nil, nil, err
+		}
+		truncatedTime := lastEditedTime.In(localTimezone).Truncate(time.Minute)
+		icon := GetBlockIcon(block)
+		content := GetBlockContent(block)
+		if len(content) > 50 {
+			content = content[:47] + "..."
+		}
+		element := fmt.Sprintf("%4d %s  [%-20s] %s (%s)",
+			index+1,
+			icon,
+			block.Type,
+			content,
+			truncatedTime.Format("2006-01-02 15:04"))
+		formatted = append(formatted, element)
+		typeCounts[block.Type]++
+	}
+	return formatted, typeCounts, nil
+}
+
+// AddBlock appends a block of the given type to the given page. Pass the
+// block's text for rich-text types; text is ignored for the divider block.
+func (b *BlockClient) AddBlock(ctx context.Context, pageID, blockType, text string) error {
+	if !IsValidBlockType(blockType) {
+		return fmt.Errorf("unsupported block type: %s", blockType)
+	}
+
+	var blockContent map[string]interface{}
+	if blockType == "divider" {
+		blockContent = map[string]interface{}{
+			"object":  "block",
+			"type":    "divider",
+			"divider": map[string]interface{}{},
+		}
+	} else {
+		richText := []map[string]interface{}{
+			{
+				"type": "text",
+				"text": map[string]interface{}{
+					"content": text,
+				},
+			},
+		}
+		innerContent := map[string]interface{}{"rich_text": richText}
+		if blockType == "code" {
+			innerContent["language"] = "plain text"
+		}
+		blockContent = map[string]interface{}{
+			"object":  "block",
+			"type":    blockType,
+			blockType: innerContent,
+		}
+	}
+
+	body := map[string]interface{}{
+		"children": []map[string]interface{}{blockContent},
+	}
+	req, err := b.c.newRequest(ctx, http.MethodPatch, "/blocks/"+pageID+"/children", body)
+	if err != nil {
+		return err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return err
+	}
+	return expectStatus(resp, http.StatusOK)
+}
+
+// DeleteBlock removes the block at the given 1-based index across the full
+// paginated block list.
+func (b *BlockClient) DeleteBlock(ctx context.Context, pageID string, order int) error {
+	blocks, err := b.GetAllBlocks(ctx, pageID, "")
+	if err != nil {
+		return err
+	}
+	if order < 1 || order > len(blocks) {
+		return fmt.Errorf("block number %d out of range (1-%d)", order, len(blocks))
+	}
+	blockID := blocks[order-1].ID
+	req, err := b.c.newRequest(ctx, http.MethodDelete, "/blocks/"+blockID, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := b.c.do(req)
+	if err != nil {
+		return err
+	}
+	return expectStatus(resp, http.StatusOK)
+}

--- a/utils/client.go
+++ b/utils/client.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -131,6 +130,11 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body inter
 
 // do executes the request using the Client's *http.Client. The caller is
 // responsible for reading and closing the response body.
+//
+// This wrapper currently delegates directly to *http.Client.Do, but is
+// retained as the single extension point for future cross-cutting concerns
+// (retries, rate limiting, structured logging) so individual resource
+// clients do not each need to grow their own middleware stack.
 func (c *Client) do(req *http.Request) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -145,8 +149,8 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 func decodeInto(resp *http.Response, target interface{}) error {
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := ioutil.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(body))
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 	if target == nil {
 		return nil
@@ -163,20 +167,11 @@ func decodeInto(resp *http.Response, target interface{}) error {
 func expectStatus(resp *http.Response, want int) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != want {
-		body, _ := ioutil.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(body))
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }
-
-// defaultClient is the package-level Client used by the legacy top-level
-// functions (GetBlocks, AddNewToDoItem, etc.). It is reconfigured when
-// callers mutate the baseURL via SetBaseURL, which preserves existing
-// httptest-based test wiring.
-//
-// New code should construct its own Client via NewClient rather than
-// reaching for the default.
-var defaultClient = NewClient("", WithBaseURL(DefaultBaseURL))
 
 // defaultCtx returns a context for legacy package-level callers that do not
 // yet plumb context.Context. Kept tight so it is easy to find and remove

--- a/utils/client.go
+++ b/utils/client.go
@@ -1,0 +1,186 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// NotionAPIVersion is the pinned Notion API version used for every request.
+// Bumping it is an explicit, tracked change (see issue #11) — do not update
+// without a linked issue.
+const NotionAPIVersion = "2022-06-28"
+
+// DefaultBaseURL is the default Notion API base URL. It is exposed so tests
+// and integrators can reason about the default target without reaching into
+// a global.
+const DefaultBaseURL = "https://api.notion.com/v1"
+
+// Client is the shared HTTP client used by every typed resource client
+// (BlockClient, PageClient, etc.). It owns the Notion credentials and the
+// underlying *http.Client so callers can inject their own transport for
+// tests or custom timeouts.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	apiVersion string
+	httpClient *http.Client
+}
+
+// Option mutates a Client during construction. Pass Options into NewClient
+// to override defaults.
+type Option func(*Client)
+
+// WithBaseURL overrides the Notion API base URL. Useful for tests that wire
+// an httptest.Server in front of the client.
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) {
+		c.baseURL = baseURL
+	}
+}
+
+// WithAPIVersion overrides the Notion-Version header sent with every request.
+// Defaults to NotionAPIVersion. Only override in tests that verify the
+// header wiring — production callers should rely on the pinned constant.
+func WithAPIVersion(version string) Option {
+	return func(c *Client) {
+		c.apiVersion = version
+	}
+}
+
+// WithHTTPClient injects a custom *http.Client (for example, one with a
+// tuned timeout or a test RoundTripper). If not provided, NewClient uses a
+// zero-value *http.Client matching the previous package-level behavior.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		if hc != nil {
+			c.httpClient = hc
+		}
+	}
+}
+
+// NewClient constructs a Client with sensible defaults: DefaultBaseURL,
+// NotionAPIVersion, and a bare *http.Client. Override any of those via
+// Options.
+func NewClient(apiKey string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:    DefaultBaseURL,
+		apiKey:     apiKey,
+		apiVersion: NotionAPIVersion,
+		httpClient: &http.Client{},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// BaseURL returns the client's configured base URL. Primarily useful for
+// tests and diagnostic output.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
+// APIVersion returns the client's configured Notion-Version value.
+func (c *Client) APIVersion() string {
+	return c.apiVersion
+}
+
+// HTTPClient returns the underlying *http.Client.
+func (c *Client) HTTPClient() *http.Client {
+	return c.httpClient
+}
+
+// newRequest builds an *http.Request with the standard Notion headers
+// applied. It is unexported — callers should use one of the typed resource
+// clients (BlockClient, etc.) rather than hand-assembling requests.
+func (c *Client) newRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
+	var reader io.Reader
+	hasBody := false
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewBuffer(buf)
+		hasBody = true
+	}
+
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Notion-Version", c.apiVersion)
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if hasBody {
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	}
+	return req, nil
+}
+
+// do executes the request using the Client's *http.Client. The caller is
+// responsible for reading and closing the response body.
+func (c *Client) do(req *http.Request) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// decodeInto reads resp.Body and unmarshals it into target. It always closes
+// resp.Body. Returns an error if the status code is non-2xx or the payload
+// fails to decode.
+func decodeInto(resp *http.Response, target interface{}) error {
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(body))
+	}
+	if target == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+// expectStatus closes resp.Body and returns an error if the status code is
+// outside the 2xx range. Use this for PATCH/DELETE calls where the response
+// payload is uninteresting.
+func expectStatus(resp *http.Response, want int) error {
+	defer resp.Body.Close()
+	if resp.StatusCode != want {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// defaultClient is the package-level Client used by the legacy top-level
+// functions (GetBlocks, AddNewToDoItem, etc.). It is reconfigured when
+// callers mutate the baseURL via SetBaseURL, which preserves existing
+// httptest-based test wiring.
+//
+// New code should construct its own Client via NewClient rather than
+// reaching for the default.
+var defaultClient = NewClient("", WithBaseURL(DefaultBaseURL))
+
+// defaultCtx returns a context for legacy package-level callers that do not
+// yet plumb context.Context. Kept tight so it is easy to find and remove
+// when callers are migrated.
+func defaultCtx() context.Context {
+	return context.Background()
+}

--- a/utils/client_test.go
+++ b/utils/client_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -139,6 +140,28 @@ func TestClientDefaultAPIVersion(t *testing.T) {
 	}
 	if gotVersion != NotionAPIVersion {
 		t.Errorf("Notion-Version=%q want %q (default)", gotVersion, NotionAPIVersion)
+	}
+}
+
+// TestDecodeIntoNon2xx covers the non-2xx branch of decodeInto: the server
+// returns HTTP 400 with an error payload, and the caller should get a
+// non-nil error whose message surfaces the status code and the body.
+func TestDecodeIntoNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"bad request"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("sk_test", WithBaseURL(srv.URL))
+	bc := NewBlockClient(c)
+
+	_, err := bc.GetBlocks(context.Background(), "pageID")
+	if err == nil {
+		t.Fatal("expected error from 400 response, got nil")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "400") || !strings.Contains(msg, "bad request") {
+		t.Errorf("error=%q should include status 400 and body", msg)
 	}
 }
 

--- a/utils/client_test.go
+++ b/utils/client_test.go
@@ -1,0 +1,229 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient("sk_test")
+	if c == nil {
+		t.Fatal("NewClient returned nil")
+	}
+	if c.apiKey != "sk_test" {
+		t.Errorf("apiKey=%q want sk_test", c.apiKey)
+	}
+	if c.BaseURL() != DefaultBaseURL {
+		t.Errorf("baseURL=%q want %q", c.BaseURL(), DefaultBaseURL)
+	}
+	if c.APIVersion() != NotionAPIVersion {
+		t.Errorf("apiVersion=%q want %q", c.APIVersion(), NotionAPIVersion)
+	}
+	if c.HTTPClient() == nil {
+		t.Error("HTTPClient is nil; want a non-nil default *http.Client")
+	}
+}
+
+func TestWithBaseURL(t *testing.T) {
+	c := NewClient("sk_test", WithBaseURL("https://example.test/v1"))
+	if c.BaseURL() != "https://example.test/v1" {
+		t.Errorf("baseURL=%q want https://example.test/v1", c.BaseURL())
+	}
+}
+
+func TestWithAPIVersion(t *testing.T) {
+	c := NewClient("sk_test", WithAPIVersion("2099-01-01"))
+	if c.APIVersion() != "2099-01-01" {
+		t.Errorf("apiVersion=%q want 2099-01-01", c.APIVersion())
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	custom := &http.Client{}
+	c := NewClient("sk_test", WithHTTPClient(custom))
+	if c.HTTPClient() != custom {
+		t.Error("WithHTTPClient did not set the injected client")
+	}
+	// nil is a no-op (keeps the default client rather than crashing later).
+	c2 := NewClient("sk_test", WithHTTPClient(nil))
+	if c2.HTTPClient() == nil {
+		t.Error("WithHTTPClient(nil) should leave the default client in place")
+	}
+}
+
+func TestBaseURL(t *testing.T) {
+	c := NewClient("sk_test", WithBaseURL("https://mock/v1"))
+	if got := c.BaseURL(); got != "https://mock/v1" {
+		t.Errorf("BaseURL()=%q", got)
+	}
+}
+
+func TestAPIVersion(t *testing.T) {
+	c := NewClient("sk_test", WithAPIVersion("2099-12-31"))
+	if got := c.APIVersion(); got != "2099-12-31" {
+		t.Errorf("APIVersion()=%q", got)
+	}
+}
+
+func TestHTTPClient(t *testing.T) {
+	hc := &http.Client{}
+	c := NewClient("sk_test", WithHTTPClient(hc))
+	if c.HTTPClient() != hc {
+		t.Error("HTTPClient() did not return the injected *http.Client")
+	}
+}
+
+// TestClientSendsNotionHeaders verifies every outbound request carries the
+// Authorization, Notion-Version, and Accept headers. Uses BlockClient as a
+// convenient exerciser of the full newRequest/do path.
+func TestClientSendsNotionHeaders(t *testing.T) {
+	var gotAuth, gotVersion, gotAccept, gotContentType string
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotVersion = r.Header.Get("Notion-Version")
+		gotAccept = r.Header.Get("Accept")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("sk_test_abc",
+		WithBaseURL(srv.URL),
+		WithAPIVersion("2099-01-01"),
+	)
+
+	// PATCH carries a body, so Content-Type must be set. Use AddNewToDoItem
+	// via BlockClient because it's the simplest body-bearing path.
+	bc := NewBlockClient(c)
+	if err := bc.AddNewToDoItem(context.Background(), "pageID", "hello"); err != nil {
+		t.Fatalf("AddNewToDoItem: %v", err)
+	}
+	if gotMethod != http.MethodPatch {
+		t.Errorf("method=%s want PATCH", gotMethod)
+	}
+	if gotAuth != "Bearer sk_test_abc" {
+		t.Errorf("Authorization=%q want 'Bearer sk_test_abc'", gotAuth)
+	}
+	if gotVersion != "2099-01-01" {
+		t.Errorf("Notion-Version=%q want 2099-01-01 (WithAPIVersion override)", gotVersion)
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept=%q want application/json", gotAccept)
+	}
+	if gotContentType != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type=%q want application/json; charset=utf-8", gotContentType)
+	}
+}
+
+func TestClientDefaultAPIVersion(t *testing.T) {
+	var gotVersion string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotVersion = r.Header.Get("Notion-Version")
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("sk_test", WithBaseURL(srv.URL))
+	bc := NewBlockClient(c)
+	if _, err := bc.GetBlocks(context.Background(), "pageID"); err != nil {
+		t.Fatalf("GetBlocks: %v", err)
+	}
+	if gotVersion != NotionAPIVersion {
+		t.Errorf("Notion-Version=%q want %q (default)", gotVersion, NotionAPIVersion)
+	}
+}
+
+func TestClientRespectsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("sk_test", WithBaseURL(srv.URL))
+	bc := NewBlockClient(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before dispatch
+
+	_, err := bc.GetBlocks(ctx, "pageID")
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}
+
+// --- Resource-client stub constructors ---
+
+func TestNewBlockClient(t *testing.T) {
+	c := NewClient("sk_test")
+	bc := NewBlockClient(c)
+	if bc == nil {
+		t.Fatal("NewBlockClient returned nil")
+	}
+	if bc.c != c {
+		t.Error("NewBlockClient did not store the injected *Client")
+	}
+}
+
+func TestNewPageClient(t *testing.T) {
+	c := NewClient("sk_test")
+	pc := NewPageClient(c)
+	if pc == nil {
+		t.Fatal("NewPageClient returned nil")
+	}
+	if pc.c != c {
+		t.Error("NewPageClient did not store the injected *Client")
+	}
+}
+
+func TestNewDatabaseClient(t *testing.T) {
+	c := NewClient("sk_test")
+	dc := NewDatabaseClient(c)
+	if dc == nil {
+		t.Fatal("NewDatabaseClient returned nil")
+	}
+	if dc.c != c {
+		t.Error("NewDatabaseClient did not store the injected *Client")
+	}
+}
+
+func TestNewSearchClient(t *testing.T) {
+	c := NewClient("sk_test")
+	sc := NewSearchClient(c)
+	if sc == nil {
+		t.Fatal("NewSearchClient returned nil")
+	}
+	if sc.c != c {
+		t.Error("NewSearchClient did not store the injected *Client")
+	}
+}
+
+func TestNewCommentClient(t *testing.T) {
+	c := NewClient("sk_test")
+	cc := NewCommentClient(c)
+	if cc == nil {
+		t.Fatal("NewCommentClient returned nil")
+	}
+	if cc.c != c {
+		t.Error("NewCommentClient did not store the injected *Client")
+	}
+}
+
+func TestNewUserClient(t *testing.T) {
+	c := NewClient("sk_test")
+	uc := NewUserClient(c)
+	if uc == nil {
+		t.Fatal("NewUserClient returned nil")
+	}
+	if uc.c != c {
+		t.Error("NewUserClient did not store the injected *Client")
+	}
+}

--- a/utils/comments.go
+++ b/utils/comments.go
@@ -1,0 +1,19 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+// CommentClient is the typed resource client for the Notion comments API.
+//
+// TODO(#9): flesh out with List + Create methods.
+// Today this is a deliberate stub so the shape of the refactor is visible
+// without expanding the scope of issue #1.
+type CommentClient struct {
+	c *Client
+}
+
+// NewCommentClient wraps a *Client with comment-resource methods.
+func NewCommentClient(c *Client) *CommentClient {
+	return &CommentClient{c: c}
+}

--- a/utils/databases.go
+++ b/utils/databases.go
@@ -1,0 +1,19 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+// DatabaseClient is the typed resource client for the Notion databases API.
+//
+// TODO(#6): flesh out with Retrieve, Query, Create, Update methods.
+// Today this is a deliberate stub so the shape of the refactor is visible
+// without expanding the scope of issue #1.
+type DatabaseClient struct {
+	c *Client
+}
+
+// NewDatabaseClient wraps a *Client with database-resource methods.
+func NewDatabaseClient(c *Client) *DatabaseClient {
+	return &DatabaseClient{c: c}
+}

--- a/utils/pages.go
+++ b/utils/pages.go
@@ -1,0 +1,19 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+// PageClient is the typed resource client for the Notion pages API.
+//
+// TODO(#5): flesh out with Retrieve, Create, Update, Archive methods.
+// Today this is a deliberate stub so the shape of the refactor is visible
+// without expanding the scope of issue #1.
+type PageClient struct {
+	c *Client
+}
+
+// NewPageClient wraps a *Client with page-resource methods.
+func NewPageClient(c *Client) *PageClient {
+	return &PageClient{c: c}
+}

--- a/utils/search.go
+++ b/utils/search.go
@@ -1,0 +1,19 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+// SearchClient is the typed resource client for the Notion search API.
+//
+// TODO(#8): flesh out with Query method, filter + sort options.
+// Today this is a deliberate stub so the shape of the refactor is visible
+// without expanding the scope of issue #1.
+type SearchClient struct {
+	c *Client
+}
+
+// NewSearchClient wraps a *Client with search-resource methods.
+func NewSearchClient(c *Client) *SearchClient {
+	return &SearchClient{c: c}
+}

--- a/utils/users.go
+++ b/utils/users.go
@@ -1,0 +1,19 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+// UserClient is the typed resource client for the Notion users API.
+//
+// TODO: flesh out with List, Retrieve, and Me methods (see MCP-parity
+// tracking issues). Today this is a deliberate stub so the shape of the
+// refactor is visible without expanding the scope of issue #1.
+type UserClient struct {
+	c *Client
+}
+
+// NewUserClient wraps a *Client with user-resource methods.
+func NewUserClient(c *Client) *UserClient {
+	return &UserClient{c: c}
+}


### PR DESCRIPTION
## Summary

First cut of the `utils/` refactor called out in issue #1.

- **`utils/client.go`** — new `Client` that owns `baseURL`, `apiKey`, `apiVersion`, and `*http.Client`. Functional options: `WithBaseURL`, `WithAPIVersion`, `WithHTTPClient`. `const NotionAPIVersion = "2022-06-28"` now lives in one place.
- **`utils/blocks.go`** — new `BlockClient` with context-first methods mirroring every existing block helper: `GetBlocks`, `GetToDoBlocks`, `AddNewToDoItem`, `GetBlockID`, `MarkToDoBlockChecked/UnChecked`, `DeleteToDoBlock`, `GetAllBlocks`, `FormatAllBlocks`, `AddBlock`, `DeleteBlock`.
- **`utils/block.go`** — shrinks from ~640 lines to ~310. Keeps types (`Block`, `ToDo`, `RichText`, etc.), display helpers (`GetBlockContent`, `GetBlockIcon`, `SupportedBlockTypes`, `GetSupportedBlockTypeNames`, `IsValidBlockType`), and thin package-level delegators that forward to a default `BlockClient`. Every delegator is marked `// Deprecated:` in godoc. `cmd/` callers compile without change.
- **`utils/pages.go` / `databases.go` / `search.go` / `comments.go` / `users.go`** — empty `XClient` stubs with `NewXClient(*Client)` constructors and TODO comments pointing at their tracking issues (#5/#6/#8/#9). Deliberate no-ops so the follow-up PRs have obvious landing pads.

## Scope cuts / decisions

- **Kept `var baseURL` in `block.go`** as the source of truth for legacy top-level calls so existing `SetBaseURL`-based tests continue to redirect without changes. New code should construct its own `*Client` via `NewClient(WithBaseURL(...))`.
- **Did not touch `utils/page.go`** (the legacy `getNotionPage` helper). It coexists with the new `utils/pages.go` stub; #5 will migrate it.
- **Delegators marked Deprecated now, not removed.** Removal is a separate PR once call sites migrate. The godoc notes point at the new API.
- **Diff size grew to ~720 net lines** (vs. the ~500 target) because `client.go` + `client_test.go` together are ~415 lines — the tests alone are load-bearing for the new Client + every resource-stub constructor. Opened as draft per the escape-hatch instruction. Rebase/squash if a tighter single-commit story is preferred on merge.

## Test evidence

- `go test ./...` — pass
- `go test -race ./...` — pass
- `go vet ./...` — clean
- `gofmt -l .` — empty
- `make ci` — green (coverage 73.3%, gate 70%)
- Gap gate (`scripts/check-test-coverage.sh`) — every new exported identifier has a matching `Test*`

### Coverage delta

| Package | Before | After |
|---|---|---|
| `utils` | 72.5% | 73.5% |
| total | 72.4% | 73.3% |

### New tests (added in `utils/client_test.go`)

- `TestNewClient` — default construction, apiKey/baseURL/apiVersion/httpClient defaults
- `TestWithBaseURL`, `TestWithAPIVersion`, `TestWithHTTPClient` — each functional option
- `TestBaseURL`, `TestAPIVersion`, `TestHTTPClient` — accessor methods
- `TestClientSendsNotionHeaders` — verifies Authorization, Notion-Version, Accept, Content-Type on outbound requests
- `TestClientDefaultAPIVersion` — `NotionAPIVersion` constant is the default header value
- `TestClientRespectsContextCancellation` — cancelled context short-circuits the request
- `TestNewBlockClient`, `TestNewPageClient`, `TestNewDatabaseClient`, `TestNewSearchClient`, `TestNewCommentClient`, `TestNewUserClient` — stub constructors

## Follow-ups

- Remove `Deprecated` delegators once `cmd/` migrates to `BlockClient` directly (separate small PR).
- Replace `var baseURL` with a setter on `defaultClient` once the delegators are gone.
- Migrate `utils/page.go`'s `getNotionPage` onto the new `PageClient` in #5.
- #11 Notion API version bump lands as a one-line `const` edit now.

## Test plan

- [x] `make ci` green
- [x] `go test -race ./...` green
- [x] Gap gate green
- [x] `cmd/` builds without modification
- [ ] Confirm rebase/merge strategy with reviewer if diff size is blocking