### PR TITLE
feat: pages CRUD (closes #5)

### DIFF
--- a/cmd/pages.go
+++ b/cmd/pages.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"notioncli/utils"
@@ -87,18 +89,17 @@ var pagesGetCmd = &cobra.Command{
 	Use:   "get <id>",
 	Short: "Retrieve a page by ID",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		page, err := pc.Get(context.Background(), args[0])
 		if err != nil {
-			color.Red("Error getting page: %v", err)
-			return
+			return fmt.Errorf("get page: %w", err)
 		}
-		printPage(page)
+		printPage(cmd.OutOrStdout(), page)
+		return nil
 	},
 }
 
@@ -106,39 +107,41 @@ var pagesGetCmd = &cobra.Command{
 var pagesCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new page under --parent",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if pagesCreateParent == "" {
-			color.Red("Error: --parent is required")
-			return
+			return fmt.Errorf("create page: --parent is required")
 		}
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		page, err := pc.Create(context.Background(), utils.CreatePageRequest{
 			Parent: utils.PageParent{PageID: pagesCreateParent},
 			Title:  pagesCreateTitle,
 		})
 		if err != nil {
-			color.Red("Error creating page: %v", err)
-			return
+			return fmt.Errorf("create page: %w", err)
 		}
 		color.Green("Created page %s", page.ID)
-		printPage(page)
+		printPage(cmd.OutOrStdout(), page)
+		return nil
 	},
 }
 
 // pagesUpdateCmd patches title and/or --property key=value pairs on a page.
+//
+// Note: --property key=value values are always encoded as rich_text today.
+// Typed properties (status, select, number, date, checkbox, url) will 400
+// against that shape; callers that need a typed property should use the
+// PageClient.Update API directly until a typed flag shape lands.
 var pagesUpdateCmd = &cobra.Command{
 	Use:   "update <id>",
 	Short: "Update a page's title and/or properties",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		req := utils.UpdatePageRequest{Title: pagesUpdateTitle}
 		if len(pagesUpdateProps) > 0 {
@@ -146,19 +149,18 @@ var pagesUpdateCmd = &cobra.Command{
 			for _, raw := range pagesUpdateProps {
 				key, val, err := parseProperty(raw)
 				if err != nil {
-					color.Red("Error: %v", err)
-					return
+					return err
 				}
 				req.Properties[key] = val
 			}
 		}
 		page, err := pc.Update(context.Background(), args[0], req)
 		if err != nil {
-			color.Red("Error updating page: %v", err)
-			return
+			return fmt.Errorf("update page: %w", err)
 		}
 		color.Green("Updated page %s", page.ID)
-		printPage(page)
+		printPage(cmd.OutOrStdout(), page)
+		return nil
 	},
 }
 
@@ -167,17 +169,16 @@ var pagesArchiveCmd = &cobra.Command{
 	Use:   "archive <id>",
 	Short: "Archive a page",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		if err := pc.Archive(context.Background(), args[0]); err != nil {
-			color.Red("Error archiving page: %v", err)
-			return
+			return fmt.Errorf("archive page: %w", err)
 		}
 		color.Green("Archived page %s", args[0])
+		return nil
 	},
 }
 
@@ -186,40 +187,39 @@ var pagesUnarchiveCmd = &cobra.Command{
 	Use:   "unarchive <id>",
 	Short: "Unarchive a page",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		if err := pc.Unarchive(context.Background(), args[0]); err != nil {
-			color.Red("Error unarchiving page: %v", err)
-			return
+			return fmt.Errorf("unarchive page: %w", err)
 		}
 		color.Green("Unarchived page %s", args[0])
+		return nil
 	},
 }
 
-// pagesMoveCmd reparents a page.
+// pagesMoveCmd reparents a page. Only page-parent moves are supported; to
+// move a page into a database parent, use the lower-level PageClient.Update
+// with a PageParent{DatabaseID: ...}.
 var pagesMoveCmd = &cobra.Command{
 	Use:   "move <id>",
-	Short: "Move a page to a new parent (--parent)",
+	Short: "Move a page to a new page parent (--parent). Use the API for database parents.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if pagesMoveParent == "" {
-			color.Red("Error: --parent is required")
-			return
+			return fmt.Errorf("move page: --parent is required")
 		}
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		if err := pc.Move(context.Background(), args[0], pagesMoveParent); err != nil {
-			color.Red("Error moving page: %v", err)
-			return
+			return fmt.Errorf("move page: %w", err)
 		}
 		color.Green("Moved page %s → parent %s", args[0], pagesMoveParent)
+		return nil
 	},
 }
 
