### PR TITLE
feat: search command (closes #4)

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,239 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// search command flags. These are package-level vars so cobra can bind them
+// during init(); resetSearchFlags() is called at the top of Run so repeated
+// invocations within a single process (tests, REPLs) don't inherit stale
+// values.
+var (
+	searchType     string
+	searchLimit    int
+	searchPageSize int
+	searchJSON     bool
+)
+
+// searchCmd implements `notioncli search` — a workspace-wide query against
+// the Notion search API. See issue #4.
+var searchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Search pages and databases across the workspace",
+	Long: `Search matching pages and databases accessible to the integration.
+
+Examples:
+  notioncli search "roadmap"
+  notioncli search "roadmap" --type databases
+  notioncli search "" --limit 50
+  notioncli search "roadmap" --json > results.ndjson
+
+By default every matching result is fetched (pagination is followed until
+exhausted). Pass --limit N to cap the total number returned. With --json,
+one JSON object per matching result is emitted to stdout, newline-delimited,
+passing through the raw Notion response object unchanged.`,
+	Args:          cobra.MaximumNArgs(1),
+	RunE:          runSearch,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+// runSearch is broken out so tests can call it with a preconfigured
+// *cobra.Command and bypass the Execute() output shim. RunE returns an error
+// for the same reason — tests assert on it rather than on os.Exit.
+func runSearch(cmd *cobra.Command, args []string) error {
+	query := ""
+	if len(args) == 1 {
+		query = args[0]
+	}
+
+	filter, err := buildSearchFilter(searchType)
+	if err != nil {
+		emitSearchError(cmd, err)
+		return err
+	}
+
+	notionAPIKey, _ := utils.SetAPIConfig()
+	client := utils.NewSearchClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
+
+	req := utils.SearchRequest{
+		Query:    query,
+		Filter:   filter,
+		PageSize: searchPageSize,
+	}
+
+	results, err := client.SearchAll(context.Background(), req, searchLimit)
+	if err != nil {
+		emitSearchError(cmd, fmt.Errorf("search: %w", err))
+		return err
+	}
+
+	if searchJSON {
+		return emitSearchJSON(cmd, results)
+	}
+	return emitSearchTable(cmd, results)
+}
+
+// buildSearchFilter translates the user-facing --type value into the Notion
+// API filter object. Empty string means "no filter". Invalid values return
+// an error pointing at the allowed set.
+func buildSearchFilter(typeFlag string) (*utils.SearchFilter, error) {
+	switch typeFlag {
+	case "":
+		return nil, nil
+	case "page", "pages":
+		return &utils.SearchFilter{Property: "object", Value: "page"}, nil
+	case "database", "databases":
+		return &utils.SearchFilter{Property: "object", Value: "database"}, nil
+	}
+	return nil, fmt.Errorf("invalid --type %q (want pages|databases)", typeFlag)
+}
+
+// emitSearchJSON writes one result per line to stdout as the Notion API
+// returned it. This is the first --json consumer in the CLI, so the shape
+// is deliberately minimal: raw pass-through, no envelope.
+func emitSearchJSON(cmd *cobra.Command, results []utils.SearchResult) error {
+	out := cmd.OutOrStdout()
+	for _, r := range results {
+		raw := r.Raw
+		if len(raw) == 0 {
+			// Defensive: if Raw didn't make it through (e.g. synthesized in a
+			// test), re-marshal from the typed fields so the stream is never
+			// silently empty.
+			buf, err := json.Marshal(r)
+			if err != nil {
+				return fmt.Errorf("marshal result: %w", err)
+			}
+			raw = buf
+		}
+		if _, err := fmt.Fprintln(out, string(raw)); err != nil {
+			return fmt.Errorf("write result: %w", err)
+		}
+	}
+	return nil
+}
+
+// emitSearchTable renders the human-readable table: icon, title, type, url,
+// last-edited. Empty results print a friendly yellow notice and return nil
+// (this is not an error — the API responded successfully).
+func emitSearchTable(cmd *cobra.Command, results []utils.SearchResult) error {
+	out := cmd.OutOrStdout()
+	if len(results) == 0 {
+		color.Yellow("No results.")
+		return nil
+	}
+	fmt.Fprintln(out)
+	for _, r := range results {
+		icon := r.Icon.Display()
+		if icon == "" {
+			icon = "-"
+		}
+		title := extractSearchTitle(r)
+		if title == "" {
+			title = "(untitled)"
+		}
+		if len(title) > 60 {
+			title = title[:57] + "..."
+		}
+		edited := formatSearchTime(r.LastEditedTime)
+		fmt.Fprintf(out, "  %s  %-60s  %-8s  %s  %s\n", icon, title, r.Object, r.URL, edited)
+	}
+	fmt.Fprintln(out)
+	color.Cyan("  %d result(s)", len(results))
+	return nil
+}
+
+// emitSearchError writes a single-line JSON error object to stderr when
+// --json is set (keeps the stdout stream valid NDJSON for piping), or a
+// red human-readable message otherwise. Does not call os.Exit; the RunE
+// return value drives the final exit code via cobra.
+func emitSearchError(cmd *cobra.Command, err error) {
+	if searchJSON {
+		enc := json.NewEncoder(os.Stderr)
+		_ = enc.Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	color.Red("Error: %v", err)
+	_ = cmd // reserved for future SetErr wiring; avoids unused-param lint
+}
+
+// extractSearchTitle digs into the raw Notion payload to find the object's
+// display title. Pages put it at properties.title.title[].plain_text;
+// databases put it at title[].plain_text. Falls back to "" on any miss.
+func extractSearchTitle(r utils.SearchResult) string {
+	// Database shape: top-level `title` array of rich text.
+	if len(r.Title) > 0 {
+		var rt []struct {
+			PlainText string `json:"plain_text"`
+		}
+		if err := json.Unmarshal(r.Title, &rt); err == nil && len(rt) > 0 {
+			return rt[0].PlainText
+		}
+	}
+	// Page shape: properties.title.title[].plain_text. The key is typically
+	// "title" but Notion allows the primary-title property to be renamed,
+	// so we scan every property looking for a "title" type.
+	if len(r.Properties) > 0 {
+		var props map[string]json.RawMessage
+		if err := json.Unmarshal(r.Properties, &props); err == nil {
+			for _, raw := range props {
+				var p struct {
+					Type  string `json:"type"`
+					Title []struct {
+						PlainText string `json:"plain_text"`
+					} `json:"title"`
+				}
+				if err := json.Unmarshal(raw, &p); err != nil {
+					continue
+				}
+				if p.Type == "title" && len(p.Title) > 0 {
+					return p.Title[0].PlainText
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// formatSearchTime renders a Notion ISO-8601 timestamp as YYYY-MM-DD HH:MM
+// in UTC. Unparseable values pass through as-is so we never hide API data.
+func formatSearchTime(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	return t.UTC().Format("2006-01-02 15:04")
+}
+
+// resetSearchFlags clears any persistent flag state from a previous run.
+// Exposed for tests.
+func resetSearchFlags() {
+	searchType = ""
+	searchLimit = 0
+	searchPageSize = 0
+	searchJSON = false
+}
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+	searchCmd.Flags().StringVar(&searchType, "type", "", "Restrict results to pages|databases")
+	searchCmd.Flags().IntVar(&searchLimit, "limit", 0, "Maximum total results to return (0 = all)")
+	searchCmd.Flags().IntVar(&searchPageSize, "page-size", 0, "Notion API page size (1-100, 0 = server default)")
+	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "Emit raw results as NDJSON to stdout")
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"notioncli/utils"
@@ -66,6 +65,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := validateSearchPageSize(searchPageSize); err != nil {
+		emitSearchError(cmd, err)
+		return err
+	}
+
 	notionAPIKey, _ := utils.SetAPIConfig()
 	client := utils.NewSearchClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
 
@@ -100,6 +104,19 @@ func buildSearchFilter(typeFlag string) (*utils.SearchFilter, error) {
 		return &utils.SearchFilter{Property: "object", Value: "database"}, nil
 	}
 	return nil, fmt.Errorf("invalid --type %q (want pages|databases)", typeFlag)
+}
+
+// validateSearchPageSize enforces the Notion API bounds client-side so we
+// don't spend a round-trip on a value the server will reject. 0 means
+// "use the server default" and is allowed. Valid range otherwise is 1-100.
+func validateSearchPageSize(pageSize int) error {
+	if pageSize == 0 {
+		return nil
+	}
+	if pageSize < 1 || pageSize > 100 {
+		return fmt.Errorf("invalid --page-size %d (want 1-100, or 0 for server default)", pageSize)
+	}
+	return nil
 }
 
 // emitSearchJSON writes one result per line to stdout as the Notion API
@@ -145,9 +162,7 @@ func emitSearchTable(cmd *cobra.Command, results []utils.SearchResult) error {
 		if title == "" {
 			title = "(untitled)"
 		}
-		if len(title) > 60 {
-			title = title[:57] + "..."
-		}
+		title = truncateRunes(title, 60)
 		edited := formatSearchTime(r.LastEditedTime)
 		fmt.Fprintf(out, "  %s  %-60s  %-8s  %s  %s\n", icon, title, r.Object, r.URL, edited)
 	}
@@ -158,16 +173,17 @@ func emitSearchTable(cmd *cobra.Command, results []utils.SearchResult) error {
 
 // emitSearchError writes a single-line JSON error object to stderr when
 // --json is set (keeps the stdout stream valid NDJSON for piping), or a
-// red human-readable message otherwise. Does not call os.Exit; the RunE
-// return value drives the final exit code via cobra.
+// red human-readable message otherwise. Output is routed through
+// cmd.ErrOrStderr() so tests can capture the stream. Does not call
+// os.Exit; the RunE return value drives the final exit code via cobra.
 func emitSearchError(cmd *cobra.Command, err error) {
+	errOut := cmd.ErrOrStderr()
 	if searchJSON {
-		enc := json.NewEncoder(os.Stderr)
+		enc := json.NewEncoder(errOut)
 		_ = enc.Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	color.Red("Error: %v", err)
-	_ = cmd // reserved for future SetErr wiring; avoids unused-param lint
+	fmt.Fprintln(errOut, color.RedString("Error: %v", err))
 }
 
 // extractSearchTitle digs into the raw Notion payload to find the object's
@@ -206,6 +222,20 @@ func extractSearchTitle(r utils.SearchResult) string {
 		}
 	}
 	return ""
+}
+
+// truncateRunes shortens s to at most max *runes*, appending "..." when
+// truncation occurs. Rune-safe so multi-byte characters (emoji, CJK) are
+// never cut mid-codepoint. max must be >= 4 to leave room for the ellipsis.
+func truncateRunes(s string, max int) string {
+	if max < 4 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-3]) + "..."
 }
 
 // formatSearchTime renders a Notion ISO-8601 timestamp as YYYY-MM-DD HH:MM

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,0 +1,478 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// searchHandlerStats captures what the mock server saw on POST /search so
+// dispatch tests can assert on the outgoing request.
+type searchHandlerStats struct {
+	calls  int64
+	query  atomic.Value // last request query string
+	cursor atomic.Value // last request start_cursor
+	filter atomic.Value // last request filter.value
+}
+
+// overlaySearchHandler wraps cmdMockServer's handler with POST /search
+// support. The test-supplied resp function gets the decoded request body
+// and returns the JSON object to write.
+func overlaySearchHandler(t *testing.T, stats *searchHandlerStats, resp func(req map[string]interface{}) map[string]interface{}) {
+	t.Helper()
+	srv := withCmdEnv(t)
+	orig := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/search" {
+			atomic.AddInt64(&stats.calls, 1)
+			body, _ := io.ReadAll(r.Body)
+			var in map[string]interface{}
+			_ = json.Unmarshal(body, &in)
+			if q, ok := in["query"].(string); ok {
+				stats.query.Store(q)
+			}
+			if c, ok := in["start_cursor"].(string); ok {
+				stats.cursor.Store(c)
+			}
+			if f, ok := in["filter"].(map[string]interface{}); ok {
+				if v, ok := f["value"].(string); ok {
+					stats.filter.Store(v)
+				}
+			}
+			out := resp(in)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+			return
+		}
+		orig.ServeHTTP(w, r)
+	})
+}
+
+// seedResult builds a utils.SearchResult from a raw JSON string via the
+// real UnmarshalJSON so Raw is populated exactly the way the production
+// code path would see it.
+func seedResult(t *testing.T, raw string) utils.SearchResult {
+	t.Helper()
+	var r utils.SearchResult
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		t.Fatalf("seedResult: %v", err)
+	}
+	return r
+}
+
+// TestSearchCmdRegistered verifies `search` is a top-level command.
+func TestSearchCmdRegistered(t *testing.T) {
+	c := findTopLevelCmd(t, "search")
+	if c.Use == "" {
+		t.Fatal("search command has empty Use")
+	}
+}
+
+// TestSearchCmdFlags asserts every documented flag is declared with the
+// right default and type. This is a pure metadata check — no network.
+func TestSearchCmdFlags(t *testing.T) {
+	c := findTopLevelCmd(t, "search")
+
+	tests := []struct {
+		flag     string
+		typeName string
+		def      string
+	}{
+		{"type", "string", ""},
+		{"limit", "int", "0"},
+		{"page-size", "int", "0"},
+		{"json", "bool", "false"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			f := c.Flag(tt.flag)
+			if f == nil {
+				t.Fatalf("--%s flag not registered", tt.flag)
+			}
+			if f.Value.Type() != tt.typeName {
+				t.Errorf("--%s type = %q want %q", tt.flag, f.Value.Type(), tt.typeName)
+			}
+			if f.DefValue != tt.def {
+				t.Errorf("--%s default = %q want %q", tt.flag, f.DefValue, tt.def)
+			}
+		})
+	}
+}
+
+// TestSearchCmdArgs asserts the command accepts 0 or 1 positional args.
+func TestSearchCmdArgs(t *testing.T) {
+	c := findTopLevelCmd(t, "search")
+	if err := c.Args(c, []string{}); err != nil {
+		t.Errorf("zero args should be allowed: %v", err)
+	}
+	if err := c.Args(c, []string{"roadmap"}); err != nil {
+		t.Errorf("one arg should be allowed: %v", err)
+	}
+	if err := c.Args(c, []string{"a", "b"}); err == nil {
+		t.Error("two args should fail")
+	}
+}
+
+// TestBuildSearchFilter covers the --type flag translation table.
+func TestBuildSearchFilter(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantVal string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"pages", "page", false},
+		{"page", "page", false},
+		{"databases", "database", false},
+		{"database", "database", false},
+		{"users", "", true},
+		{"foo", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := buildSearchFilter(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.wantVal == "" {
+				if got != nil {
+					t.Errorf("got filter=%+v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.Value != tt.wantVal {
+				t.Errorf("got=%+v want Value=%q", got, tt.wantVal)
+			}
+		})
+	}
+}
+
+// TestSearchCmdDispatch runs `notioncli search roadmap` end-to-end through
+// rootCmd, confirms the POST /search request was made, and checks that the
+// table output names the result.
+func TestSearchCmdDispatch(t *testing.T) {
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"object":   "list",
+			"has_more": false,
+			"results": []map[string]interface{}{
+				{
+					"object":           "page",
+					"id":               "pg-1",
+					"url":              "https://notion.so/pg-1",
+					"last_edited_time": "2026-04-22T10:00:00.000Z",
+					"icon":             map[string]interface{}{"type": "emoji", "emoji": "📄"},
+					"properties": map[string]interface{}{
+						"Name": map[string]interface{}{
+							"type": "title",
+							"title": []map[string]interface{}{
+								{"plain_text": "Roadmap Q2"},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	resetSearchFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"search", "roadmap"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(search): %v", err)
+	}
+
+	if atomic.LoadInt64(&stats.calls) == 0 {
+		t.Fatal("search did not POST /search")
+	}
+	if q, _ := stats.query.Load().(string); q != "roadmap" {
+		t.Errorf("query sent to API = %q, want %q", q, "roadmap")
+	}
+	if !strings.Contains(out.String(), "Roadmap Q2") {
+		t.Errorf("output did not include title: %q", out.String())
+	}
+}
+
+// TestSearchCmdTypeFilter verifies --type databases translates to the
+// right API filter payload.
+func TestSearchCmdTypeFilter(t *testing.T) {
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"object":   "list",
+			"has_more": false,
+			"results":  []map[string]interface{}{},
+		}
+	})
+
+	resetSearchFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"search", "x", "--type", "databases"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(search --type databases): %v", err)
+	}
+
+	if got, _ := stats.filter.Load().(string); got != "database" {
+		t.Errorf("filter sent = %q, want %q", got, "database")
+	}
+}
+
+// TestSearchCmdJSONOutput verifies --json emits one NDJSON line per result.
+func TestSearchCmdJSONOutput(t *testing.T) {
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"object":   "list",
+			"has_more": false,
+			"results": []map[string]interface{}{
+				{"object": "page", "id": "pg-a", "url": "u1", "last_edited_time": "2026-04-22T10:00:00.000Z"},
+				{"object": "database", "id": "db-b", "url": "u2", "last_edited_time": "2026-04-22T11:00:00.000Z"},
+			},
+		}
+	})
+
+	resetSearchFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"search", "x", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(search --json): %v", err)
+	}
+
+	var jsonLines []string
+	for _, l := range strings.Split(strings.TrimRight(out.String(), "\n"), "\n") {
+		l = strings.TrimSpace(l)
+		if strings.HasPrefix(l, "{") {
+			jsonLines = append(jsonLines, l)
+		}
+	}
+	if len(jsonLines) != 2 {
+		t.Fatalf("want 2 NDJSON lines, got %d: %q", len(jsonLines), out.String())
+	}
+	for i, line := range jsonLines {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Errorf("line %d not valid JSON: %v (%q)", i, err, line)
+		}
+	}
+}
+
+// TestSearchCmdInvalidType verifies that --type foo surfaces an error and
+// does NOT issue a search request.
+func TestSearchCmdInvalidType(t *testing.T) {
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{"object": "list", "has_more": false, "results": []map[string]interface{}{}}
+	})
+
+	resetSearchFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"search", "x", "--type", "bogus"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error on invalid --type, got nil")
+	}
+	if atomic.LoadInt64(&stats.calls) != 0 {
+		t.Errorf("search request should not be issued on bad --type; got %d calls", stats.calls)
+	}
+}
+
+// TestExtractSearchTitle covers database + page + fallback shapes.
+func TestExtractSearchTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "database title at top level",
+			raw:  `{"object":"database","id":"db","title":[{"plain_text":"Tracker"}]}`,
+			want: "Tracker",
+		},
+		{
+			name: "page title via properties",
+			raw:  `{"object":"page","id":"pg","properties":{"Name":{"type":"title","title":[{"plain_text":"Hello"}]}}}`,
+			want: "Hello",
+		},
+		{
+			name: "page title via renamed property",
+			raw:  `{"object":"page","id":"pg","properties":{"Subject":{"type":"title","title":[{"plain_text":"Renamed"}]}}}`,
+			want: "Renamed",
+		},
+		{
+			name: "no title fields",
+			raw:  `{"object":"page","id":"pg"}`,
+			want: "",
+		},
+		{
+			name: "properties malformed",
+			raw:  `{"object":"page","id":"pg","properties":{"Name":"oops"}}`,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := seedResult(t, tt.raw)
+			if got := extractSearchTitle(r); got != tt.want {
+				t.Errorf("extractSearchTitle=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatSearchTime covers valid, invalid, and empty cases.
+func TestFormatSearchTime(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"2026-04-22T10:30:00.000Z", "2026-04-22 10:30"},
+		{"not-a-time", "not-a-time"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := formatSearchTime(tt.in); got != tt.want {
+				t.Errorf("formatSearchTime(%q)=%q want=%q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEmitSearchTable exercises the table output helper directly.
+func TestEmitSearchTable(t *testing.T) {
+	results := []utils.SearchResult{
+		seedResult(t, `{"object":"page","id":"pg","url":"https://notion.so/pg","last_edited_time":"2026-04-22T10:30:00.000Z","icon":{"type":"emoji","emoji":"📄"},"properties":{"Name":{"type":"title","title":[{"plain_text":"Title"}]}}}`),
+		seedResult(t, `{"object":"database","id":"db","url":"https://notion.so/db","last_edited_time":"2026-04-22T10:30:00.000Z","title":[{"plain_text":"`+strings.Repeat("VeryLong", 20)+`"}]}`),
+		// No icon, no title — exercises the fallbacks.
+		seedResult(t, `{"object":"page","id":"plain","url":"https://notion.so/plain","last_edited_time":"2026-04-22T10:30:00.000Z"}`),
+	}
+	c := &cobra.Command{}
+	var out bytes.Buffer
+	c.SetOut(&out)
+	if err := emitSearchTable(c, results); err != nil {
+		t.Fatalf("emitSearchTable: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "Title") {
+		t.Errorf("table output missing title: %q", s)
+	}
+	if !strings.Contains(s, "(untitled)") {
+		t.Errorf("table output missing (untitled) fallback: %q", s)
+	}
+	if !strings.Contains(s, "...") {
+		t.Errorf("table output did not truncate long title: %q", s)
+	}
+
+	// Empty results hits the early-return path.
+	out.Reset()
+	if err := emitSearchTable(c, nil); err != nil {
+		t.Fatalf("emitSearchTable empty: %v", err)
+	}
+}
+
+// TestEmitSearchJSON directly exercises the NDJSON writer.
+func TestEmitSearchJSON(t *testing.T) {
+	results := []utils.SearchResult{
+		seedResult(t, `{"object":"page","id":"pg-1","url":"u","last_edited_time":"2026-04-22T10:00:00.000Z"}`),
+		seedResult(t, `{"object":"database","id":"db-1","url":"u","last_edited_time":"2026-04-22T10:00:00.000Z"}`),
+	}
+	c := &cobra.Command{}
+	var out bytes.Buffer
+	c.SetOut(&out)
+	if err := emitSearchJSON(c, results); err != nil {
+		t.Fatalf("emitSearchJSON: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %q", len(lines), out.String())
+	}
+	for i, l := range lines {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(l), &obj); err != nil {
+			t.Errorf("line %d not valid JSON: %v", i, err)
+		}
+	}
+
+	// Zero-Raw result exercises the re-marshal fallback.
+	out.Reset()
+	synth := utils.SearchResult{ID: "synth", Object: "page", URL: "u"}
+	if err := emitSearchJSON(c, []utils.SearchResult{synth}); err != nil {
+		t.Fatalf("emitSearchJSON synth: %v", err)
+	}
+	if !strings.Contains(out.String(), `"id":"synth"`) {
+		t.Errorf("re-marshal fallback did not include synthesized id: %q", out.String())
+	}
+}
+
+// TestEmitSearchError verifies both the human and JSON branches run without
+// panicking. We can't easily capture stderr without rewiring, but this at
+// least keeps the code path under coverage.
+func TestEmitSearchError(t *testing.T) {
+	c := &cobra.Command{}
+	var out bytes.Buffer
+	c.SetOut(&out)
+	searchJSON = false
+	emitSearchError(c, errorString("human"))
+	searchJSON = true
+	emitSearchError(c, errorString("json"))
+	searchJSON = false
+}
+
+func TestResetSearchFlags(t *testing.T) {
+	searchType = "pages"
+	searchLimit = 42
+	searchPageSize = 17
+	searchJSON = true
+	resetSearchFlags()
+	if searchType != "" || searchLimit != 0 || searchPageSize != 0 || searchJSON {
+		t.Errorf("flags not reset: type=%q limit=%d pageSize=%d json=%v",
+			searchType, searchLimit, searchPageSize, searchJSON)
+	}
+}
+
+func TestRunSearch(t *testing.T) {
+	// Covered end-to-end by TestSearchCmdDispatch; this test ensures a
+	// direct RunE invocation hits the happy path with zero args.
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{"object": "list", "has_more": false, "results": []map[string]interface{}{}}
+	})
+	resetSearchFlags()
+	c := &cobra.Command{}
+	var out bytes.Buffer
+	c.SetOut(&out)
+	if err := runSearch(c, nil); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	if atomic.LoadInt64(&stats.calls) != 1 {
+		t.Errorf("want exactly 1 search call, got %d", stats.calls)
+	}
+}
+
+// errorString is a tiny error that avoids pulling in fmt just for a literal.
+type errorString string
+
+func (e errorString) Error() string { return string(e) }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -427,18 +427,42 @@ func TestEmitSearchJSON(t *testing.T) {
 	}
 }
 
-// TestEmitSearchError verifies both the human and JSON branches run without
-// panicking. We can't easily capture stderr without rewiring, but this at
-// least keeps the code path under coverage.
+// TestEmitSearchError verifies both the human and JSON branches write to
+// cmd.ErrOrStderr(). The JSON branch must emit a parseable single-line
+// error object so stdout stays valid NDJSON.
 func TestEmitSearchError(t *testing.T) {
+	// Restore package-level flag even if the test aborts mid-run.
+	prev := searchJSON
+	t.Cleanup(func() { searchJSON = prev })
+
 	c := &cobra.Command{}
-	var out bytes.Buffer
-	c.SetOut(&out)
+	var stdout, stderr bytes.Buffer
+	c.SetOut(&stdout)
+	c.SetErr(&stderr)
+
 	searchJSON = false
 	emitSearchError(c, errorString("human"))
+	if !strings.Contains(stderr.String(), "human") {
+		t.Errorf("human branch did not write to stderr: %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("human branch wrote to stdout: %q", stdout.String())
+	}
+
+	stderr.Reset()
+	stdout.Reset()
 	searchJSON = true
-	emitSearchError(c, errorString("json"))
-	searchJSON = false
+	emitSearchError(c, errorString("boom"))
+	if stdout.Len() != 0 {
+		t.Errorf("json branch wrote to stdout: %q", stdout.String())
+	}
+	var obj map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &obj); err != nil {
+		t.Fatalf("json branch stderr not a valid JSON object: %v (%q)", err, stderr.String())
+	}
+	if obj["error"] != "boom" {
+		t.Errorf("json error payload = %q, want %q", obj["error"], "boom")
+	}
 }
 
 func TestResetSearchFlags(t *testing.T) {
@@ -469,6 +493,78 @@ func TestRunSearch(t *testing.T) {
 	}
 	if atomic.LoadInt64(&stats.calls) != 1 {
 		t.Errorf("want exactly 1 search call, got %d", stats.calls)
+	}
+}
+
+// TestTruncateRunes asserts the rune-safe truncator preserves multi-byte
+// characters and appends an ellipsis only when it actually cuts.
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"shorter than max", "abc", 10, "abc"},
+		{"exactly max ascii", "abcdefghij", 10, "abcdefghij"},
+		{"truncate ascii", "abcdefghijk", 10, "abcdefg..."},
+		{"truncate emoji mid-string preserves runes", "hello " + strings.Repeat("🙂", 20), 10, "hello 🙂..."},
+		{"truncate CJK preserves runes", strings.Repeat("日本語", 20), 10, "日本語日本語日..."},
+		{"max below 4 passes through", "abcdefghij", 3, "abcdefghij"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateRunes(tt.in, tt.max)
+			if got != tt.want {
+				t.Errorf("truncateRunes(%q, %d)=%q want=%q", tt.in, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateSearchPageSize covers the client-side 1-100 bounds check.
+func TestValidateSearchPageSize(t *testing.T) {
+	tests := []struct {
+		in      int
+		wantErr bool
+	}{
+		{0, false},
+		{1, false},
+		{50, false},
+		{100, false},
+		{-1, true},
+		{101, true},
+		{99999, true},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			err := validateSearchPageSize(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSearchPageSize(%d) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestSearchCmdInvalidPageSize verifies the client-side bounds check rejects
+// out-of-range --page-size values before issuing any HTTP request.
+func TestSearchCmdInvalidPageSize(t *testing.T) {
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{"object": "list", "has_more": false, "results": []map[string]interface{}{}}
+	})
+
+	resetSearchFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"search", "x", "--page-size", "500"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error on --page-size 500, got nil")
+	}
+	if atomic.LoadInt64(&stats.calls) != 0 {
+		t.Errorf("search should not be issued on bad --page-size; got %d calls", stats.calls)
 	}
 }
 

--- a/utils/search.go
+++ b/utils/search.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -55,11 +56,20 @@ type SearchResult struct {
 	Parent         json.RawMessage `json:"parent,omitempty"`
 	Properties     json.RawMessage `json:"properties,omitempty"`
 	Title          json.RawMessage `json:"title,omitempty"`
-	Raw            json.RawMessage `json:"-"`
+	// Raw is the untouched JSON payload for this result. It exists so the
+	// --json output path can pass the full Notion object through without
+	// re-marshalling (the search endpoint is heterogeneous — pages and
+	// databases in one list — and the typed fields above intentionally
+	// model only what the table view needs). Apply this Raw pass-through
+	// pattern selectively: it's the right call for heterogeneous endpoints
+	// (search, page reads) but overkill for stable-typed responses, where
+	// re-marshalling from typed fields is lossless and simpler.
+	Raw json.RawMessage `json:"-"`
 }
 
 // UnmarshalJSON preserves the raw payload alongside the typed fields so the
-// --json flag can pass through the full Notion response unchanged.
+// --json flag can pass through the full Notion response unchanged. See the
+// Raw field's godoc for guidance on when to adopt this pattern.
 func (r *SearchResult) UnmarshalJSON(data []byte) error {
 	type alias SearchResult
 	var a alias
@@ -142,16 +152,18 @@ func (s *SearchClient) Search(ctx context.Context, req SearchRequest) (*SearchRe
 // SearchAll walks pagination until the server reports HasMore=false or the
 // supplied limit is reached. A non-positive limit means "return everything".
 // When limit is positive, the returned slice is truncated to exactly limit
-// entries (or fewer if the server ran out first).
+// entries (or fewer if the server ran out first). Mid-pagination errors are
+// wrapped with the 1-based page number so callers can see how far the walk
+// got before failing.
 func (s *SearchClient) SearchAll(ctx context.Context, req SearchRequest, limit int) ([]SearchResult, error) {
 	var all []SearchResult
 	cursor := req.StartCursor
-	for {
+	for pageNum := 1; ; pageNum++ {
 		page := req
 		page.StartCursor = cursor
 		resp, err := s.Search(ctx, page)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("search page %d: %w", pageNum, err)
 		}
 		all = append(all, resp.Results...)
 		if limit > 0 && len(all) >= limit {

--- a/utils/search.go
+++ b/utils/search.go
@@ -4,11 +4,17 @@
 
 package utils
 
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
 // SearchClient is the typed resource client for the Notion search API.
 //
-// TODO(#8): flesh out with Query method, filter + sort options.
-// Today this is a deliberate stub so the shape of the refactor is visible
-// without expanding the scope of issue #1.
+// The Notion search endpoint (POST /v1/search) returns pages and databases
+// the integration has access to, optionally filtered by object type. Results
+// are paginated via the standard has_more / next_cursor envelope.
 type SearchClient struct {
 	c *Client
 }
@@ -16,4 +22,144 @@ type SearchClient struct {
 // NewSearchClient wraps a *Client with search-resource methods.
 func NewSearchClient(c *Client) *SearchClient {
 	return &SearchClient{c: c}
+}
+
+// SearchFilter restricts results to a single object type ("page" or
+// "database"). The Notion API expects {"property":"object","value":"page"}.
+type SearchFilter struct {
+	Property string `json:"property"`
+	Value    string `json:"value"`
+}
+
+// SearchRequest is the body sent to POST /v1/search. Fields are pointer- or
+// zero-value-elidable so we only send what callers specified.
+type SearchRequest struct {
+	Query       string        `json:"query,omitempty"`
+	Filter      *SearchFilter `json:"filter,omitempty"`
+	PageSize    int           `json:"page_size,omitempty"`
+	StartCursor string        `json:"start_cursor,omitempty"`
+}
+
+// SearchResult is a single entry in the search response. The Notion API
+// returns a heterogeneous result shape (page or database with nested
+// properties, icon, url, etc.) so we preserve the raw payload as
+// json.RawMessage and surface only the fields the CLI needs for its table
+// view. Callers that want the full object can re-decode Raw themselves.
+type SearchResult struct {
+	Object         string          `json:"object"`
+	ID             string          `json:"id"`
+	URL            string          `json:"url"`
+	CreatedTime    string          `json:"created_time"`
+	LastEditedTime string          `json:"last_edited_time"`
+	Icon           *Icon           `json:"icon,omitempty"`
+	Parent         json.RawMessage `json:"parent,omitempty"`
+	Properties     json.RawMessage `json:"properties,omitempty"`
+	Title          json.RawMessage `json:"title,omitempty"`
+	Raw            json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON preserves the raw payload alongside the typed fields so the
+// --json flag can pass through the full Notion response unchanged.
+func (r *SearchResult) UnmarshalJSON(data []byte) error {
+	type alias SearchResult
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*r = SearchResult(a)
+	r.Raw = append(r.Raw[:0], data...)
+	return nil
+}
+
+// Icon represents a Notion icon, which can be emoji, external URL, or a
+// hosted file. Only the type-specific field will be populated.
+type Icon struct {
+	Type     string        `json:"type"`
+	Emoji    string        `json:"emoji,omitempty"`
+	External *IconExternal `json:"external,omitempty"`
+	File     *IconFile     `json:"file,omitempty"`
+}
+
+// Display returns a compact representation of the icon suitable for table
+// output. Empty string if no icon is set.
+func (i *Icon) Display() string {
+	if i == nil {
+		return ""
+	}
+	switch i.Type {
+	case "emoji":
+		return i.Emoji
+	case "external":
+		if i.External != nil {
+			return i.External.URL
+		}
+	case "file":
+		if i.File != nil {
+			return i.File.URL
+		}
+	}
+	return ""
+}
+
+// IconExternal is the external-URL variant of an Icon.
+type IconExternal struct {
+	URL string `json:"url"`
+}
+
+// IconFile is the hosted-file variant of an Icon.
+type IconFile struct {
+	URL        string `json:"url"`
+	ExpiryTime string `json:"expiry_time,omitempty"`
+}
+
+// SearchResponse is one page of search results returned by the Notion API.
+type SearchResponse struct {
+	Object     string         `json:"object"`
+	Results    []SearchResult `json:"results"`
+	NextCursor string         `json:"next_cursor"`
+	HasMore    bool           `json:"has_more"`
+}
+
+// Search performs a single POST /v1/search call and returns the immediate
+// page of results. Callers that need to walk every page should use
+// SearchAll, which handles cursor pagination.
+func (s *SearchClient) Search(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
+	httpReq, err := s.c.newRequest(ctx, http.MethodPost, "/search", req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	var out SearchResponse
+	if err := decodeInto(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SearchAll walks pagination until the server reports HasMore=false or the
+// supplied limit is reached. A non-positive limit means "return everything".
+// When limit is positive, the returned slice is truncated to exactly limit
+// entries (or fewer if the server ran out first).
+func (s *SearchClient) SearchAll(ctx context.Context, req SearchRequest, limit int) ([]SearchResult, error) {
+	var all []SearchResult
+	cursor := req.StartCursor
+	for {
+		page := req
+		page.StartCursor = cursor
+		resp, err := s.Search(ctx, page)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Results...)
+		if limit > 0 && len(all) >= limit {
+			return all[:limit], nil
+		}
+		if !resp.HasMore || resp.NextCursor == "" {
+			return all, nil
+		}
+		cursor = resp.NextCursor
+	}
 }

--- a/utils/search_test.go
+++ b/utils/search_test.go
@@ -1,0 +1,337 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newSearchMock returns an httptest server that handles POST /search, with
+// behavior driven by the query field of the request body. This mirrors the
+// block_extra_test.go pattern of switching on (method, path, payload) rather
+// than spinning up a fresh server per test case.
+func newSearchMock(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	result := func(id, object, title string) SearchResult {
+		raw := `{"object":"` + object + `","id":"` + id + `","url":"https://notion.so/` + id + `","last_edited_time":"2026-04-22T10:00:00.000Z","icon":{"type":"emoji","emoji":"🗒️"},"properties":{"title":{"title":[{"plain_text":"` + title + `"}]}}}`
+		var r SearchResult
+		if err := json.Unmarshal([]byte(raw), &r); err != nil {
+			t.Fatalf("seed result: %v", err)
+		}
+		return r
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/search" {
+			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req SearchRequest
+		_ = json.Unmarshal(body, &req)
+
+		writeJSON := func(v interface{}) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(v)
+		}
+
+		// Pagination fixture: "paginated" returns two pages.
+		if req.Query == "paginated" {
+			if req.StartCursor == "cursor-1" {
+				writeJSON(SearchResponse{
+					Object:  "list",
+					Results: []SearchResult{result("pg-3", "page", "Third")},
+					HasMore: false,
+				})
+				return
+			}
+			writeJSON(SearchResponse{
+				Object:     "list",
+				Results:    []SearchResult{result("pg-1", "page", "First"), result("pg-2", "page", "Second")},
+				HasMore:    true,
+				NextCursor: "cursor-1",
+			})
+			return
+		}
+
+		// Empty fixture.
+		if req.Query == "missing" {
+			writeJSON(SearchResponse{Object: "list", Results: []SearchResult{}})
+			return
+		}
+
+		// Type-filtered fixtures.
+		if req.Filter != nil && req.Filter.Property == "object" {
+			switch req.Filter.Value {
+			case "page":
+				writeJSON(SearchResponse{Object: "list", Results: []SearchResult{
+					result("pg-only", "page", "Only Page"),
+				}})
+				return
+			case "database":
+				writeJSON(SearchResponse{Object: "list", Results: []SearchResult{
+					result("db-only", "database", "Only DB"),
+				}})
+				return
+			}
+		}
+
+		// Default: one page + one database.
+		writeJSON(SearchResponse{Object: "list", Results: []SearchResult{
+			result("pg-1", "page", "Roadmap"),
+			result("db-1", "database", "Tracker"),
+		}})
+	}))
+}
+
+// withSearchMock wires the search mock and restores baseURL on teardown.
+func withSearchMock(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := newSearchMock(t)
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	t.Cleanup(func() {
+		SetBaseURL(prev)
+		srv.Close()
+	})
+	return srv
+}
+
+// newClientForSearch returns a SearchClient bound to the current baseURL so
+// tests exercise the same wiring the cmd layer uses.
+func newClientForSearch() *SearchClient {
+	return NewSearchClient(NewClient("fakeKey", WithBaseURL(baseURL)))
+}
+
+func TestSearch(t *testing.T) {
+	withSearchMock(t)
+	sc := newClientForSearch()
+
+	tests := []struct {
+		name    string
+		req     SearchRequest
+		wantLen int
+		wantIDs []string
+	}{
+		{
+			name:    "basic query returns page + database",
+			req:     SearchRequest{Query: "roadmap"},
+			wantLen: 2,
+			wantIDs: []string{"pg-1", "db-1"},
+		},
+		{
+			name:    "filter pages only",
+			req:     SearchRequest{Query: "x", Filter: &SearchFilter{Property: "object", Value: "page"}},
+			wantLen: 1,
+			wantIDs: []string{"pg-only"},
+		},
+		{
+			name:    "filter databases only",
+			req:     SearchRequest{Query: "x", Filter: &SearchFilter{Property: "object", Value: "database"}},
+			wantLen: 1,
+			wantIDs: []string{"db-only"},
+		},
+		{
+			name:    "empty results",
+			req:     SearchRequest{Query: "missing"},
+			wantLen: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := sc.Search(context.Background(), tt.req)
+			if err != nil {
+				t.Fatalf("Search: %v", err)
+			}
+			if len(resp.Results) != tt.wantLen {
+				t.Fatalf("len=%d want=%d", len(resp.Results), tt.wantLen)
+			}
+			for i, id := range tt.wantIDs {
+				if resp.Results[i].ID != id {
+					t.Errorf("result[%d].ID=%q want=%q", i, resp.Results[i].ID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchAll(t *testing.T) {
+	withSearchMock(t)
+	sc := newClientForSearch()
+
+	tests := []struct {
+		name    string
+		req     SearchRequest
+		limit   int
+		wantLen int
+		wantIDs []string
+	}{
+		{
+			name:    "walks pagination across two pages",
+			req:     SearchRequest{Query: "paginated"},
+			limit:   0,
+			wantLen: 3,
+			wantIDs: []string{"pg-1", "pg-2", "pg-3"},
+		},
+		{
+			name:    "limit truncates mid-page",
+			req:     SearchRequest{Query: "paginated"},
+			limit:   2,
+			wantLen: 2,
+			wantIDs: []string{"pg-1", "pg-2"},
+		},
+		{
+			name:    "limit exceeds total returns all",
+			req:     SearchRequest{Query: "paginated"},
+			limit:   999,
+			wantLen: 3,
+			wantIDs: []string{"pg-1", "pg-2", "pg-3"},
+		},
+		{
+			name:    "single page returns early",
+			req:     SearchRequest{Query: "roadmap"},
+			limit:   0,
+			wantLen: 2,
+			wantIDs: []string{"pg-1", "db-1"},
+		},
+		{
+			name:    "empty result set",
+			req:     SearchRequest{Query: "missing"},
+			limit:   0,
+			wantLen: 0,
+		},
+		{
+			name:    "negative limit treated as unlimited",
+			req:     SearchRequest{Query: "paginated"},
+			limit:   -5,
+			wantLen: 3,
+			wantIDs: []string{"pg-1", "pg-2", "pg-3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sc.SearchAll(context.Background(), tt.req, tt.limit)
+			if err != nil {
+				t.Fatalf("SearchAll: %v", err)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("len=%d want=%d", len(got), tt.wantLen)
+			}
+			for i, id := range tt.wantIDs {
+				if got[i].ID != id {
+					t.Errorf("result[%d].ID=%q want=%q", i, got[i].ID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchAll_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"object":"error","code":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	defer SetBaseURL(prev)
+
+	sc := newClientForSearch()
+	if _, err := sc.SearchAll(context.Background(), SearchRequest{Query: "anything"}, 0); err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantID   string
+		wantType string
+		wantRaw  string
+	}{
+		{
+			name:     "page payload populates typed + raw",
+			input:    `{"object":"page","id":"pg-1","url":"https://notion.so/pg-1","last_edited_time":"2026-04-22T10:00:00.000Z","icon":{"type":"emoji","emoji":"📄"}}`,
+			wantID:   "pg-1",
+			wantType: "page",
+			wantRaw:  `"id":"pg-1"`,
+		},
+		{
+			name:     "database payload",
+			input:    `{"object":"database","id":"db-9","url":"https://notion.so/db-9"}`,
+			wantID:   "db-9",
+			wantType: "database",
+			wantRaw:  `"id":"db-9"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r SearchResult
+			if err := json.Unmarshal([]byte(tt.input), &r); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if r.ID != tt.wantID {
+				t.Errorf("ID=%q want=%q", r.ID, tt.wantID)
+			}
+			if r.Object != tt.wantType {
+				t.Errorf("Object=%q want=%q", r.Object, tt.wantType)
+			}
+			if !strings.Contains(string(r.Raw), tt.wantRaw) {
+				t.Errorf("Raw missing %q: %s", tt.wantRaw, string(r.Raw))
+			}
+		})
+	}
+
+	t.Run("malformed json returns error", func(t *testing.T) {
+		var r SearchResult
+		if err := json.Unmarshal([]byte(`{"id":`), &r); err == nil {
+			t.Fatal("expected error on malformed json, got nil")
+		}
+	})
+}
+
+func TestSearchResultRawPreservedThroughHTTP(t *testing.T) {
+	withSearchMock(t)
+	sc := newClientForSearch()
+	resp, err := sc.Search(context.Background(), SearchRequest{Query: "roadmap"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("no results")
+	}
+	if len(resp.Results[0].Raw) == 0 {
+		t.Fatal("Raw was not populated")
+	}
+	if !strings.Contains(string(resp.Results[0].Raw), `"id":"pg-1"`) {
+		t.Errorf("Raw did not contain expected id: %s", string(resp.Results[0].Raw))
+	}
+}
+
+func TestDisplay(t *testing.T) {
+	tests := []struct {
+		name string
+		icon *Icon
+		want string
+	}{
+		{"nil icon", nil, ""},
+		{"emoji", &Icon{Type: "emoji", Emoji: "📄"}, "📄"},
+		{"external url", &Icon{Type: "external", External: &IconExternal{URL: "https://ex/x.png"}}, "https://ex/x.png"},
+		{"external nil inner", &Icon{Type: "external"}, ""},
+		{"file url", &Icon{Type: "file", File: &IconFile{URL: "https://files/y.png"}}, "https://files/y.png"},
+		{"file nil inner", &Icon{Type: "file"}, ""},
+		{"unknown type", &Icon{Type: "custom"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.icon.Display(); got != tt.want {
+				t.Errorf("Display()=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/search_test.go
+++ b/utils/search_test.go
@@ -241,8 +241,47 @@ func TestSearchAll_HTTPError(t *testing.T) {
 	defer SetBaseURL(prev)
 
 	sc := newClientForSearch()
-	if _, err := sc.SearchAll(context.Background(), SearchRequest{Query: "anything"}, 0); err == nil {
+	_, err := sc.SearchAll(context.Background(), SearchRequest{Query: "anything"}, 0)
+	if err == nil {
 		t.Fatal("expected error on 401, got nil")
+	}
+	// Page 1 failures should be wrapped with "search page 1:".
+	if !strings.Contains(err.Error(), "search page 1:") {
+		t.Errorf("error missing page-number wrap: %v", err)
+	}
+}
+
+// TestSearchAll_MidPaginationError verifies that a failure on page 2 of a
+// walk is wrapped with the correct page number so callers can see how far
+// the walk got before failing.
+func TestSearchAll_MidPaginationError(t *testing.T) {
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(SearchResponse{
+				Object:     "list",
+				Results:    []SearchResult{},
+				HasMore:    true,
+				NextCursor: "cursor-2",
+			})
+			return
+		}
+		http.Error(w, `{"object":"error","code":"rate_limited"}`, http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	defer SetBaseURL(prev)
+
+	sc := newClientForSearch()
+	_, err := sc.SearchAll(context.Background(), SearchRequest{Query: "sweep"}, 0)
+	if err == nil {
+		t.Fatal("expected mid-pagination error, got nil")
+	}
+	if !strings.Contains(err.Error(), "search page 2:") {
+		t.Errorf("error missing page-2 wrap: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements issue #4: `notioncli search <query>` for workspace-wide queries against `POST /v1/search`.

- `utils/search.go`: typed `SearchRequest` / `SearchResult` / `SearchResponse`, a single-page `Search`, and a `SearchAll` that walks `has_more` / `next_cursor` until the server runs out or the caller's `limit` is reached (`limit<=0` = unlimited).
- `cmd/search.go`: new top-level cobra subcommand with `--type pages|databases`, `--limit N`, `--page-size N`, and `--json`.
- `SearchResult.UnmarshalJSON` preserves the raw Notion payload in `Raw`, so `--json` can pass through the API response verbatim (NDJSON, one object per line) without re-serializing.

### JSON output convention (first use; establishes pattern for #2)

- `--json` -> one raw result object per line on stdout (no envelope).
- Errors -> single-line JSON `{"error":"..."}` to stderr when `--json` is set; red human message otherwise.
- Non-zero exit via cobra `RunE` return.

## Test evidence

- `make ci` -> green. Full tail:
  ```
  notioncli/utils/search.go:23: NewSearchClient   100.0%
  notioncli/utils/search.go:63: UnmarshalJSON      85.7%
  notioncli/utils/search.go:85: Display           100.0%
  notioncli/utils/search.go:126: Search            80.0%
  notioncli/utils/search.go:146: SearchAll        100.0%
  total: (statements) 84.0%
  Total coverage: 84.0% (gate: 70%)
  ✓ Every exported function has a matching Test* (skips honored).
  ```
- Coverage delta: **79.9% -> 84.0%** (utils 78.8% -> 80.4%, cmd 68.9% -> 80.1%).
- `go test -race ./...` clean.
- `gofmt -l .` empty, `go vet ./...` clean.

### utils/search_test.go cases

Basic query, `--type pages`, `--type databases`, empty results, pagination across two pages (`has_more` + `next_cursor`), `--limit` truncation mid-page, limit-exceeds-total, single-page early return, negative limit treated as unlimited, HTTP error propagation, `UnmarshalJSON` page/database/malformed, `Icon.Display` across emoji/external/file/unknown/nil.

### cmd/search_test.go cases

Flag registration + defaults, arg count bounds, `buildSearchFilter` translation table, end-to-end rootCmd dispatch with title extraction, `--type databases` filter payload inspection, `--json` NDJSON output shape, invalid `--type` short-circuits before any API call, `extractSearchTitle` across database / page / renamed-property / empty / malformed shapes, `formatSearchTime` round-trip, direct `runSearch` invocation.

## Test plan

- [ ] CI green on Go 1.21
- [ ] `notioncli search "roadmap"` against a real workspace returns pages + databases
- [ ] `notioncli search "roadmap" --type databases` filters correctly
- [ ] `notioncli search "" --limit 50 --json` streams 50 NDJSON lines

## Scope notes

- Only `utils/search.go`, `utils/search_test.go`, `cmd/search.go`, `cmd/search_test.go` touched.
- No bump to the pinned Notion API version (2022-06-28).
- No new dependencies.