@@ -235,48 +235,55 @@ var pagesDuplicateCmd = &cobra.Command{
 	Long: `Duplicate a Notion page under a new parent.
 
 Notion does not expose a native duplicate endpoint. This command emulates
-one by (1) fetching the source page's children, (2) creating a new page
-under --parent with the source's title, and (3) appending those children.
+one by (1) fetching the source page and its children, (2) creating a new
+page under --parent with the source's title, and (3) appending those
+children.
 
 Limitations:
   - Only top-level blocks are copied. Nested blocks where has_children=true
     are NOT recursed into.
+  - Unsupported top-level block types (image, file, video, bookmark, embed,
+    child_page, child_database, table, column_list, equation, synced_block)
+    are silently skipped.
   - Child databases are not re-created.
   - Property values from database-parented sources are not carried over.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if pagesDuplicateParent == "" {
-			color.Red("Error: --parent is required")
-			return
+			return fmt.Errorf("duplicate page: --parent is required")
 		}
 		pc, err := newPageClient()
 		if err != nil {
-			color.Red("Error: %v", err)
-			return
+			return err
 		}
 		page, err := pc.Duplicate(context.Background(), args[0], pagesDuplicateParent)
 		if err != nil {
-			color.Red("Error duplicating page: %v", err)
-			return
+			return fmt.Errorf("duplicate page: %w", err)
 		}
 		color.Green("Duplicated page %s → %s", args[0], page.ID)
-		printPage(page)
+		printPage(cmd.OutOrStdout(), page)
+		return nil
 	},
 }
 
-// printPage writes a human-readable JSON blob to stdout. This is the v1
-// output format for every pages subcommand — a proper --json vs. table split
-// will land with the wider --json rollout on the roadmap.
-func printPage(page *utils.Page) {
+// printPage writes a human-readable JSON blob to the given writer. This is
+// the v1 output format for every pages subcommand — a proper --json vs.
+// table split will land with the wider --json rollout on the roadmap. The
+// writer is threaded through cmd.OutOrStdout() so tests can capture output
+// via cmd.SetOut.
+func printPage(w io.Writer, page *utils.Page) {
 	if page == nil {
 		return
+	}
+	if w == nil {
+		w = os.Stdout
 	}
 	b, err := json.MarshalIndent(page, "", "  ")
 	if err != nil {
 		color.Red("Error formatting page: %v", err)
 		return
 	}
-	fmt.Println(string(b))
+	fmt.Fprintln(w, string(b))
 }
 
 func init() {

--- a/cmd/pages.go
+++ b/cmd/pages.go
@@ -1,0 +1,296 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// Flag vars for the pages subcommands. Keeping them package-level mirrors
+// blocks.go's pattern and lets cobra bind them via init().
+var (
+	pagesCreateParent    string
+	pagesCreateTitle     string
+	pagesUpdateTitle     string
+	pagesUpdateProps     []string
+	pagesMoveParent      string
+	pagesDuplicateParent string
+)
+
+// pagesCmd is the parent of every `notioncli pages …` subcommand.
+var pagesCmd = &cobra.Command{
+	Use:   "pages",
+	Short: "Manage Notion pages (get, create, update, archive, move, duplicate)",
+	Long: `Work with Notion pages directly: retrieve, create, update,
+archive/unarchive, move between parents, and duplicate.
+
+Examples:
+  notioncli pages get <page-id>
+  notioncli pages create --parent <page-or-db-id> --title "New page"
+  notioncli pages update <id> --title "Renamed"
+  notioncli pages archive <id>
+  notioncli pages unarchive <id>
+  notioncli pages move <id> --parent <new-parent>
+  notioncli pages duplicate <id> --parent <parent-id>`,
+}
+
+// newPageClient builds a PageClient using the CLI's standard config loading
+// so every subcommand shares identical client construction.
+func newPageClient() (*utils.PageClient, error) {
+	apiKey, _ := utils.SetAPIConfig()
+	c := utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))
+	return utils.NewPageClient(c), nil
+}
+
+// parseProperty splits "key=value" from the --property flag. Values are sent
+// as plain-text rich_text entries because without a schema lookup we cannot
+// infer the target property type; callers that need typed properties should
+// use the lower-level PageClient.Update with a full Properties map.
+func parseProperty(raw string) (string, map[string]interface{}, error) {
+	idx := strings.Index(raw, "=")
+	if idx < 1 {
+		return "", nil, fmt.Errorf("invalid --property %q, expected key=value", raw)
+	}
+	key := strings.TrimSpace(raw[:idx])
+	value := raw[idx+1:]
+	if key == "" {
+		return "", nil, fmt.Errorf("invalid --property %q, key is empty", raw)
+	}
+	payload := map[string]interface{}{
+		"rich_text": []map[string]interface{}{
+			{
+				"type": "text",
+				"text": map[string]interface{}{"content": value},
+			},
+		},
+	}
+	return key, payload, nil
+}
+
+// pagesGetCmd retrieves a page by ID.
+var pagesGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Retrieve a page by ID",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		page, err := pc.Get(context.Background(), args[0])
+		if err != nil {
+			color.Red("Error getting page: %v", err)
+			return
+		}
+		printPage(page)
+	},
+}
+
+// pagesCreateCmd creates a new page under the provided parent.
+var pagesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new page under --parent",
+	Run: func(cmd *cobra.Command, args []string) {
+		if pagesCreateParent == "" {
+			color.Red("Error: --parent is required")
+			return
+		}
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		page, err := pc.Create(context.Background(), utils.CreatePageRequest{
+			Parent: utils.PageParent{PageID: pagesCreateParent},
+			Title:  pagesCreateTitle,
+		})
+		if err != nil {
+			color.Red("Error creating page: %v", err)
+			return
+		}
+		color.Green("Created page %s", page.ID)
+		printPage(page)
+	},
+}
+
+// pagesUpdateCmd patches title and/or --property key=value pairs on a page.
+var pagesUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a page's title and/or properties",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		req := utils.UpdatePageRequest{Title: pagesUpdateTitle}
+		if len(pagesUpdateProps) > 0 {
+			req.Properties = map[string]interface{}{}
+			for _, raw := range pagesUpdateProps {
+				key, val, err := parseProperty(raw)
+				if err != nil {
+					color.Red("Error: %v", err)
+					return
+				}
+				req.Properties[key] = val
+			}
+		}
+		page, err := pc.Update(context.Background(), args[0], req)
+		if err != nil {
+			color.Red("Error updating page: %v", err)
+			return
+		}
+		color.Green("Updated page %s", page.ID)
+		printPage(page)
+	},
+}
+
+// pagesArchiveCmd archives a page.
+var pagesArchiveCmd = &cobra.Command{
+	Use:   "archive <id>",
+	Short: "Archive a page",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		if err := pc.Archive(context.Background(), args[0]); err != nil {
+			color.Red("Error archiving page: %v", err)
+			return
+		}
+		color.Green("Archived page %s", args[0])
+	},
+}
+
+// pagesUnarchiveCmd unarchives a page.
+var pagesUnarchiveCmd = &cobra.Command{
+	Use:   "unarchive <id>",
+	Short: "Unarchive a page",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		if err := pc.Unarchive(context.Background(), args[0]); err != nil {
+			color.Red("Error unarchiving page: %v", err)
+			return
+		}
+		color.Green("Unarchived page %s", args[0])
+	},
+}
+
+// pagesMoveCmd reparents a page.
+var pagesMoveCmd = &cobra.Command{
+	Use:   "move <id>",
+	Short: "Move a page to a new parent (--parent)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if pagesMoveParent == "" {
+			color.Red("Error: --parent is required")
+			return
+		}
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		if err := pc.Move(context.Background(), args[0], pagesMoveParent); err != nil {
+			color.Red("Error moving page: %v", err)
+			return
+		}
+		color.Green("Moved page %s → parent %s", args[0], pagesMoveParent)
+	},
+}
+
+// pagesDuplicateCmd emulates a Notion page duplicate.
+//
+// Notion has no native duplicate endpoint; this command performs a
+// best-effort copy by fetching the source's top-level blocks, creating a new
+// page under --parent, and appending those blocks. Nested databases and
+// blocks with has_children=true are NOT recursively copied.
+var pagesDuplicateCmd = &cobra.Command{
+	Use:   "duplicate <id>",
+	Short: "Duplicate a page under --parent (top-level blocks only)",
+	Long: `Duplicate a Notion page under a new parent.
+
+Notion does not expose a native duplicate endpoint. This command emulates
+one by (1) fetching the source page's children, (2) creating a new page
+under --parent with the source's title, and (3) appending those children.
+
+Limitations:
+  - Only top-level blocks are copied. Nested blocks where has_children=true
+    are NOT recursed into.
+  - Child databases are not re-created.
+  - Property values from database-parented sources are not carried over.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if pagesDuplicateParent == "" {
+			color.Red("Error: --parent is required")
+			return
+		}
+		pc, err := newPageClient()
+		if err != nil {
+			color.Red("Error: %v", err)
+			return
+		}
+		page, err := pc.Duplicate(context.Background(), args[0], pagesDuplicateParent)
+		if err != nil {
+			color.Red("Error duplicating page: %v", err)
+			return
+		}
+		color.Green("Duplicated page %s → %s", args[0], page.ID)
+		printPage(page)
+	},
+}
+
+// printPage writes a human-readable JSON blob to stdout. This is the v1
+// output format for every pages subcommand — a proper --json vs. table split
+// will land with the wider --json rollout on the roadmap.
+func printPage(page *utils.Page) {
+	if page == nil {
+		return
+	}
+	b, err := json.MarshalIndent(page, "", "  ")
+	if err != nil {
+		color.Red("Error formatting page: %v", err)
+		return
+	}
+	fmt.Println(string(b))
+}
+
+func init() {
+	rootCmd.AddCommand(pagesCmd)
+	pagesCmd.AddCommand(pagesGetCmd)
+	pagesCmd.AddCommand(pagesCreateCmd)
+	pagesCmd.AddCommand(pagesUpdateCmd)
+	pagesCmd.AddCommand(pagesArchiveCmd)
+	pagesCmd.AddCommand(pagesUnarchiveCmd)
+	pagesCmd.AddCommand(pagesMoveCmd)
+	pagesCmd.AddCommand(pagesDuplicateCmd)
+
+	pagesCreateCmd.Flags().StringVar(&pagesCreateParent, "parent", "", "Parent page or database ID (required)")
+	pagesCreateCmd.Flags().StringVar(&pagesCreateTitle, "title", "", "Title for the new page")
+
+	pagesUpdateCmd.Flags().StringVar(&pagesUpdateTitle, "title", "", "New title for the page")
+	pagesUpdateCmd.Flags().StringArrayVar(&pagesUpdateProps, "property", nil, "Set a property as key=value (repeatable)")
+
+	pagesMoveCmd.Flags().StringVar(&pagesMoveParent, "parent", "", "New parent page ID (required)")
+
+	pagesDuplicateCmd.Flags().StringVar(&pagesDuplicateParent, "parent", "", "Parent page ID for the duplicate (required)")
+}

--- a/cmd/pages.go
+++ b/cmd/pages.go
@@ -45,9 +45,14 @@ Examples:
 }
 
 // newPageClient builds a PageClient using the CLI's standard config loading
-// so every subcommand shares identical client construction.
+// so every subcommand shares identical client construction. Returns
+// utils.ErrMissingAPIKey (wrapped) when NOTION_API_KEY resolves empty so
+// callers get a clear configuration error instead of a downstream 401.
 func newPageClient() (*utils.PageClient, error) {
 	apiKey, _ := utils.SetAPIConfig()
+	if apiKey == "" {
+		return nil, fmt.Errorf("pages client: %w", utils.ErrMissingAPIKey)
+	}
 	c := utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))
 	return utils.NewPageClient(c), nil
 }

--- a/cmd/pages_test.go
+++ b/cmd/pages_test.go
@@ -1,0 +1,387 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// findPagesSubcommand walks the pages command's children and returns the
+// child matching name, or fails the test.
+func findPagesSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	pagesC := findTopLevelCmd(t, "pages")
+	for _, c := range pagesC.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("pages subcommand %q not found", name)
+	return nil
+}
+
+// TestPagesCmdRegistered confirms every expected pages subcommand is wired
+// onto the root command.
+func TestPagesCmdRegistered(t *testing.T) {
+	pagesC := findTopLevelCmd(t, "pages")
+	want := map[string]bool{
+		"get": false, "create": false, "update": false,
+		"archive": false, "unarchive": false, "move": false, "duplicate": false,
+	}
+	for _, c := range pagesC.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("pages subcommand %q not registered", name)
+		}
+	}
+}
+
+// TestPagesCreateFlags asserts the create subcommand exposes --parent and --title.
+func TestPagesCreateFlags(t *testing.T) {
+	create := findPagesSubcommand(t, "create")
+	if create.Flag("parent") == nil {
+		t.Error("pages create: --parent flag missing")
+	}
+	if create.Flag("title") == nil {
+		t.Error("pages create: --title flag missing")
+	}
+}
+
+// TestPagesUpdateFlags asserts the update subcommand exposes --title and --property.
+func TestPagesUpdateFlags(t *testing.T) {
+	update := findPagesSubcommand(t, "update")
+	if update.Flag("title") == nil {
+		t.Error("pages update: --title flag missing")
+	}
+	prop := update.Flag("property")
+	if prop == nil {
+		t.Fatal("pages update: --property flag missing")
+	}
+	if prop.Value.Type() != "stringArray" {
+		t.Errorf("pages update: --property type=%q want stringArray", prop.Value.Type())
+	}
+
+	// update requires exactly one positional arg (the page id).
+	if err := update.Args(update, []string{}); err == nil {
+		t.Error("pages update: expected error on zero args")
+	}
+	if err := update.Args(update, []string{"id"}); err != nil {
+		t.Errorf("pages update: expected no error on one arg, got %v", err)
+	}
+}
+
+// TestPagesMoveFlags confirms --parent is present on move.
+func TestPagesMoveFlags(t *testing.T) {
+	move := findPagesSubcommand(t, "move")
+	if move.Flag("parent") == nil {
+		t.Error("pages move: --parent flag missing")
+	}
+}
+
+// TestPagesDuplicateFlags confirms --parent is present on duplicate.
+func TestPagesDuplicateFlags(t *testing.T) {
+	dup := findPagesSubcommand(t, "duplicate")
+	if dup.Flag("parent") == nil {
+		t.Error("pages duplicate: --parent flag missing")
+	}
+}
+
+// TestPagesArgs confirms each subcommand's positional-arg contract.
+func TestPagesArgs(t *testing.T) {
+	for _, name := range []string{"get", "update", "archive", "unarchive", "move", "duplicate"} {
+		sub := findPagesSubcommand(t, name)
+		if err := sub.Args(sub, []string{}); err == nil {
+			t.Errorf("pages %s: expected error on zero args", name)
+		}
+		if err := sub.Args(sub, []string{"id"}); err != nil {
+			t.Errorf("pages %s: expected no error on one arg, got %v", name, err)
+		}
+	}
+}
+
+// TestPagesParseProperty covers the key=value parser shared by pages update.
+func TestPagesParseProperty(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantKey string
+		wantErr bool
+	}{
+		{name: "happy", input: "Status=Done", wantKey: "Status"},
+		{name: "value with equals", input: "Note=a=b", wantKey: "Note"},
+		{name: "missing equals", input: "oops", wantErr: true},
+		{name: "empty key", input: "=nope", wantErr: true},
+		{name: "whitespace key", input: " =v", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, val, err := parseProperty(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if key != tt.wantKey {
+				t.Errorf("key=%q want %q", key, tt.wantKey)
+			}
+			if val == nil {
+				t.Error("expected non-nil value payload")
+			}
+		})
+	}
+}
+
+// pagesDispatchServer swaps the cmd-layer mock with a pages-aware handler.
+// It returns a counter map keyed by method+path and a close func.
+type pagesDispatchServer struct {
+	srv   *httptest.Server
+	mu    sync.Mutex
+	calls map[string]int64
+}
+
+func newPagesDispatchServer(t *testing.T) *pagesDispatchServer {
+	t.Helper()
+	d := &pagesDispatchServer{calls: map[string]int64{}}
+	d.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		d.mu.Lock()
+		d.calls[r.Method+" "+r.URL.Path]++
+		d.mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pages/"):
+			writeDispatchPage(w, strings.TrimPrefix(r.URL.Path, "/pages/"))
+		case r.Method == http.MethodPost && r.URL.Path == "/pages":
+			writeDispatchPage(w, "newPageID")
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/pages/"):
+			writeDispatchPage(w, strings.TrimPrefix(r.URL.Path, "/pages/"))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/children"):
+			_ = json.NewEncoder(w).Encode(utils.BlockList{Results: []utils.Block{{
+				Object: "block", ID: "b1", Type: "paragraph",
+				Paragraph: &utils.RichTextBlock{RichText: []utils.RichText{{PlainText: "hi"}}},
+			}}})
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/children"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(d.srv.Close)
+	return d
+}
+
+func writeDispatchPage(w http.ResponseWriter, id string) {
+	page := map[string]interface{}{
+		"object":           "page",
+		"id":               id,
+		"created_time":     "2026-04-22T10:00:00.000Z",
+		"last_edited_time": "2026-04-22T10:00:00.000Z",
+		"url":              "https://notion.so/" + id,
+		"parent":           map[string]interface{}{"type": "page_id", "page_id": "parent"},
+		"properties":       map[string]interface{}{},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(page)
+}
+
+func (d *pagesDispatchServer) count(key string) int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls[key]
+}
+
+// withPagesEnv swaps in the pages dispatch server and sets env the way the
+// blocks tests do.
+func withPagesEnv(t *testing.T) *pagesDispatchServer {
+	t.Helper()
+	// Inherit the usual cmd-layer env (.env, HOME, etc.), but redirect
+	// utils.baseURL to our pages-aware server.
+	_ = withCmdEnv(t)
+	d := newPagesDispatchServer(t)
+	priorBaseURL := utils.GetBaseURL()
+	utils.SetBaseURL(d.srv.URL)
+	t.Cleanup(func() { utils.SetBaseURL(priorBaseURL) })
+	return d
+}
+
+// resetPagesFlags wipes the package-level flag vars between tests. cobra
+// persists bound flag values across executions.
+func resetPagesFlags() {
+	pagesCreateParent = ""
+	pagesCreateTitle = ""
+	pagesUpdateTitle = ""
+	pagesUpdateProps = nil
+	pagesMoveParent = ""
+	pagesDuplicateParent = ""
+}
+
+// TestPagesGetDispatch runs `pages get <id>` end-to-end against the mock.
+func TestPagesGetDispatch(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"pages", "get", "pageID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := d.count("GET /pages/pageID"); got == 0 {
+		t.Errorf("pages get did not GET /pages/pageID (calls=%v)", d.calls)
+	}
+}
+
+// TestPagesCreateDispatch runs `pages create --parent p --title t`.
+func TestPagesCreateDispatch(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "create", "--parent", "parentID", "--title", "New thing"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := d.count("POST /pages"); got != 1 {
+		t.Errorf("POST /pages count=%d want 1 (calls=%v)", got, d.calls)
+	}
+}
+
+// TestPagesCreateMissingParent confirms --parent is required.
+func TestPagesCreateMissingParent(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "create", "--title", "x"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// No POST should have happened.
+	if got := d.count("POST /pages"); got != 0 {
+		t.Errorf("expected no POST /pages when --parent missing, got %d", got)
+	}
+}
+
+// TestPagesUpdateDispatch runs `pages update id --title ... --property k=v`.
+func TestPagesUpdateDispatch(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "update", "pageID", "--title", "Renamed", "--property", "Status=Done"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := d.count("PATCH /pages/pageID"); got != 1 {
+		t.Errorf("PATCH /pages/pageID count=%d want 1", got)
+	}
+}
+
+// TestPagesArchiveUnarchiveDispatch covers both archive commands.
+func TestPagesArchiveUnarchiveDispatch(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "archive", "pageID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("archive Execute: %v", err)
+	}
+	resetRootCmdArgs()
+	rootCmd.SetArgs([]string{"pages", "unarchive", "pageID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unarchive Execute: %v", err)
+	}
+
+	if got := d.count("PATCH /pages/pageID"); got != 2 {
+		t.Errorf("PATCH /pages/pageID count=%d want 2", got)
+	}
+}
+
+// TestPagesMoveDispatch runs `pages move id --parent newParent`.
+func TestPagesMoveDispatch(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "move", "pageID", "--parent", "newParentID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := d.count("PATCH /pages/pageID"); got == 0 {
+		t.Errorf("pages move did not PATCH /pages/pageID")
+	}
+}
+
+// TestPagesMoveMissingParent confirms --parent is required for move.
+func TestPagesMoveMissingParent(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "move", "pageID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := d.count("PATCH /pages/pageID"); got != 0 {
+		t.Errorf("expected no PATCH when --parent missing, got %d", got)
+	}
+}
+
+// TestPagesDuplicateDispatch confirms the duplicate emulation sequence.
+func TestPagesDuplicateDispatch(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "duplicate", "srcID", "--parent", "parentID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := d.count("POST /pages"); got != 1 {
+		t.Errorf("duplicate POST /pages count=%d want 1", got)
+	}
+	if got := d.count("GET /blocks/srcID/children"); got == 0 {
+		t.Errorf("duplicate did not GET source children")
+	}
+	if got := d.count("PATCH /blocks/newPageID/children"); got == 0 {
+		t.Errorf("duplicate did not PATCH new page children (calls=%v)", d.calls)
+	}
+}
+
+// TestPagesDuplicateMissingParent confirms --parent is required.
+func TestPagesDuplicateMissingParent(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "duplicate", "srcID"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := d.count("POST /pages"); got != 0 {
+		t.Errorf("expected no POST /pages when --parent missing, got %d", got)
+	}
+}

--- a/cmd/pages_test.go
+++ b/cmd/pages_test.go
@@ -268,15 +268,19 @@ func TestPagesCreateDispatch(t *testing.T) {
 	}
 }
 
-// TestPagesCreateMissingParent confirms --parent is required.
+// TestPagesCreateMissingParent confirms --parent is required and that the
+// missing-flag case propagates a non-nil error out of RunE so cobra sets a
+// non-zero shell exit code.
 func TestPagesCreateMissingParent(t *testing.T) {
 	d := withPagesEnv(t)
 	resetPagesFlags()
 	resetRootCmdArgs()
 
 	rootCmd.SetArgs([]string{"pages", "create", "--title", "x"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when --parent missing, got nil")
 	}
 	// No POST should have happened.
 	if got := d.count("POST /pages"); got != 0 {
@@ -335,15 +339,18 @@ func TestPagesMoveDispatch(t *testing.T) {
 	}
 }
 
-// TestPagesMoveMissingParent confirms --parent is required for move.
+// TestPagesMoveMissingParent confirms --parent is required for move and
+// that RunE returns a non-nil error for the missing-flag case.
 func TestPagesMoveMissingParent(t *testing.T) {
 	d := withPagesEnv(t)
 	resetPagesFlags()
 	resetRootCmdArgs()
 
 	rootCmd.SetArgs([]string{"pages", "move", "pageID"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when --parent missing, got nil")
 	}
 	if got := d.count("PATCH /pages/pageID"); got != 0 {
 		t.Errorf("expected no PATCH when --parent missing, got %d", got)
@@ -397,15 +404,18 @@ func TestPagesDuplicateDispatch(t *testing.T) {
 	}
 }
 
-// TestPagesDuplicateMissingParent confirms --parent is required.
+// TestPagesDuplicateMissingParent confirms --parent is required and that
+// RunE surfaces the missing-flag error so shell callers see a non-zero exit.
 func TestPagesDuplicateMissingParent(t *testing.T) {
 	d := withPagesEnv(t)
 	resetPagesFlags()
 	resetRootCmdArgs()
 
 	rootCmd.SetArgs([]string{"pages", "duplicate", "srcID"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when --parent missing, got nil")
 	}
 	if got := d.count("POST /pages"); got != 0 {
 		t.Errorf("expected no POST /pages when --parent missing, got %d", got)

--- a/cmd/pages_test.go
+++ b/cmd/pages_test.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -346,6 +347,31 @@ func TestPagesMoveMissingParent(t *testing.T) {
 	}
 	if got := d.count("PATCH /pages/pageID"); got != 0 {
 		t.Errorf("expected no PATCH when --parent missing, got %d", got)
+	}
+}
+
+// TestPagesMissingAPIKey asserts that when NOTION_API_KEY resolves empty,
+// newPageClient returns ErrMissingAPIKey (wrapped) instead of silently
+// building a Client that would later 401.
+func TestPagesMissingAPIKey(t *testing.T) {
+	_ = withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	// Blank out the API key after the usual cmd env has been set up. The
+	// .env file in the test cwd is empty, so os.LookupEnv sees the empty
+	// value we Setenv here, and SetAPIConfig returns "" for apiKey.
+	t.Setenv("NOTION_API_KEY", "")
+
+	pc, err := newPageClient()
+	if err == nil {
+		t.Fatal("expected error when NOTION_API_KEY empty, got nil")
+	}
+	if pc != nil {
+		t.Errorf("expected nil client on error, got %+v", pc)
+	}
+	if !errors.Is(err, utils.ErrMissingAPIKey) {
+		t.Errorf("expected errors.Is ErrMissingAPIKey, got %v", err)
 	}
 }
 

--- a/utils/pages.go
+++ b/utils/pages.go
@@ -6,9 +6,16 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
+
+// ErrMissingAPIKey is returned by PageClient methods when the underlying
+// Client was constructed without a Notion integration token. Callers can
+// match it with errors.Is to distinguish configuration problems from
+// transport or Notion-side failures.
+var ErrMissingAPIKey = errors.New("notion api key is required")
 
 // PageClient is the typed resource client for the Notion pages API. Build one
 // with NewPageClient and reuse across calls — it is safe for concurrent use
@@ -20,6 +27,17 @@ type PageClient struct {
 // NewPageClient wraps a *Client with page-resource methods.
 func NewPageClient(c *Client) *PageClient {
 	return &PageClient{c: c}
+}
+
+// checkAuth ensures the underlying Client has a non-empty API key. Every
+// HTTP-calling method on PageClient calls this before issuing a request so
+// missing-credential errors surface as ErrMissingAPIKey rather than as an
+// opaque 401 from Notion.
+func (p *PageClient) checkAuth() error {
+	if p == nil || p.c == nil || p.c.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	return nil
 }
 
 // PageParent describes where a page lives. Notion accepts exactly one of
@@ -84,6 +102,9 @@ func titleProperty(title string) map[string]interface{} {
 
 // Get retrieves a page by ID via GET /v1/pages/{id}.
 func (p *PageClient) Get(ctx context.Context, id string) (*Page, error) {
+	if err := p.checkAuth(); err != nil {
+		return nil, fmt.Errorf("get page: %w", err)
+	}
 	if id == "" {
 		return nil, fmt.Errorf("get page: id is required")
 	}
@@ -106,6 +127,9 @@ func (p *PageClient) Get(ctx context.Context, id string) (*Page, error) {
 // req.Title is non-empty it is merged into Properties under the "title" key,
 // overwriting any title the caller already supplied there.
 func (p *PageClient) Create(ctx context.Context, req CreatePageRequest) (*Page, error) {
+	if err := p.checkAuth(); err != nil {
+		return nil, fmt.Errorf("create page: %w", err)
+	}
 	if req.Parent.DatabaseID == "" && req.Parent.PageID == "" && !req.Parent.Workspace {
 		return nil, fmt.Errorf("create page: parent is required")
 	}
@@ -143,6 +167,9 @@ func (p *PageClient) Create(ctx context.Context, req CreatePageRequest) (*Page, 
 // Update patches a page via PATCH /v1/pages/{id}. All fields on the request
 // are optional. Title, when non-empty, becomes a title property.
 func (p *PageClient) Update(ctx context.Context, id string, req UpdatePageRequest) (*Page, error) {
+	if err := p.checkAuth(); err != nil {
+		return nil, fmt.Errorf("update page: %w", err)
+	}
 	if id == "" {
 		return nil, fmt.Errorf("update page: id is required")
 	}
@@ -183,6 +210,9 @@ func (p *PageClient) Update(ctx context.Context, id string, req UpdatePageReques
 
 // setArchived issues the archived PATCH for Archive/Unarchive.
 func (p *PageClient) setArchived(ctx context.Context, id string, archived bool) error {
+	if err := p.checkAuth(); err != nil {
+		return fmt.Errorf("set archived: %w", err)
+	}
 	if id == "" {
 		return fmt.Errorf("set archived: id is required")
 	}
@@ -212,6 +242,9 @@ func (p *PageClient) Unarchive(ctx context.Context, id string) error {
 // newParentID is treated as a page_id parent; to move into a database parent
 // the caller should use Update with a PageParent{DatabaseID: ...}.
 func (p *PageClient) Move(ctx context.Context, id, newParentID string) error {
+	if err := p.checkAuth(); err != nil {
+		return fmt.Errorf("move page: %w", err)
+	}
 	if id == "" {
 		return fmt.Errorf("move page: id is required")
 	}
@@ -245,6 +278,9 @@ func (p *PageClient) Move(ctx context.Context, id, newParentID string) error {
 //   - The source's title, when retrievable, is used for the new page;
 //     otherwise "Copy" is used.
 func (p *PageClient) Duplicate(ctx context.Context, srcID, parentID string) (*Page, error) {
+	if err := p.checkAuth(); err != nil {
+		return nil, fmt.Errorf("duplicate page: %w", err)
+	}
 	if srcID == "" {
 		return nil, fmt.Errorf("duplicate page: source id is required")
 	}

--- a/utils/pages.go
+++ b/utils/pages.go
@@ -4,11 +4,15 @@
 
 package utils
 
-// PageClient is the typed resource client for the Notion pages API.
-//
-// TODO(#5): flesh out with Retrieve, Create, Update, Archive methods.
-// Today this is a deliberate stub so the shape of the refactor is visible
-// without expanding the scope of issue #1.
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PageClient is the typed resource client for the Notion pages API. Build one
+// with NewPageClient and reuse across calls — it is safe for concurrent use
+// because it is a thin wrapper around *Client's *http.Client.
 type PageClient struct {
 	c *Client
 }
@@ -16,4 +20,409 @@ type PageClient struct {
 // NewPageClient wraps a *Client with page-resource methods.
 func NewPageClient(c *Client) *PageClient {
 	return &PageClient{c: c}
+}
+
+// PageParent describes where a page lives. Notion accepts exactly one of
+// database_id, page_id, or workspace=true. The zero value is invalid; callers
+// constructing a CreatePageRequest must populate one of the three identifiers.
+type PageParent struct {
+	Type       string `json:"type,omitempty"`
+	DatabaseID string `json:"database_id,omitempty"`
+	PageID     string `json:"page_id,omitempty"`
+	Workspace  bool   `json:"workspace,omitempty"`
+}
+
+// Page is the envelope returned by /v1/pages endpoints. Properties is left as
+// a loosely-typed map for v1 so callers can round-trip arbitrary Notion
+// property shapes without losing fields. A typed property surface can land in
+// a follow-up.
+type Page struct {
+	Object         string                 `json:"object"`
+	ID             string                 `json:"id"`
+	CreatedTime    string                 `json:"created_time"`
+	LastEditedTime string                 `json:"last_edited_time"`
+	Archived       bool                   `json:"archived"`
+	URL            string                 `json:"url"`
+	Parent         PageParent             `json:"parent"`
+	Properties     map[string]interface{} `json:"properties"`
+}
+
+// CreatePageRequest is the body for POST /v1/pages. Parent is required. Title
+// is a convenience — when non-empty it is folded into a minimal title
+// property. Properties lets callers send additional property values for
+// database-parented pages (e.g. {"Status": {"status": {"name": "Done"}}}).
+// Children, when non-nil, seeds the new page with block content.
+type CreatePageRequest struct {
+	Parent     PageParent               `json:"parent"`
+	Title      string                   `json:"-"`
+	Properties map[string]interface{}   `json:"properties,omitempty"`
+	Children   []map[string]interface{} `json:"children,omitempty"`
+}
+
+// UpdatePageRequest is the body for PATCH /v1/pages/{id}. All fields are
+// optional: unset fields are not sent. Archived is a *bool so callers can
+// distinguish "leave alone" from "explicitly unarchive".
+type UpdatePageRequest struct {
+	Title      string                 `json:"-"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+	Archived   *bool                  `json:"archived,omitempty"`
+	Parent     *PageParent            `json:"parent,omitempty"`
+}
+
+// titleProperty returns the minimal Notion title property payload for the
+// given plain-text title.
+func titleProperty(title string) map[string]interface{} {
+	return map[string]interface{}{
+		"title": []map[string]interface{}{
+			{
+				"type": "text",
+				"text": map[string]interface{}{"content": title},
+			},
+		},
+	}
+}
+
+// Get retrieves a page by ID via GET /v1/pages/{id}.
+func (p *PageClient) Get(ctx context.Context, id string) (*Page, error) {
+	if id == "" {
+		return nil, fmt.Errorf("get page: id is required")
+	}
+	req, err := p.c.newRequest(ctx, http.MethodGet, "/pages/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get page: %w", err)
+	}
+	var page Page
+	if err := decodeInto(resp, &page); err != nil {
+		return nil, fmt.Errorf("get page: %w", err)
+	}
+	return &page, nil
+}
+
+// Create posts a new page to POST /v1/pages. The parent must be set. If
+// req.Title is non-empty it is merged into Properties under the "title" key,
+// overwriting any title the caller already supplied there.
+func (p *PageClient) Create(ctx context.Context, req CreatePageRequest) (*Page, error) {
+	if req.Parent.DatabaseID == "" && req.Parent.PageID == "" && !req.Parent.Workspace {
+		return nil, fmt.Errorf("create page: parent is required")
+	}
+	body := map[string]interface{}{
+		"parent": req.Parent,
+	}
+	props := map[string]interface{}{}
+	for k, v := range req.Properties {
+		props[k] = v
+	}
+	if req.Title != "" {
+		props["title"] = titleProperty(req.Title)
+	}
+	if len(props) > 0 {
+		body["properties"] = props
+	}
+	if len(req.Children) > 0 {
+		body["children"] = req.Children
+	}
+	httpReq, err := p.c.newRequest(ctx, http.MethodPost, "/pages", body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.c.do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("create page: %w", err)
+	}
+	var page Page
+	if err := decodeInto(resp, &page); err != nil {
+		return nil, fmt.Errorf("create page: %w", err)
+	}
+	return &page, nil
+}
+
+// Update patches a page via PATCH /v1/pages/{id}. All fields on the request
+// are optional. Title, when non-empty, becomes a title property.
+func (p *PageClient) Update(ctx context.Context, id string, req UpdatePageRequest) (*Page, error) {
+	if id == "" {
+		return nil, fmt.Errorf("update page: id is required")
+	}
+	body := map[string]interface{}{}
+	props := map[string]interface{}{}
+	for k, v := range req.Properties {
+		props[k] = v
+	}
+	if req.Title != "" {
+		props["title"] = titleProperty(req.Title)
+	}
+	if len(props) > 0 {
+		body["properties"] = props
+	}
+	if req.Archived != nil {
+		body["archived"] = *req.Archived
+	}
+	if req.Parent != nil {
+		body["parent"] = *req.Parent
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("update page: no fields to update")
+	}
+	httpReq, err := p.c.newRequest(ctx, http.MethodPatch, "/pages/"+id, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.c.do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("update page: %w", err)
+	}
+	var page Page
+	if err := decodeInto(resp, &page); err != nil {
+		return nil, fmt.Errorf("update page: %w", err)
+	}
+	return &page, nil
+}
+
+// setArchived issues the archived PATCH for Archive/Unarchive.
+func (p *PageClient) setArchived(ctx context.Context, id string, archived bool) error {
+	if id == "" {
+		return fmt.Errorf("set archived: id is required")
+	}
+	body := map[string]interface{}{"archived": archived}
+	req, err := p.c.newRequest(ctx, http.MethodPatch, "/pages/"+id, body)
+	if err != nil {
+		return err
+	}
+	resp, err := p.c.do(req)
+	if err != nil {
+		return fmt.Errorf("set archived: %w", err)
+	}
+	return expectStatus(resp, http.StatusOK)
+}
+
+// Archive sets archived=true on the page.
+func (p *PageClient) Archive(ctx context.Context, id string) error {
+	return p.setArchived(ctx, id, true)
+}
+
+// Unarchive sets archived=false on the page.
+func (p *PageClient) Unarchive(ctx context.Context, id string) error {
+	return p.setArchived(ctx, id, false)
+}
+
+// Move reparents a page via PATCH /v1/pages/{id} with a parent update. The
+// newParentID is treated as a page_id parent; to move into a database parent
+// the caller should use Update with a PageParent{DatabaseID: ...}.
+func (p *PageClient) Move(ctx context.Context, id, newParentID string) error {
+	if id == "" {
+		return fmt.Errorf("move page: id is required")
+	}
+	if newParentID == "" {
+		return fmt.Errorf("move page: new parent id is required")
+	}
+	body := map[string]interface{}{
+		"parent": PageParent{PageID: newParentID},
+	}
+	req, err := p.c.newRequest(ctx, http.MethodPatch, "/pages/"+id, body)
+	if err != nil {
+		return err
+	}
+	resp, err := p.c.do(req)
+	if err != nil {
+		return fmt.Errorf("move page: %w", err)
+	}
+	return expectStatus(resp, http.StatusOK)
+}
+
+// Duplicate emulates a page copy: GET the source's children, POST a new page
+// under parentID, then PATCH the source's children onto the new page. Notion
+// has no native duplicate endpoint.
+//
+// Limitations (v1):
+//   - Does NOT recurse into nested databases or blocks where has_children is
+//     true. Top-level children only.
+//   - Properties from a database-parented source page are NOT carried over;
+//     the new page is created with a minimal title only. Callers that need
+//     property parity should use Get + Create with the returned Properties.
+//   - The source's title, when retrievable, is used for the new page;
+//     otherwise "Copy" is used.
+func (p *PageClient) Duplicate(ctx context.Context, srcID, parentID string) (*Page, error) {
+	if srcID == "" {
+		return nil, fmt.Errorf("duplicate page: source id is required")
+	}
+	if parentID == "" {
+		return nil, fmt.Errorf("duplicate page: parent id is required")
+	}
+
+	bc := NewBlockClient(p.c)
+	blocks, err := bc.GetAllBlocks(ctx, srcID, "")
+	if err != nil {
+		return nil, fmt.Errorf("duplicate page: fetch children: %w", err)
+	}
+
+	// Best-effort title lookup. A failure here is non-fatal — fall back to
+	// "Copy" so Duplicate can still make progress against mocks and against
+	// pages whose title is hidden from this integration.
+	title := "Copy"
+	if src, err := p.Get(ctx, srcID); err == nil {
+		if t := extractTitle(src); t != "" {
+			title = t
+		}
+	}
+
+	newPage, err := p.Create(ctx, CreatePageRequest{
+		Parent: PageParent{PageID: parentID},
+		Title:  title,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("duplicate page: create: %w", err)
+	}
+
+	if len(blocks) == 0 {
+		return newPage, nil
+	}
+
+	children := blocksToChildren(blocks)
+	body := map[string]interface{}{"children": children}
+	req, err := p.c.newRequest(ctx, http.MethodPatch, "/blocks/"+newPage.ID+"/children", body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate page: append children: %w", err)
+	}
+	if err := expectStatus(resp, http.StatusOK); err != nil {
+		return nil, fmt.Errorf("duplicate page: append children: %w", err)
+	}
+	return newPage, nil
+}
+
+// extractTitle returns the plain-text title of a page when it can be found in
+// the loose property map. Returns "" if no title property is present.
+func extractTitle(page *Page) string {
+	if page == nil {
+		return ""
+	}
+	for _, v := range page.Properties {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		items, ok := m["title"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range items {
+			run, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if pt, ok := run["plain_text"].(string); ok && pt != "" {
+				return pt
+			}
+		}
+	}
+	return ""
+}
+
+// blocksToChildren rebuilds the minimal "children" payload for PATCH
+// /blocks/{id}/children from a slice of Block. Only top-level, supported
+// block types are rewritten; unsupported types are skipped so the PATCH does
+// not 400 on an unknown shape.
+func blocksToChildren(blocks []Block) []map[string]interface{} {
+	children := make([]map[string]interface{}, 0, len(blocks))
+	for _, b := range blocks {
+		child := rebuildBlock(b)
+		if child == nil {
+			continue
+		}
+		children = append(children, child)
+	}
+	return children
+}
+
+// rebuildBlock reconstructs the create-children payload for a single block.
+// Returns nil for block types not supported by the v1 create-children shape
+// we emit here (e.g. child_database, file, image).
+func rebuildBlock(b Block) map[string]interface{} {
+	switch b.Type {
+	case "divider":
+		return map[string]interface{}{
+			"object":  "block",
+			"type":    "divider",
+			"divider": map[string]interface{}{},
+		}
+	case "to_do":
+		if b.ToDo == nil {
+			return nil
+		}
+		return richTextChild("to_do", map[string]interface{}{
+			"checked": b.ToDo.Checked,
+		}, b.ToDo.RichText)
+	case "paragraph":
+		return richTextFromBlock("paragraph", b.Paragraph)
+	case "heading_1":
+		return richTextFromBlock("heading_1", b.Heading1)
+	case "heading_2":
+		return richTextFromBlock("heading_2", b.Heading2)
+	case "heading_3":
+		return richTextFromBlock("heading_3", b.Heading3)
+	case "bulleted_list_item":
+		return richTextFromBlock("bulleted_list_item", b.BulletedListItem)
+	case "numbered_list_item":
+		return richTextFromBlock("numbered_list_item", b.NumberedListItem)
+	case "toggle":
+		return richTextFromBlock("toggle", b.Toggle)
+	case "quote":
+		return richTextFromBlock("quote", b.Quote)
+	case "callout":
+		return richTextFromBlock("callout", b.Callout)
+	case "code":
+		if b.Code == nil {
+			return nil
+		}
+		extra := map[string]interface{}{}
+		if b.Code.Language != "" {
+			extra["language"] = b.Code.Language
+		} else {
+			extra["language"] = "plain text"
+		}
+		return richTextChild("code", extra, b.Code.RichText)
+	}
+	return nil
+}
+
+func richTextFromBlock(typ string, rtb *RichTextBlock) map[string]interface{} {
+	if rtb == nil {
+		return nil
+	}
+	return richTextChild(typ, nil, rtb.RichText)
+}
+
+func richTextChild(typ string, extra map[string]interface{}, runs []RichText) map[string]interface{} {
+	inner := map[string]interface{}{
+		"rich_text": richTextPayload(runs),
+	}
+	for k, v := range extra {
+		inner[k] = v
+	}
+	return map[string]interface{}{
+		"object": "block",
+		"type":   typ,
+		typ:      inner,
+	}
+}
+
+func richTextPayload(runs []RichText) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(runs))
+	for _, r := range runs {
+		content := r.Text.Content
+		if content == "" {
+			content = r.PlainText
+		}
+		out = append(out, map[string]interface{}{
+			"type": "text",
+			"text": map[string]interface{}{"content": content},
+		})
+	}
+	return out
 }

--- a/utils/pages.go
+++ b/utils/pages.go
@@ -288,20 +288,23 @@ func (p *PageClient) Duplicate(ctx context.Context, srcID, parentID string) (*Pa
 		return nil, fmt.Errorf("duplicate page: parent id is required")
 	}
 
+	// Fetch the source page first and surface any error (including 404)
+	// BEFORE creating the destination. Previous revisions swallowed this
+	// error and happily created an empty "Copy" page for a bogus srcID.
+	src, err := p.Get(ctx, srcID)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate page: fetch source: %w", err)
+	}
+
 	bc := NewBlockClient(p.c)
 	blocks, err := bc.GetAllBlocks(ctx, srcID, "")
 	if err != nil {
 		return nil, fmt.Errorf("duplicate page: fetch children: %w", err)
 	}
 
-	// Best-effort title lookup. A failure here is non-fatal — fall back to
-	// "Copy" so Duplicate can still make progress against mocks and against
-	// pages whose title is hidden from this integration.
 	title := "Copy"
-	if src, err := p.Get(ctx, srcID); err == nil {
-		if t := extractTitle(src); t != "" {
-			title = t
-		}
+	if t := extractTitle(src); t != "" {
+		title = t
 	}
 
 	newPage, err := p.Create(ctx, CreatePageRequest{

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -1,0 +1,546 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// pagesMockServer is a stateful httptest server covering every /pages and
+// /blocks path the PageClient touches. Per-test behavior is tuned by swapping
+// fields on the returned handle rather than juggling multiple servers.
+type pagesMockServer struct {
+	srv      *httptest.Server
+	calls    []recordedCall
+	mu       chan struct{} // simple mutex via buffered chan
+	notFound bool
+
+	archiveStates map[string]bool
+
+	// For Duplicate: count of /blocks/{id}/children GETs and PATCHes.
+	blocksGet   int64
+	blocksPatch int64
+}
+
+type recordedCall struct {
+	method string
+	path   string
+	body   map[string]interface{}
+}
+
+func newPagesMockServer(t *testing.T) *pagesMockServer {
+	t.Helper()
+	p := &pagesMockServer{
+		mu:            make(chan struct{}, 1),
+		archiveStates: map[string]bool{},
+	}
+	p.mu <- struct{}{}
+	p.srv = httptest.NewServer(http.HandlerFunc(p.handle))
+	t.Cleanup(p.srv.Close)
+	return p
+}
+
+func (p *pagesMockServer) lock()   { <-p.mu }
+func (p *pagesMockServer) unlock() { p.mu <- struct{}{} }
+
+func (p *pagesMockServer) record(method, path string, body map[string]interface{}) {
+	p.lock()
+	defer p.unlock()
+	p.calls = append(p.calls, recordedCall{method: method, path: path, body: body})
+}
+
+// callsSnapshot returns a copy of the recorded call log under lock.
+func (p *pagesMockServer) callsSnapshot() []recordedCall {
+	p.lock()
+	defer p.unlock()
+	out := make([]recordedCall, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+func (p *pagesMockServer) client() *Client {
+	return NewClient("sk_test", WithBaseURL(p.srv.URL))
+}
+
+func (p *pagesMockServer) handle(w http.ResponseWriter, r *http.Request) {
+	var body map[string]interface{}
+	if r.Method == http.MethodPatch || r.Method == http.MethodPost {
+		buf, _ := io.ReadAll(r.Body)
+		if len(buf) > 0 {
+			_ = json.Unmarshal(buf, &body)
+		}
+	}
+	p.record(r.Method, r.URL.Path, body)
+
+	if p.notFound {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"object":"error","status":404,"code":"object_not_found","message":"Could not find page"}`))
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pages/"):
+		id := strings.TrimPrefix(r.URL.Path, "/pages/")
+		archived := false
+		p.lock()
+		if v, ok := p.archiveStates[id]; ok {
+			archived = v
+		}
+		p.unlock()
+		writeJSONPage(w, id, archived, "Source title")
+
+	case r.Method == http.MethodPost && r.URL.Path == "/pages":
+		writeJSONPage(w, "newPageID", false, "Created")
+
+	case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/pages/"):
+		id := strings.TrimPrefix(r.URL.Path, "/pages/")
+		if body != nil {
+			if v, ok := body["archived"].(bool); ok {
+				p.lock()
+				p.archiveStates[id] = v
+				p.unlock()
+			}
+		}
+		writeJSONPage(w, id, p.archiveStates[id], "Updated")
+
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/children"):
+		atomic.AddInt64(&p.blocksGet, 1)
+		writeJSONBlocks(w)
+
+	case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/children"):
+		atomic.AddInt64(&p.blocksPatch, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","results":[]}`))
+
+	default:
+		http.Error(w, `{"code":"not_found"}`, http.StatusNotFound)
+	}
+}
+
+func writeJSONPage(w http.ResponseWriter, id string, archived bool, title string) {
+	page := map[string]interface{}{
+		"object":           "page",
+		"id":               id,
+		"created_time":     "2026-04-22T10:00:00.000Z",
+		"last_edited_time": "2026-04-22T10:00:00.000Z",
+		"archived":         archived,
+		"url":              "https://notion.so/" + id,
+		"parent":           map[string]interface{}{"type": "page_id", "page_id": "parentID"},
+		"properties": map[string]interface{}{
+			"title": map[string]interface{}{
+				"id":   "title",
+				"type": "title",
+				"title": []map[string]interface{}{
+					{
+						"type":       "text",
+						"plain_text": title,
+						"text":       map[string]interface{}{"content": title},
+					},
+				},
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(page)
+}
+
+func writeJSONBlocks(w http.ResponseWriter) {
+	payload := BlockList{
+		Results: []Block{
+			{
+				Object: "block", ID: "b1", Type: "paragraph",
+				Paragraph: &RichTextBlock{RichText: []RichText{{PlainText: "hello", Text: Text{Content: "hello"}}}},
+			},
+			{
+				Object: "block", ID: "b2", Type: "to_do",
+				ToDo: &ToDo{Checked: true, RichText: []RichText{{PlainText: "pack", Text: Text{Content: "pack"}}}},
+			},
+			{
+				Object: "block", ID: "b3", Type: "divider",
+				Divider: &struct{}{},
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// -------- Tests --------
+
+func TestGet_HappyPath(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+
+	page, err := pc.Get(context.Background(), "pageID")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if page.ID != "pageID" {
+		t.Errorf("page.ID=%q want pageID", page.ID)
+	}
+	if page.URL == "" {
+		t.Error("expected non-empty URL on returned page")
+	}
+}
+
+func TestGet_EmptyID(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if _, err := pc.Get(context.Background(), ""); err == nil {
+		t.Fatal("expected error on empty id, got nil")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	m := newPagesMockServer(t)
+	m.notFound = true
+	pc := NewPageClient(m.client())
+
+	_, err := pc.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected 404 error, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error=%q should mention 404", err.Error())
+	}
+}
+
+func TestCreate_Minimal(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+
+	page, err := pc.Create(context.Background(), CreatePageRequest{
+		Parent: PageParent{PageID: "parentID"},
+		Title:  "New thing",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if page.ID != "newPageID" {
+		t.Errorf("page.ID=%q want newPageID", page.ID)
+	}
+
+	calls := m.callsSnapshot()
+	if len(calls) != 1 {
+		t.Fatalf("len(calls)=%d want 1", len(calls))
+	}
+	if calls[0].method != http.MethodPost || calls[0].path != "/pages" {
+		t.Errorf("call=%s %s want POST /pages", calls[0].method, calls[0].path)
+	}
+	props, ok := calls[0].body["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected properties in body, got %v", calls[0].body)
+	}
+	if _, ok := props["title"]; !ok {
+		t.Error("expected title property in request body")
+	}
+}
+
+func TestCreate_NoParent(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	_, err := pc.Create(context.Background(), CreatePageRequest{Title: "x"})
+	if err == nil {
+		t.Fatal("expected error when parent missing")
+	}
+}
+
+func TestUpdate_TitleOnly(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+
+	page, err := pc.Update(context.Background(), "pageID", UpdatePageRequest{Title: "Renamed"})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if page.ID != "pageID" {
+		t.Errorf("page.ID=%q want pageID", page.ID)
+	}
+
+	calls := m.callsSnapshot()
+	if len(calls) != 1 {
+		t.Fatalf("len(calls)=%d want 1", len(calls))
+	}
+	if calls[0].method != http.MethodPatch || calls[0].path != "/pages/pageID" {
+		t.Errorf("call=%s %s want PATCH /pages/pageID", calls[0].method, calls[0].path)
+	}
+	if _, ok := calls[0].body["properties"]; !ok {
+		t.Error("expected title-only update to include properties")
+	}
+	if _, ok := calls[0].body["archived"]; ok {
+		t.Error("title-only update should not include archived")
+	}
+}
+
+func TestUpdate_Empty(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if _, err := pc.Update(context.Background(), "pageID", UpdatePageRequest{}); err == nil {
+		t.Fatal("expected error when no fields provided")
+	}
+}
+
+func TestUpdate_EmptyID(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if _, err := pc.Update(context.Background(), "", UpdatePageRequest{Title: "x"}); err == nil {
+		t.Fatal("expected error on empty id")
+	}
+}
+
+func TestArchive_Unarchive_RoundTrip(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	ctx := context.Background()
+
+	if err := pc.Archive(ctx, "pageID"); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	m.lock()
+	if !m.archiveStates["pageID"] {
+		t.Error("expected archived=true after Archive")
+	}
+	m.unlock()
+
+	if err := pc.Unarchive(ctx, "pageID"); err != nil {
+		t.Fatalf("Unarchive: %v", err)
+	}
+	m.lock()
+	if m.archiveStates["pageID"] {
+		t.Error("expected archived=false after Unarchive")
+	}
+	m.unlock()
+
+	calls := m.callsSnapshot()
+	if len(calls) != 2 {
+		t.Fatalf("len(calls)=%d want 2", len(calls))
+	}
+	if calls[0].body["archived"] != true {
+		t.Error("first call should set archived=true")
+	}
+	if calls[1].body["archived"] != false {
+		t.Error("second call should set archived=false")
+	}
+}
+
+func TestArchive_EmptyID(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if err := pc.Archive(context.Background(), ""); err == nil {
+		t.Fatal("expected error on empty id")
+	}
+}
+
+// TestUnarchive exists so the test-gap checker sees a direct mapping from
+// the exported PageClient.Unarchive method to a Test* function. The behavior
+// is exercised more fully by TestArchive_Unarchive_RoundTrip.
+func TestUnarchive(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if err := pc.Unarchive(context.Background(), ""); err == nil {
+		t.Fatal("expected error on empty id for Unarchive")
+	}
+	if err := pc.Unarchive(context.Background(), "pageID"); err != nil {
+		t.Fatalf("Unarchive: %v", err)
+	}
+}
+
+func TestMove_HappyPath(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+
+	if err := pc.Move(context.Background(), "pageID", "newParentID"); err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	calls := m.callsSnapshot()
+	if len(calls) != 1 {
+		t.Fatalf("len(calls)=%d want 1", len(calls))
+	}
+	if calls[0].method != http.MethodPatch {
+		t.Errorf("method=%s want PATCH", calls[0].method)
+	}
+	parent, ok := calls[0].body["parent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected parent in body, got %v", calls[0].body)
+	}
+	if parent["page_id"] != "newParentID" {
+		t.Errorf("parent.page_id=%v want newParentID", parent["page_id"])
+	}
+}
+
+func TestMove_EmptyArgs(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if err := pc.Move(context.Background(), "", "newParentID"); err == nil {
+		t.Fatal("expected error on empty page id")
+	}
+	if err := pc.Move(context.Background(), "pageID", ""); err == nil {
+		t.Fatal("expected error on empty new parent id")
+	}
+}
+
+func TestDuplicate_CallSequence(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+
+	newPage, err := pc.Duplicate(context.Background(), "srcID", "parentID")
+	if err != nil {
+		t.Fatalf("Duplicate: %v", err)
+	}
+	if newPage.ID != "newPageID" {
+		t.Errorf("newPage.ID=%q want newPageID", newPage.ID)
+	}
+
+	// Expected call sequence: GET children → GET source page → POST new page → PATCH children
+	calls := m.callsSnapshot()
+	if len(calls) < 3 {
+		t.Fatalf("expected >= 3 calls, got %d (%+v)", len(calls), calls)
+	}
+
+	var sawGetChildren, sawPostPage, sawPatchChildren bool
+	for _, c := range calls {
+		switch {
+		case c.method == http.MethodGet && strings.HasSuffix(c.path, "/children"):
+			sawGetChildren = true
+		case c.method == http.MethodPost && c.path == "/pages":
+			sawPostPage = true
+			// Confirm the new page's parent is the requested one.
+			parent, _ := c.body["parent"].(map[string]interface{})
+			if parent["page_id"] != "parentID" {
+				t.Errorf("create call parent=%v want parentID", parent)
+			}
+		case c.method == http.MethodPatch && strings.HasSuffix(c.path, "/children"):
+			sawPatchChildren = true
+			children, _ := c.body["children"].([]interface{})
+			if len(children) == 0 {
+				t.Error("patch children call sent empty children slice")
+			}
+		}
+	}
+	if !sawGetChildren || !sawPostPage || !sawPatchChildren {
+		t.Errorf("missing call; got=%+v", calls)
+	}
+}
+
+func TestDuplicate_EmptyArgs(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+	if _, err := pc.Duplicate(context.Background(), "", "parent"); err == nil {
+		t.Fatal("expected error on empty srcID")
+	}
+	if _, err := pc.Duplicate(context.Background(), "src", ""); err == nil {
+		t.Fatal("expected error on empty parentID")
+	}
+}
+
+// TestBlocksToChildren confirms rebuildBlock handles every block type the
+// duplicate pipeline emits children for, and skips the ones it doesn't.
+func TestBlocksToChildren(t *testing.T) {
+	blocks := []Block{
+		{Type: "paragraph", Paragraph: &RichTextBlock{RichText: []RichText{{PlainText: "p"}}}},
+		{Type: "heading_1", Heading1: &RichTextBlock{RichText: []RichText{{PlainText: "h1"}}}},
+		{Type: "heading_2", Heading2: &RichTextBlock{RichText: []RichText{{PlainText: "h2"}}}},
+		{Type: "heading_3", Heading3: &RichTextBlock{RichText: []RichText{{PlainText: "h3"}}}},
+		{Type: "bulleted_list_item", BulletedListItem: &RichTextBlock{RichText: []RichText{{PlainText: "b"}}}},
+		{Type: "numbered_list_item", NumberedListItem: &RichTextBlock{RichText: []RichText{{PlainText: "n"}}}},
+		{Type: "toggle", Toggle: &RichTextBlock{RichText: []RichText{{PlainText: "t"}}}},
+		{Type: "quote", Quote: &RichTextBlock{RichText: []RichText{{PlainText: "q"}}}},
+		{Type: "callout", Callout: &RichTextBlock{RichText: []RichText{{PlainText: "c"}}}},
+		{Type: "code", Code: &RichTextBlock{RichText: []RichText{{PlainText: "c"}}, Language: "go"}},
+		{Type: "to_do", ToDo: &ToDo{Checked: true, RichText: []RichText{{PlainText: "d"}}}},
+		{Type: "divider", Divider: &struct{}{}},
+		// Unsupported: should be dropped.
+		{Type: "image"},
+		// Nil inner block: should be dropped.
+		{Type: "paragraph"},
+		{Type: "to_do"},
+		{Type: "code"},
+	}
+
+	children := blocksToChildren(blocks)
+	// 12 supported types present.
+	if len(children) != 12 {
+		t.Fatalf("len(children)=%d want 12", len(children))
+	}
+	// Spot-check: code block carries language.
+	var codeBlock map[string]interface{}
+	for _, c := range children {
+		if c["type"] == "code" {
+			codeBlock = c
+			break
+		}
+	}
+	if codeBlock == nil {
+		t.Fatal("code block missing from children")
+	}
+	inner, _ := codeBlock["code"].(map[string]interface{})
+	if inner["language"] != "go" {
+		t.Errorf("code.language=%v want go", inner["language"])
+	}
+}
+
+// TestRichTextPayload covers the content fallback: when Text.Content is empty
+// the run's PlainText is used so round-tripping blocks from GET responses
+// doesn't lose text.
+func TestRichTextPayload(t *testing.T) {
+	out := richTextPayload([]RichText{
+		{PlainText: "hello"},
+		{Text: Text{Content: "world"}},
+	})
+	if len(out) != 2 {
+		t.Fatalf("len=%d want 2", len(out))
+	}
+	first, _ := out[0]["text"].(map[string]interface{})
+	if first["content"] != "hello" {
+		t.Errorf("first content=%v want hello", first["content"])
+	}
+	second, _ := out[1]["text"].(map[string]interface{})
+	if second["content"] != "world" {
+		t.Errorf("second content=%v want world", second["content"])
+	}
+}
+
+func TestExtractTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		page *Page
+		want string
+	}{
+		{name: "nil page", page: nil, want: ""},
+		{name: "no props", page: &Page{}, want: ""},
+		{
+			name: "with title",
+			page: &Page{Properties: map[string]interface{}{
+				"Name": map[string]interface{}{
+					"title": []interface{}{
+						map[string]interface{}{"plain_text": "Hello"},
+					},
+				},
+			}},
+			want: "Hello",
+		},
+		{
+			name: "unrelated property",
+			page: &Page{Properties: map[string]interface{}{
+				"Tags": map[string]interface{}{"multi_select": []interface{}{}},
+			}},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractTitle(tt.page); got != tt.want {
+				t.Errorf("extractTitle=%q want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -556,6 +556,40 @@ func TestPageClient_MissingAPIKey(t *testing.T) {
 	}
 }
 
+// TestDuplicate_SourceNotFound asserts that when the source page 404s, the
+// Duplicate call aborts BEFORE creating a destination page. The returned
+// error must wrap the underlying 404 so callers can classify it.
+func TestDuplicate_SourceNotFound(t *testing.T) {
+	m := newPagesMockServer(t)
+	m.notFound = true
+	pc := NewPageClient(m.client())
+
+	newPage, err := pc.Duplicate(context.Background(), "missingSrc", "parentID")
+	if err == nil {
+		t.Fatal("expected error when source page 404s, got nil")
+	}
+	if newPage != nil {
+		t.Errorf("expected nil page on error, got %+v", newPage)
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected error to mention 404, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "fetch source") {
+		t.Errorf("expected error to mention fetch source, got %q", err.Error())
+	}
+
+	// Critical: no POST /pages (no destination created) and no PATCH
+	// /blocks/*/children (no empty page orphaned).
+	for _, c := range m.callsSnapshot() {
+		if c.method == http.MethodPost && c.path == "/pages" {
+			t.Errorf("Duplicate must not POST /pages when source 404s (calls=%+v)", m.calls)
+		}
+		if c.method == http.MethodPatch && strings.HasSuffix(c.path, "/children") {
+			t.Errorf("Duplicate must not PATCH children when source 404s (calls=%+v)", m.calls)
+		}
+	}
+}
+
 func TestExtractTitle(t *testing.T) {
 	tests := []struct {
 		name string

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -506,6 +507,52 @@ func TestRichTextPayload(t *testing.T) {
 	second, _ := out[1]["text"].(map[string]interface{})
 	if second["content"] != "world" {
 		t.Errorf("second content=%v want world", second["content"])
+	}
+}
+
+// TestPageClient_MissingAPIKey asserts that every HTTP-calling method on
+// PageClient refuses to issue a request when the underlying Client has an
+// empty API key, and returns ErrMissingAPIKey (wrapped).
+func TestPageClient_MissingAPIKey(t *testing.T) {
+	m := newPagesMockServer(t)
+	// Construct a Client with an empty apiKey but pointed at the mock so
+	// we can also assert no HTTP call escapes the guard.
+	c := NewClient("", WithBaseURL(m.srv.URL))
+	pc := NewPageClient(c)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{name: "Get", call: func() error { _, err := pc.Get(ctx, "id"); return err }},
+		{name: "Create", call: func() error {
+			_, err := pc.Create(ctx, CreatePageRequest{Parent: PageParent{PageID: "p"}})
+			return err
+		}},
+		{name: "Update", call: func() error {
+			_, err := pc.Update(ctx, "id", UpdatePageRequest{Title: "t"})
+			return err
+		}},
+		{name: "Archive", call: func() error { return pc.Archive(ctx, "id") }},
+		{name: "Unarchive", call: func() error { return pc.Unarchive(ctx, "id") }},
+		{name: "Move", call: func() error { return pc.Move(ctx, "id", "newParent") }},
+		{name: "Duplicate", call: func() error { _, err := pc.Duplicate(ctx, "src", "parent"); return err }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, ErrMissingAPIKey) {
+				t.Errorf("expected errors.Is ErrMissingAPIKey, got %v", err)
+			}
+		})
+	}
+	// No HTTP traffic should have reached the mock.
+	if calls := m.callsSnapshot(); len(calls) != 0 {
+		t.Errorf("expected zero HTTP calls, got %d: %+v", len(calls), calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #5. Ships the full Pages CRUD surface from the MCP-parity issue:

- `notioncli pages get <id>` → `GET /v1/pages/{id}`
- `notioncli pages create --parent <id> [--title ...]` → `POST /v1/pages`
- `notioncli pages update <id> [--title ...] [--property k=v ...]` → `PATCH /v1/pages/{id}`
- `notioncli pages archive <id>` / `pages unarchive <id>` → `PATCH` with `archived`
- `notioncli pages move <id> --parent <new-parent>` → `PATCH` with parent update
- `notioncli pages duplicate <id> --parent <parent>` → emulated (see caveat)

## Scope & design notes

- Typed surface in `utils/pages.go`: `Page`, `PageParent`, `CreatePageRequest`, `UpdatePageRequest` plus `PageClient.Get / Create / Update / Archive / Unarchive / Move / Duplicate`. Properties are a `map[string]interface{}` for v1 so the loosely-shaped Notion property surface round-trips without loss; a typed property layer can land in a follow-up.
- `cmd/pages.go` registers the parent `pagesCmd` in its own `init()` and mirrors `cmd/blocks.go` conventions (package-level flag vars, positional args for IDs, flags for modifiers).
- No new dependencies. Notion API version untouched (still `2022-06-28`).
- `--json` is not added here — the roadmap has a global `--json` rollout and the spec for this feature wants consistent output paths. Pages subcommands currently pretty-print JSON for `get`/`create`/`update`/`duplicate` and a single-line status for `archive`/`unarchive`/`move`, matching the existing `blocks` output style.

## Duplicate caveat

Notion has no native duplicate endpoint. The command emulates it in three steps:

1. `GET /blocks/{srcID}/children` (via `BlockClient.GetAllBlocks`, paginated)
2. `POST /v1/pages` under the caller's `--parent` with the source's title (or `Copy` if not discoverable)
3. `PATCH /blocks/{newID}/children` to append the source's blocks

Limitations are documented in the subcommand's `Long` help:

- Only top-level blocks are copied — `has_children=true` subtrees are not recursed.
- Child databases are not re-created.
- Property values from database-parented sources are not carried over (use `Get` + `Create` with explicit `Properties` if you need parity).

## Test evidence

`make ci` is green end-to-end on this branch:

- `gofmt -l .` → empty
- `go vet ./...` → clean
- `go test -race ./...` → pass
- Coverage: **total 82.2%** (gate 70%); `utils/` 78.8% → 81.0%; `cmd/` 68.9% → 70.0%
- Gap gate: `✓ Every exported function has a matching Test* (skips honored).`

Coverage of new exported functions:

```
utils.Get         83.3%
utils.Create      77.3%
utils.Update      76.9%
utils.Archive    100.0%
utils.Unarchive  100.0%
utils.Move        83.3%
utils.Duplicate   78.6%
```

Test surface includes: get happy path / empty-id / 404, create minimal / no-parent, update title-only / empty-request / empty-id, archive+unarchive round-trip, move happy path / required-args, duplicate call-sequence assertion (GET children → POST /pages → PATCH children), `blocksToChildren` across every supported block type, `extractTitle` property walking, and cmd-layer flag registration + dispatch wiring for every subcommand.

## Commits

1. `feat: pages CRUD (get, create, update, archive, move, duplicate)` — implementation
2. `test: cover pages CRUD surface with httptest mocks` — tests