### PR TITLE
feat: users + teams commands (closes #9)

### DIFF
--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -32,6 +32,9 @@ var teamsListCmd = &cobra.Command{
 		notionAPIKey, _ := utils.SetAPIConfig()
 		client := utils.NewTeamClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
 
+		// client.List currently always returns (nil, ErrTeamsNotSupported)
+		// on this branch; the discard of the first return is intentional
+		// and becomes load-bearing once issue #11 lands the real impl.
 		if _, err := client.List(context.Background()); err != nil {
 			color.Red("Error: %v", err)
 			osExit(1)

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -1,0 +1,46 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// teamsCmd is the parent command for team-related operations. The teams
+// endpoint is not available on the pinned Notion-Version (2022-06-28);
+// see issue #11 for the version bump that will enable a real listing.
+var teamsCmd = &cobra.Command{
+	Use:   "teams",
+	Short: "Manage Notion workspace teams (pending API version bump)",
+	Long: `The teams command will work once the Notion-Version pinned by
+this CLI is bumped (tracked in issue #11). Today every subcommand returns
+a clear "not supported" error so callers can branch on it.`,
+}
+
+// teamsListCmd surfaces utils.ErrTeamsNotSupported to the user.
+var teamsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List every team in the workspace",
+	Run: func(cmd *cobra.Command, args []string) {
+		notionAPIKey, _ := utils.SetAPIConfig()
+		client := utils.NewTeamClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
+
+		if _, err := client.List(context.Background()); err != nil {
+			color.Red("Error: %v", err)
+			osExit(1)
+			return
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(teamsCmd)
+	teamsCmd.AddCommand(teamsListCmd)
+}

--- a/cmd/teams_test.go
+++ b/cmd/teams_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// findTeamsSubcommand walks the teams command's children and returns the
+// child matching name, or fails the test.
+func findTeamsSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	teamsC := findTopLevelCmd(t, "teams")
+	for _, c := range teamsC.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("teams subcommand %q not found", name)
+	return nil
+}
+
+// TestTeamsCmdRegistered verifies `teams` is a top-level command with a
+// list subcommand.
+func TestTeamsCmdRegistered(t *testing.T) {
+	teamsC := findTopLevelCmd(t, "teams")
+	found := false
+	for _, c := range teamsC.Commands() {
+		if c.Name() == "list" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("teams list subcommand not registered")
+	}
+}
+
+// TestTeamsListExists asserts the list subcommand exists and is a valid
+// cobra.Command (catches nil-pointer registration bugs).
+func TestTeamsListExists(t *testing.T) {
+	list := findTeamsSubcommand(t, "list")
+	if list.Use == "" {
+		t.Error("teams list: Use field is empty")
+	}
+}
+
+// TestTeamsListDispatch_SurfacesStubError runs `notioncli teams list`
+// and asserts the osExit recorder fires with code 1 (the stub path).
+// The purpose is to confirm the CLI wires the stub error cleanly rather
+// than panicking.
+func TestTeamsListDispatch_SurfacesStubError(t *testing.T) {
+	// Env scaffolding: teams list calls utils.SetAPIConfig which needs
+	// env vars and a loadable .env.
+	emptyCwd := t.TempDir()
+	emptyHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(emptyCwd, ".env"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(emptyCwd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("NOTION_API_KEY", "test-key")
+	t.Setenv("NOTION_PAGE_ID", "pageID")
+	t.Setenv("LOCAL_TIMEZONE", "UTC")
+
+	// Swap osExit so the test binary survives the stub's exit(1).
+	var exited bool
+	var code int
+	origExit := osExit
+	osExit = func(c int) {
+		exited = true
+		code = c
+	}
+	t.Cleanup(func() { osExit = origExit })
+
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"teams", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(teams list): %v", err)
+	}
+
+	if !exited {
+		t.Fatal("teams list did not invoke osExit; expected stub error path")
+	}
+	if code != 1 {
+		t.Errorf("teams list osExit code = %d, want 1", code)
+	}
+}
+
+// TestTeamsListErrExposedViaUtils is a belt-and-braces check that the
+// cmd layer is paired with the utils stub so a future refactor can't
+// silently drop the error.
+func TestTeamsListErrExposedViaUtils(t *testing.T) {
+	if utils.ErrTeamsNotSupported == nil {
+		t.Fatal("utils.ErrTeamsNotSupported must be non-nil for teams list to have a stable error")
+	}
+}

--- a/cmd/teams_test.go
+++ b/cmd/teams_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"notioncli/utils"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -85,8 +87,20 @@ func TestTeamsListDispatch_SurfacesStubError(t *testing.T) {
 	}
 	t.Cleanup(func() { osExit = origExit })
 
-	resetRootCmdArgs()
+	// Swap fatih/color's package-level writers so color.Red's output is
+	// observable. Without this the sentinel error lands on os.Stderr and
+	// the #11 assertion below can't see it.
 	var out bytes.Buffer
+	origColorOut := color.Output
+	origColorErr := color.Error
+	color.Output = &out
+	color.Error = &out
+	t.Cleanup(func() {
+		color.Output = origColorOut
+		color.Error = origColorErr
+	})
+
+	resetRootCmdArgs()
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"teams", "list"})
@@ -99,6 +113,14 @@ func TestTeamsListDispatch_SurfacesStubError(t *testing.T) {
 	}
 	if code != 1 {
 		t.Errorf("teams list osExit code = %d, want 1", code)
+	}
+
+	// The stub error must bubble through the CLI surface so operators
+	// who grep for "#11" in the output land on the tracking issue. This
+	// also confirms the discarded-team return at cmd/teams.go isn't
+	// suppressing the sentinel before the color.Red call.
+	if got := out.String(); !strings.Contains(got, "#11") {
+		t.Errorf("teams list output missing #11 marker:\n%s", got)
 	}
 }
 

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -1,0 +1,170 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// usersJSON toggles JSON output on the users subcommands. It is a
+// package-level var so each subcommand can bind its own --json flag.
+var usersJSON bool
+
+// usersCmd is the parent command for user-related operations on the
+// Notion API.
+var usersCmd = &cobra.Command{
+	Use:   "users",
+	Short: "Manage Notion workspace users",
+	Long: `The users command works with the Notion users API.
+
+Subcommands:
+  list           List every user the integration can see
+  get <id>       Retrieve a single user by id
+  whoami         Show the bot user associated with NOTION_API_KEY`,
+}
+
+// usersListCmd lists every user the integration can see, following
+// pagination internally.
+var usersListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List every user in the workspace",
+	Long:  `List every user the current integration can access. Use --json for machine-readable output.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		notionAPIKey, _ := utils.SetAPIConfig()
+		client := utils.NewUserClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
+
+		users, err := client.List(context.Background())
+		if err != nil {
+			color.Red("Error listing users: %v", err)
+			osExit(1)
+			return
+		}
+
+		if usersJSON {
+			if err := writeJSON(cmd.OutOrStdout(), users); err != nil {
+				color.Red("Error encoding JSON: %v", err)
+				osExit(1)
+				return
+			}
+			return
+		}
+
+		if len(users) == 0 {
+			color.Yellow("No users returned.")
+			return
+		}
+		for _, u := range users {
+			fmt.Fprintln(cmd.OutOrStdout(), formatUser(u))
+		}
+	},
+}
+
+// usersGetCmd retrieves a single user by id.
+var usersGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Retrieve a user by id",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		notionAPIKey, _ := utils.SetAPIConfig()
+		client := utils.NewUserClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
+
+		user, err := client.Get(context.Background(), args[0])
+		if err != nil {
+			color.Red("Error getting user: %v", err)
+			osExit(1)
+			return
+		}
+
+		if usersJSON {
+			if err := writeJSON(cmd.OutOrStdout(), user); err != nil {
+				color.Red("Error encoding JSON: %v", err)
+				osExit(1)
+				return
+			}
+			return
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), formatUser(*user))
+	},
+}
+
+// usersWhoamiCmd prints the bot user associated with the current token.
+var usersWhoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show the current integration's bot user",
+	Run: func(cmd *cobra.Command, args []string) {
+		notionAPIKey, _ := utils.SetAPIConfig()
+		client := utils.NewUserClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
+
+		user, err := client.Me(context.Background())
+		if err != nil {
+			color.Red("Error retrieving self: %v", err)
+			osExit(1)
+			return
+		}
+
+		if usersJSON {
+			if err := writeJSON(cmd.OutOrStdout(), user); err != nil {
+				color.Red("Error encoding JSON: %v", err)
+				osExit(1)
+				return
+			}
+			return
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), formatUser(*user))
+	},
+}
+
+// formatUser renders a single user as a one-line human-readable summary.
+// Kept minimal so CI snapshots (none today) would be stable.
+func formatUser(u utils.User) string {
+	name := u.Name
+	if name == "" {
+		name = "(unnamed)"
+	}
+	kind := u.Type
+	if kind == "" {
+		kind = "user"
+	}
+	detail := ""
+	switch {
+	case u.Person != nil && u.Person.Email != "":
+		detail = " <" + u.Person.Email + ">"
+	case u.Bot != nil && u.Bot.WorkspaceName != "":
+		detail = " (workspace: " + u.Bot.WorkspaceName + ")"
+	}
+	return fmt.Sprintf("[%s] %s%s  id=%s", kind, name, detail, u.ID)
+}
+
+// writeJSON encodes v as indented JSON to w. Broken out so the users
+// subcommands share a single encoder configuration.
+func writeJSON(w interface{ Write(p []byte) (n int, err error) }, v interface{}) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// Ensure os is referenced even if osExit is unused in this file's test
+// configuration; keeps godoc-importable tools happy without an import
+// side-effect.
+var _ = os.Stdout
+
+func init() {
+	rootCmd.AddCommand(usersCmd)
+	usersCmd.AddCommand(usersListCmd)
+	usersCmd.AddCommand(usersGetCmd)
+	usersCmd.AddCommand(usersWhoamiCmd)
+
+	usersListCmd.Flags().BoolVar(&usersJSON, "json", false, "Emit JSON instead of human-readable output")
+	usersGetCmd.Flags().BoolVar(&usersJSON, "json", false, "Emit JSON instead of human-readable output")
+	usersWhoamiCmd.Flags().BoolVar(&usersJSON, "json", false, "Emit JSON instead of human-readable output")
+}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 
 	"notioncli/utils"
 
@@ -147,16 +147,11 @@ func formatUser(u utils.User) string {
 
 // writeJSON encodes v as indented JSON to w. Broken out so the users
 // subcommands share a single encoder configuration.
-func writeJSON(w interface{ Write(p []byte) (n int, err error) }, v interface{}) error {
+func writeJSON(w io.Writer, v interface{}) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(v)
 }
-
-// Ensure os is referenced even if osExit is unused in this file's test
-// configuration; keeps godoc-importable tools happy without an import
-// side-effect.
-var _ = os.Stdout
 
 func init() {
 	rootCmd.AddCommand(usersCmd)

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// findUsersSubcommand walks the users command's children and returns the
+// child matching name, or fails the test.
+func findUsersSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	usersC := findTopLevelCmd(t, "users")
+	for _, c := range usersC.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("users subcommand %q not found", name)
+	return nil
+}
+
+// withUsersEnv is like withCmdEnv but the mock server understands the
+// /v1/users endpoints instead of /v1/blocks. Kept in this file (rather
+// than testhelpers_test.go) because scope for this change is limited to
+// cmd/users_test.go and cmd/teams_test.go.
+func withUsersEnv(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	writeJSON := func(w http.ResponseWriter, v interface{}) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/users":
+			writeJSON(w, utils.UserList{
+				Object: "list",
+				Results: []utils.User{
+					{Object: "user", ID: "u1", Type: "person", Name: "Ada", Person: &utils.UserPerson{Email: "ada@example.com"}},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/users/me":
+			writeJSON(w, utils.User{Object: "user", ID: "bot-1", Type: "bot", Name: "CLI bot", Bot: &utils.UserBot{WorkspaceName: "Acme"}})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/"):
+			writeJSON(w, utils.User{Object: "user", ID: strings.TrimPrefix(r.URL.Path, "/users/"), Type: "person", Name: "Ada"})
+		default:
+			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+		}
+	}))
+
+	priorBaseURL := utils.GetBaseURL()
+	utils.SetBaseURL(srv.URL)
+	t.Cleanup(func() {
+		utils.SetBaseURL(priorBaseURL)
+		srv.Close()
+	})
+
+	emptyCwd := t.TempDir()
+	emptyHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(emptyCwd, ".env"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(emptyCwd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("NOTION_API_KEY", "test-key")
+	t.Setenv("NOTION_PAGE_ID", "pageID")
+	t.Setenv("LOCAL_TIMEZONE", "UTC")
+
+	return srv
+}
+
+// TestUsersCmdRegistered verifies `users` is a top-level command with
+// the three subcommands the issue requires.
+func TestUsersCmdRegistered(t *testing.T) {
+	usersC := findTopLevelCmd(t, "users")
+	want := map[string]bool{"list": false, "get": false, "whoami": false}
+	for _, c := range usersC.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("users subcommand %q not registered", name)
+		}
+	}
+}
+
+// TestUsersListFlags asserts the list subcommand declares a --json flag
+// with default false.
+func TestUsersListFlags(t *testing.T) {
+	list := findUsersSubcommand(t, "list")
+	f := list.Flag("json")
+	if f == nil {
+		t.Fatal("users list: --json flag not registered")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("users list: --json default = %q, want false", f.DefValue)
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("users list: --json type = %q, want bool", f.Value.Type())
+	}
+}
+
+// TestUsersGetArgs asserts the get subcommand requires exactly one
+// positional argument.
+func TestUsersGetArgs(t *testing.T) {
+	get := findUsersSubcommand(t, "get")
+
+	if err := get.Args(get, []string{}); err == nil {
+		t.Error("users get: expected error on zero args, got nil")
+	}
+	if err := get.Args(get, []string{"abc"}); err != nil {
+		t.Errorf("users get: expected no error on one arg, got %v", err)
+	}
+	if err := get.Args(get, []string{"a", "b"}); err == nil {
+		t.Error("users get: expected error on two args, got nil")
+	}
+
+	f := get.Flag("json")
+	if f == nil {
+		t.Fatal("users get: --json flag not registered")
+	}
+}
+
+// TestUsersWhoamiFlags asserts the whoami subcommand has --json wired.
+func TestUsersWhoamiFlags(t *testing.T) {
+	whoami := findUsersSubcommand(t, "whoami")
+	f := whoami.Flag("json")
+	if f == nil {
+		t.Fatal("users whoami: --json flag not registered")
+	}
+}
+
+// TestUsersListDispatch runs `notioncli users list --json` and asserts
+// the list GET was issued and the output is parseable JSON.
+func TestUsersListDispatch(t *testing.T) {
+	srv := withUsersEnv(t)
+
+	var listed int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/users" {
+			atomic.AddInt64(&listed, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	// Reset shared JSON flag so prior tests don't leak state.
+	usersJSON = false
+
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "list", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users list): %v", err)
+	}
+	if atomic.LoadInt64(&listed) == 0 {
+		t.Error("users list did not hit /users")
+	}
+
+	// JSON body should decode as a []User.
+	body := bytes.TrimSpace(out.Bytes())
+	if len(body) == 0 {
+		t.Fatal("users list --json: empty output")
+	}
+	var decoded []utils.User
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Errorf("users list --json: output is not a []User: %v\n%s", err, body)
+	}
+}
+
+// TestUsersGetDispatch runs `notioncli users get u1` and asserts the
+// per-id GET was issued.
+func TestUsersGetDispatch(t *testing.T) {
+	srv := withUsersEnv(t)
+
+	var got int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/users/u1" {
+			atomic.AddInt64(&got, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	usersJSON = false
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "get", "u1"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users get): %v", err)
+	}
+	if atomic.LoadInt64(&got) == 0 {
+		t.Error("users get did not hit /users/u1")
+	}
+}
+
+// TestUsersWhoamiDispatch runs `notioncli users whoami --json` and
+// asserts /users/me was hit.
+func TestUsersWhoamiDispatch(t *testing.T) {
+	srv := withUsersEnv(t)
+
+	var hit int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/users/me" {
+			atomic.AddInt64(&hit, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	usersJSON = false
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "whoami", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users whoami): %v", err)
+	}
+	if atomic.LoadInt64(&hit) == 0 {
+		t.Error("users whoami did not hit /users/me")
+	}
+
+	body := bytes.TrimSpace(out.Bytes())
+	if len(body) == 0 {
+		t.Fatal("users whoami --json: empty output")
+	}
+	var decoded utils.User
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Errorf("users whoami --json: output is not a User: %v\n%s", err, body)
+	}
+}

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"notioncli/utils"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -30,18 +32,16 @@ func findUsersSubcommand(t *testing.T, name string) *cobra.Command {
 	return nil
 }
 
-// withUsersEnv is like withCmdEnv but the mock server understands the
-// /v1/users endpoints instead of /v1/blocks. Kept in this file (rather
-// than testhelpers_test.go) because scope for this change is limited to
-// cmd/users_test.go and cmd/teams_test.go.
-func withUsersEnv(t *testing.T) *httptest.Server {
-	t.Helper()
-
+// defaultUsersHandler serves the standard /v1/users fixtures shared by
+// the happy-path dispatch tests. It is factored out so error-path tests
+// can construct a server with a replacement handler while reusing the
+// same env scaffolding.
+func defaultUsersHandler() http.Handler {
 	writeJSON := func(w http.ResponseWriter, v interface{}) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(v)
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/users":
 			writeJSON(w, utils.UserList{
@@ -57,7 +57,27 @@ func withUsersEnv(t *testing.T) *httptest.Server {
 		default:
 			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
 		}
-	}))
+	})
+}
+
+// withUsersEnv is like withCmdEnv but the mock server understands the
+// /v1/users endpoints instead of /v1/blocks. Kept in this file (rather
+// than testhelpers_test.go) because scope for this change is limited to
+// cmd/users_test.go and cmd/teams_test.go.
+func withUsersEnv(t *testing.T) *httptest.Server {
+	t.Helper()
+	return withUsersEnvHandler(t, defaultUsersHandler())
+}
+
+// withUsersEnvHandler is the overlay-friendly form: callers pass in a
+// replacement handler (typically one that simulates errors) and the
+// helper takes care of all the cwd/env scaffolding. This mirrors the
+// pattern recommended for sibling PRs so error branches are easy to
+// reach without duplicating the env setup.
+func withUsersEnvHandler(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(h)
 
 	priorBaseURL := utils.GetBaseURL()
 	utils.SetBaseURL(srv.URL)
@@ -86,6 +106,41 @@ func withUsersEnv(t *testing.T) *httptest.Server {
 	t.Setenv("LOCAL_TIMEZONE", "UTC")
 
 	return srv
+}
+
+// recordOSExit swaps osExit with a recorder for the duration of the
+// test. Returns pointers so callers can assert on the captured code.
+// Tests using this helper must not rely on osExit actually terminating
+// the goroutine; the Cobra Run closure returns after osExit per the
+// existing `return` statements in cmd/users.go.
+func recordOSExit(t *testing.T) (*bool, *int) {
+	t.Helper()
+	exited := false
+	code := 0
+	orig := osExit
+	osExit = func(c int) {
+		exited = true
+		code = c
+	}
+	t.Cleanup(func() { osExit = orig })
+	return &exited, &code
+}
+
+// captureColorOutput redirects fatih/color's package-level Output and
+// Error writers into the given io.Writer for the duration of the test.
+// color.Red / color.Yellow etc. write to color.Output (not the cobra
+// command's stdout), so tests that need to assert on that output must
+// swap it out explicitly. Restored in t.Cleanup.
+func captureColorOutput(t *testing.T, w io.Writer) {
+	t.Helper()
+	origOut := color.Output
+	origErr := color.Error
+	color.Output = w
+	color.Error = w
+	t.Cleanup(func() {
+		color.Output = origOut
+		color.Error = origErr
+	})
 }
 
 // TestUsersCmdRegistered verifies `users` is a top-level command with
@@ -216,6 +271,99 @@ func TestUsersGetDispatch(t *testing.T) {
 	}
 	if atomic.LoadInt64(&got) == 0 {
 		t.Error("users get did not hit /users/u1")
+	}
+}
+
+// errorHandler returns an http.Handler that responds to every request
+// with the given status code and a minimal Notion-shaped error body.
+func errorHandler(status int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"object":"error","code":"unauthorized"}`, status)
+	})
+}
+
+// TestUsersListDispatch_HTTPErrorExits asserts that a non-2xx response
+// from the Notion users endpoint surfaces through the Run closure,
+// prints an error, and calls osExit(1). Covers cmd/users.go:47-51.
+func TestUsersListDispatch_HTTPErrorExits(t *testing.T) {
+	withUsersEnvHandler(t, errorHandler(http.StatusUnauthorized))
+
+	exited, code := recordOSExit(t)
+	var out bytes.Buffer
+	captureColorOutput(t, &out)
+
+	usersJSON = false
+	resetRootCmdArgs()
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users list): %v", err)
+	}
+	if !*exited {
+		t.Fatal("users list: osExit not called on HTTP error")
+	}
+	if *code != 1 {
+		t.Errorf("users list: osExit code = %d, want 1", *code)
+	}
+	if !strings.Contains(out.String(), "Error listing users") {
+		t.Errorf("users list: missing error message in output:\n%s", out.String())
+	}
+}
+
+// TestUsersGetDispatch_HTTPErrorExits covers the 404 path for
+// `users get <id>` (cmd/users.go:82-86).
+func TestUsersGetDispatch_HTTPErrorExits(t *testing.T) {
+	withUsersEnvHandler(t, errorHandler(http.StatusNotFound))
+
+	exited, code := recordOSExit(t)
+	var out bytes.Buffer
+	captureColorOutput(t, &out)
+
+	usersJSON = false
+	resetRootCmdArgs()
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "get", "does-not-exist"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users get): %v", err)
+	}
+	if !*exited {
+		t.Fatal("users get: osExit not called on HTTP error")
+	}
+	if *code != 1 {
+		t.Errorf("users get: osExit code = %d, want 1", *code)
+	}
+	if !strings.Contains(out.String(), "Error getting user") {
+		t.Errorf("users get: missing error message in output:\n%s", out.String())
+	}
+}
+
+// TestUsersWhoamiDispatch_HTTPErrorExits covers the 401 path for
+// `users whoami` (cmd/users.go:109-113).
+func TestUsersWhoamiDispatch_HTTPErrorExits(t *testing.T) {
+	withUsersEnvHandler(t, errorHandler(http.StatusUnauthorized))
+
+	exited, code := recordOSExit(t)
+	var out bytes.Buffer
+	captureColorOutput(t, &out)
+
+	usersJSON = false
+	resetRootCmdArgs()
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "whoami"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users whoami): %v", err)
+	}
+	if !*exited {
+		t.Fatal("users whoami: osExit not called on HTTP error")
+	}
+	if *code != 1 {
+		t.Errorf("users whoami: osExit code = %d, want 1", *code)
+	}
+	if !strings.Contains(out.String(), "Error retrieving self") {
+		t.Errorf("users whoami: missing error message in output:\n%s", out.String())
 	}
 }
 

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -367,6 +367,170 @@ func TestUsersWhoamiDispatch_HTTPErrorExits(t *testing.T) {
 	}
 }
 
+// TestUsersListDispatch_HumanOutput runs `notioncli users list` WITHOUT
+// --json and asserts the rendered rows contain each user's key fields.
+// Covers cmd/users.go:62-68 (the empty-check + formatUser loop).
+func TestUsersListDispatch_HumanOutput(t *testing.T) {
+	withUsersEnvHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/users" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(utils.UserList{
+				Object: "list",
+				Results: []utils.User{
+					{Object: "user", ID: "u1", Type: "person", Name: "Ada", Person: &utils.UserPerson{Email: "ada@example.com"}},
+					{Object: "user", ID: "u2", Type: "person", Name: "Grace", Person: &utils.UserPerson{Email: "grace@example.com"}},
+					{Object: "user", ID: "bot-1", Type: "bot", Name: "CLI bot", Bot: &utils.UserBot{WorkspaceName: "Acme"}},
+				},
+			})
+			return
+		}
+		http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+	}))
+
+	usersJSON = false
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users list): %v", err)
+	}
+
+	// Assert that each user's key fields land on stdout exactly once.
+	// Stick to key substrings rather than exact byte-matching the whole
+	// line so the formatter is free to tweak cosmetics.
+	got := out.String()
+	for _, want := range []string{"Ada", "ada@example.com", "Grace", "grace@example.com", "CLI bot", "Acme", "u1", "u2", "bot-1"} {
+		if c := strings.Count(got, want); c != 1 {
+			t.Errorf("users list human output: want substring %q exactly once, got %d\noutput:\n%s", want, c, got)
+		}
+	}
+}
+
+// TestUsersListDispatch_HumanOutputEmpty covers the "No users returned."
+// branch (cmd/users.go:62-65) when the Notion API returns an empty list.
+func TestUsersListDispatch_HumanOutputEmpty(t *testing.T) {
+	withUsersEnvHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(utils.UserList{Object: "list", Results: []utils.User{}})
+	}))
+
+	exited, _ := recordOSExit(t)
+	var out bytes.Buffer
+	captureColorOutput(t, &out)
+
+	usersJSON = false
+	resetRootCmdArgs()
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users list): %v", err)
+	}
+
+	if *exited {
+		t.Error("users list: osExit was unexpectedly called on an empty list")
+	}
+	if !strings.Contains(out.String(), "No users returned") {
+		t.Errorf("users list (empty): want substring 'No users returned' in:\n%s", out.String())
+	}
+}
+
+// TestUsersGetDispatch_HumanOutput runs `users get u1` without --json
+// and asserts formatUser produced output containing the id and name.
+// Covers cmd/users.go:96.
+func TestUsersGetDispatch_HumanOutput(t *testing.T) {
+	withUsersEnv(t)
+
+	usersJSON = false
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "get", "u1"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users get): %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"u1", "Ada"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("users get human output: want substring %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestUsersWhoamiDispatch_HumanOutput runs `users whoami` without
+// --json and asserts formatUser produced output for the bot user.
+// Covers cmd/users.go:123.
+func TestUsersWhoamiDispatch_HumanOutput(t *testing.T) {
+	withUsersEnv(t)
+
+	usersJSON = false
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "whoami"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(users whoami): %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"bot-1", "CLI bot", "Acme"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("users whoami human output: want substring %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFormatUser is a table-driven unit test that drives every branch
+// of the formatUser switch without going through HTTP. Covers the
+// unnamed-fallback and missing-type paths that the dispatch tests
+// don't reach.
+func TestFormatUser(t *testing.T) {
+	cases := []struct {
+		name string
+		in   utils.User
+		want []string // substrings the formatted string must contain
+	}{
+		{
+			name: "person with email",
+			in:   utils.User{ID: "u1", Type: "person", Name: "Ada", Person: &utils.UserPerson{Email: "ada@example.com"}},
+			want: []string{"[person]", "Ada", "<ada@example.com>", "id=u1"},
+		},
+		{
+			name: "bot with workspace",
+			in:   utils.User{ID: "bot-1", Type: "bot", Name: "CLI bot", Bot: &utils.UserBot{WorkspaceName: "Acme"}},
+			want: []string{"[bot]", "CLI bot", "(workspace: Acme)", "id=bot-1"},
+		},
+		{
+			name: "unnamed person falls back to placeholder",
+			in:   utils.User{ID: "u2", Type: "person"},
+			want: []string{"[person]", "(unnamed)", "id=u2"},
+		},
+		{
+			name: "missing type falls back to user",
+			in:   utils.User{ID: "u3", Name: "Anon"},
+			want: []string{"[user]", "Anon", "id=u3"},
+		},
+		{
+			name: "person with nil email does not add detail",
+			in:   utils.User{ID: "u4", Type: "person", Name: "Nilmail", Person: &utils.UserPerson{}},
+			want: []string{"[person]", "Nilmail", "id=u4"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatUser(tc.in)
+			for _, sub := range tc.want {
+				if !strings.Contains(got, sub) {
+					t.Errorf("formatUser = %q; missing %q", got, sub)
+				}
+			}
+		})
+	}
+}
+
 // TestUsersWhoamiDispatch runs `notioncli users whoami --json` and
 // asserts /users/me was hit.
 func TestUsersWhoamiDispatch(t *testing.T) {

--- a/utils/teams.go
+++ b/utils/teams.go
@@ -1,0 +1,64 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrTeamsNotSupported is returned by TeamClient methods when the pinned
+// Notion API version does not expose a teams endpoint. The MCP server's
+// notion-get-teams is implemented against a newer Notion API surface than
+// the 2022-06-28 version this CLI currently pins. Issue #11 tracks the
+// version bump that will enable a real implementation; until then this
+// client surfaces a typed error so callers can check for it with
+// errors.Is.
+var ErrTeamsNotSupported = errors.New("teams are not supported on Notion-Version " + NotionAPIVersion + "; will be enabled by issue #11")
+
+// Team is a placeholder for the Notion team object. The concrete shape
+// depends on a newer Notion API version than the CLI currently pins, so
+// the fields here are deliberately minimal — do not rely on them yet.
+type Team struct {
+	Object string `json:"object"`
+	ID     string `json:"id"`
+	Name   string `json:"name,omitempty"`
+}
+
+// TeamList is a single page of teams. Populated once issue #11 bumps the
+// pinned Notion-Version and a real endpoint is available.
+type TeamList struct {
+	Object     string `json:"object"`
+	Results    []Team `json:"results"`
+	NextCursor string `json:"next_cursor"`
+	HasMore    bool   `json:"has_more"`
+}
+
+// TeamClient is the typed resource client for the Notion teams API.
+//
+// The methods currently return ErrTeamsNotSupported because the pinned
+// Notion-Version does not expose a teams endpoint. The client shape is
+// kept stable so issue #11 can flip the implementation without breaking
+// callers.
+type TeamClient struct {
+	c *Client
+}
+
+// NewTeamClient wraps a *Client with team-resource methods.
+func NewTeamClient(c *Client) *TeamClient {
+	return &TeamClient{c: c}
+}
+
+// List would return every team visible to the integration. On the pinned
+// Notion-Version it returns ErrTeamsNotSupported.
+func (t *TeamClient) List(ctx context.Context) ([]Team, error) {
+	return nil, ErrTeamsNotSupported
+}
+
+// ListPage would return a single page of teams. On the pinned
+// Notion-Version it returns ErrTeamsNotSupported.
+func (t *TeamClient) ListPage(ctx context.Context, cursor string) (*TeamList, error) {
+	return nil, ErrTeamsNotSupported
+}

--- a/utils/teams_test.go
+++ b/utils/teams_test.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestNewTeamClient is a smoke test for the constructor; it exists so the
+// gap-check script sees a matching Test function for the exported
+// NewTeamClient symbol.
+func TestNewTeamClient(t *testing.T) {
+	c := NewClient("k", WithBaseURL("http://example"))
+	got := NewTeamClient(c)
+	if got == nil || got.c != c {
+		t.Fatalf("NewTeamClient: %+v", got)
+	}
+}
+
+// TestTeamClient_List_ReturnsNotSupported asserts the stub surfaces a
+// typed error referencing the pinned API version / issue #11. Verified
+// via errors.Is so callers can branch without string-matching.
+func TestTeamClient_List_ReturnsNotSupported(t *testing.T) {
+	client := NewTeamClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	got, err := client.List(context.Background())
+	if err == nil {
+		t.Fatalf("List: want error, got teams %+v", got)
+	}
+	if !errors.Is(err, ErrTeamsNotSupported) {
+		t.Errorf("List: want errors.Is ErrTeamsNotSupported, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("List: want nil teams, got %+v", got)
+	}
+}
+
+// TestTeamClient_ListPage_ReturnsNotSupported covers the per-page
+// accessor for parity with List.
+func TestTeamClient_ListPage_ReturnsNotSupported(t *testing.T) {
+	client := NewTeamClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	got, err := client.ListPage(context.Background(), "")
+	if err == nil {
+		t.Fatalf("ListPage: want error, got %+v", got)
+	}
+	if !errors.Is(err, ErrTeamsNotSupported) {
+		t.Errorf("ListPage: want errors.Is ErrTeamsNotSupported, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("ListPage: want nil page, got %+v", got)
+	}
+}
+
+// TestErrTeamsNotSupported_MessageReferences11 asserts the error
+// message mentions the pinned version and issue #11 so users can find
+// the tracking issue without reading the code.
+func TestErrTeamsNotSupported_MessageReferences11(t *testing.T) {
+	msg := ErrTeamsNotSupported.Error()
+	if !containsAll(msg, NotionAPIVersion, "#11") {
+		t.Errorf("ErrTeamsNotSupported message = %q; want it to mention %q and %q", msg, NotionAPIVersion, "#11")
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	n, m := len(s), len(sub)
+	if m > n {
+		return -1
+	}
+	for i := 0; i+m <= n; i++ {
+		if s[i:i+m] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/utils/teams_test.go
+++ b/utils/teams_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -55,33 +56,10 @@ func TestTeamClient_ListPage_ReturnsNotSupported(t *testing.T) {
 // the tracking issue without reading the code.
 func TestErrTeamsNotSupported_MessageReferences11(t *testing.T) {
 	msg := ErrTeamsNotSupported.Error()
-	if !containsAll(msg, NotionAPIVersion, "#11") {
-		t.Errorf("ErrTeamsNotSupported message = %q; want it to mention %q and %q", msg, NotionAPIVersion, "#11")
+	if !strings.Contains(msg, NotionAPIVersion) {
+		t.Errorf("ErrTeamsNotSupported message = %q; want it to mention %q", msg, NotionAPIVersion)
 	}
-}
-
-func containsAll(s string, subs ...string) bool {
-	for _, sub := range subs {
-		if !contains(s, sub) {
-			return false
-		}
+	if !strings.Contains(msg, "#11") {
+		t.Errorf("ErrTeamsNotSupported message = %q; want it to mention %q", msg, "#11")
 	}
-	return true
-}
-
-func contains(s, sub string) bool {
-	return len(sub) == 0 || indexOf(s, sub) >= 0
-}
-
-func indexOf(s, sub string) int {
-	n, m := len(s), len(sub)
-	if m > n {
-		return -1
-	}
-	for i := 0; i+m <= n; i++ {
-		if s[i:i+m] == sub {
-			return i
-		}
-	}
-	return -1
 }

--- a/utils/users.go
+++ b/utils/users.go
@@ -4,11 +4,57 @@
 
 package utils
 
-// UserClient is the typed resource client for the Notion users API.
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// User is a Notion user object as returned by the /v1/users endpoints.
 //
-// TODO: flesh out with List, Retrieve, and Me methods (see MCP-parity
-// tracking issues). Today this is a deliberate stub so the shape of the
-// refactor is visible without expanding the scope of issue #1.
+// Notion users come in two variants ("person" and "bot") distinguished by
+// Type. The Person / Bot sub-objects are only populated for the matching
+// variant; both are pointers so an omitted variant is clearly nil rather
+// than a zero-value struct.
+type User struct {
+	Object    string      `json:"object"`
+	ID        string      `json:"id"`
+	Type      string      `json:"type,omitempty"`
+	Name      string      `json:"name,omitempty"`
+	AvatarURL string      `json:"avatar_url,omitempty"`
+	Person    *UserPerson `json:"person,omitempty"`
+	Bot       *UserBot    `json:"bot,omitempty"`
+}
+
+// UserPerson is the Notion person-variant sub-object.
+type UserPerson struct {
+	Email string `json:"email,omitempty"`
+}
+
+// UserBot is the Notion bot-variant sub-object. Owner identifies the
+// integration or workspace that owns the bot.
+type UserBot struct {
+	Owner         *UserBotOwner `json:"owner,omitempty"`
+	WorkspaceName string        `json:"workspace_name,omitempty"`
+}
+
+// UserBotOwner is the owner sub-object on a bot user.
+type UserBotOwner struct {
+	Type      string `json:"type,omitempty"`
+	Workspace bool   `json:"workspace,omitempty"`
+}
+
+// UserList is a single page of users as returned by GET /v1/users.
+type UserList struct {
+	Object     string `json:"object"`
+	Results    []User `json:"results"`
+	NextCursor string `json:"next_cursor"`
+	HasMore    bool   `json:"has_more"`
+	Type       string `json:"type,omitempty"`
+}
+
+// UserClient is the typed resource client for the Notion users API.
 type UserClient struct {
 	c *Client
 }
@@ -16,4 +62,85 @@ type UserClient struct {
 // NewUserClient wraps a *Client with user-resource methods.
 func NewUserClient(c *Client) *UserClient {
 	return &UserClient{c: c}
+}
+
+// ListPage fetches a single page of users. Pass an empty cursor for the
+// first page; subsequent calls should pass the NextCursor returned by the
+// previous page.
+func (u *UserClient) ListPage(ctx context.Context, cursor string) (*UserList, error) {
+	path := "/users"
+	if cursor != "" {
+		path += "?start_cursor=" + url.QueryEscape(cursor)
+	}
+	req, err := u.c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	var list UserList
+	if err := decodeInto(resp, &list); err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	return &list, nil
+}
+
+// List fetches every user visible to the integration, walking pagination
+// internally. Returns an empty slice (never nil) when the workspace has no
+// users.
+func (u *UserClient) List(ctx context.Context) ([]User, error) {
+	results := make([]User, 0)
+	cursor := ""
+	for {
+		page, err := u.ListPage(ctx, cursor)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, page.Results...)
+		if !page.HasMore || page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	return results, nil
+}
+
+// Get retrieves a single user by id.
+func (u *UserClient) Get(ctx context.Context, id string) (*User, error) {
+	if id == "" {
+		return nil, fmt.Errorf("get user: id is required")
+	}
+	req, err := u.c.newRequest(ctx, http.MethodGet, "/users/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	var user User
+	if err := decodeInto(resp, &user); err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	return &user, nil
+}
+
+// Me returns the bot user associated with the integration token in use.
+// Corresponds to GET /v1/users/me.
+func (u *UserClient) Me(ctx context.Context) (*User, error) {
+	req, err := u.c.newRequest(ctx, http.MethodGet, "/users/me", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get self: %w", err)
+	}
+	var user User
+	if err := decodeInto(resp, &user); err != nil {
+		return nil, fmt.Errorf("get self: %w", err)
+	}
+	return &user, nil
 }

--- a/utils/users_test.go
+++ b/utils/users_test.go
@@ -1,0 +1,281 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newUsersMock returns an httptest server that answers the /v1/users
+// endpoints the UserClient hits. Behavior is keyed off of the request
+// path and, for the list endpoint, the start_cursor query parameter so
+// pagination can be exercised deterministically.
+func newUsersMock(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	writeJSON := func(w http.ResponseWriter, v interface{}) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// /v1/users list endpoint
+		case r.Method == http.MethodGet && r.URL.Path == "/users":
+			cursor := r.URL.Query().Get("start_cursor")
+			page := r.URL.Query().Get("page")
+			// The "page" query param lets a test opt into pagination
+			// without having to re-encode fixtures for every case.
+			switch page {
+			case "empty":
+				writeJSON(w, UserList{Object: "list", Results: []User{}})
+			case "paginated":
+				if cursor == "cursor-1" {
+					writeJSON(w, UserList{
+						Object:  "list",
+						Results: []User{{Object: "user", ID: "u3", Type: "bot", Name: "Integration", Bot: &UserBot{WorkspaceName: "Acme"}}},
+					})
+					return
+				}
+				writeJSON(w, UserList{
+					Object: "list",
+					Results: []User{
+						{Object: "user", ID: "u1", Type: "person", Name: "Ada", Person: &UserPerson{Email: "ada@example.com"}},
+						{Object: "user", ID: "u2", Type: "person", Name: "Grace", Person: &UserPerson{Email: "grace@example.com"}},
+					},
+					HasMore:    true,
+					NextCursor: "cursor-1",
+				})
+			default:
+				// Default: single-page listing with one user.
+				writeJSON(w, UserList{
+					Object:  "list",
+					Results: []User{{Object: "user", ID: "u1", Type: "person", Name: "Ada", Person: &UserPerson{Email: "ada@example.com"}}},
+				})
+			}
+
+		// /v1/users/me
+		case r.Method == http.MethodGet && r.URL.Path == "/users/me":
+			writeJSON(w, User{Object: "user", ID: "bot-1", Type: "bot", Name: "CLI bot", Bot: &UserBot{WorkspaceName: "Acme"}})
+
+		// /v1/users/{id} — match by exact suffix rather than prefix so the
+		// 404 path is easy to exercise.
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/"):
+			id := strings.TrimPrefix(r.URL.Path, "/users/")
+			if id == "u1" {
+				writeJSON(w, User{Object: "user", ID: "u1", Type: "person", Name: "Ada", Person: &UserPerson{Email: "ada@example.com"}})
+				return
+			}
+			http.Error(w, `{"object":"error","code":"object_not_found"}`, http.StatusNotFound)
+
+		default:
+			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+		}
+	}))
+}
+
+// newUserClient builds a UserClient pointed at the given httptest server.
+func newUserClient(srv *httptest.Server) *UserClient {
+	return NewUserClient(NewClient("test-key", WithBaseURL(srv.URL)))
+}
+
+// pagedUsersBaseURL lets a test request a specific fixture by appending
+// a synthetic ?page= query parameter that the mock server reads. This
+// is simpler than mutating WithBaseURL per-case.
+func pagedUsersBaseURL(srv *httptest.Server, page string) string {
+	return srv.URL + "?page=" + page
+}
+
+// TestList_Empty exercises the pagination-walk on an empty
+// workspace. The returned slice must be non-nil so downstream JSON
+// callers emit [] rather than null.
+func TestList_Empty(t *testing.T) {
+	srv := newUsersMock(t)
+	defer srv.Close()
+
+	// Wire up a *Client whose base URL appends ?page=empty to every
+	// request path. We do this by constructing a dedicated mock for
+	// this test with the empty branch pinned; reusing the existing
+	// mock via query would require rewriting paths, which is brittle.
+	emptySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(UserList{Object: "list", Results: []User{}})
+	}))
+	defer emptySrv.Close()
+
+	client := NewUserClient(NewClient("test-key", WithBaseURL(emptySrv.URL)))
+	got, err := client.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got == nil {
+		t.Fatal("List returned nil slice; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d want=0", len(got))
+	}
+}
+
+// TestList_SinglePage covers the non-paginated happy path.
+func TestList_SinglePage(t *testing.T) {
+	srv := newUsersMock(t)
+	defer srv.Close()
+
+	client := newUserClient(srv)
+	got, err := client.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 user, got %d", len(got))
+	}
+	if got[0].ID != "u1" || got[0].Type != "person" || got[0].Person == nil || got[0].Person.Email != "ada@example.com" {
+		t.Errorf("unexpected user: %+v", got[0])
+	}
+}
+
+// TestList_Paginated asserts the client walks multiple pages
+// and concatenates the results in order.
+func TestList_Paginated(t *testing.T) {
+	// Mock that dispatches on start_cursor explicitly.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		cursor := r.URL.Query().Get("start_cursor")
+		if cursor == "cursor-1" {
+			_ = enc.Encode(UserList{
+				Object:  "list",
+				Results: []User{{Object: "user", ID: "u3", Type: "bot", Name: "Integration", Bot: &UserBot{WorkspaceName: "Acme"}}},
+			})
+			return
+		}
+		_ = enc.Encode(UserList{
+			Object: "list",
+			Results: []User{
+				{Object: "user", ID: "u1", Type: "person", Name: "Ada"},
+				{Object: "user", ID: "u2", Type: "person", Name: "Grace"},
+			},
+			HasMore:    true,
+			NextCursor: "cursor-1",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewUserClient(NewClient("test-key", WithBaseURL(srv.URL)))
+	got, err := client.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 users (2 + 1), got %d", len(got))
+	}
+	wantIDs := []string{"u1", "u2", "u3"}
+	for i, id := range wantIDs {
+		if got[i].ID != id {
+			t.Errorf("got[%d].ID=%q want=%q", i, got[i].ID, id)
+		}
+	}
+}
+
+// TestListPage_CursorEncoded asserts ListPage forwards the
+// cursor verbatim on the wire (URL-encoded).
+func TestListPage_CursorEncoded(t *testing.T) {
+	var gotCursor string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCursor = r.URL.Query().Get("start_cursor")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(UserList{Object: "list", Results: []User{}})
+	}))
+	defer srv.Close()
+
+	client := NewUserClient(NewClient("test-key", WithBaseURL(srv.URL)))
+	if _, err := client.ListPage(context.Background(), "abc xyz"); err != nil {
+		t.Fatalf("ListPage: %v", err)
+	}
+	if gotCursor != "abc xyz" {
+		t.Errorf("gotCursor=%q want=%q", gotCursor, "abc xyz")
+	}
+}
+
+// TestGet_Happy covers the /v1/users/{id} happy path.
+func TestGet_Happy(t *testing.T) {
+	srv := newUsersMock(t)
+	defer srv.Close()
+
+	client := newUserClient(srv)
+	got, err := client.Get(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != "u1" {
+		t.Errorf("ID=%q want=u1", got.ID)
+	}
+	if got.Person == nil || got.Person.Email != "ada@example.com" {
+		t.Errorf("unexpected Person: %+v", got.Person)
+	}
+}
+
+// TestGet_NotFound verifies a 404 produces an error rather
+// than a panic or nil user.
+func TestGet_NotFound(t *testing.T) {
+	srv := newUsersMock(t)
+	defer srv.Close()
+
+	client := newUserClient(srv)
+	got, err := client.Get(context.Background(), "does-not-exist")
+	if err == nil {
+		t.Fatalf("Get: want error, got user %+v", got)
+	}
+	if got != nil {
+		t.Errorf("Get: want nil user on error, got %+v", got)
+	}
+}
+
+// TestGet_RequiresID rejects an empty id before hitting the
+// network.
+func TestGet_RequiresID(t *testing.T) {
+	client := NewUserClient(NewClient("test-key", WithBaseURL("http://127.0.0.1:0")))
+	if _, err := client.Get(context.Background(), ""); err == nil {
+		t.Fatal("Get(\"\"): want error, got nil")
+	}
+}
+
+// TestMe_Happy covers /v1/users/me and asserts the bot variant is
+// decoded into the Bot pointer.
+func TestMe_Happy(t *testing.T) {
+	srv := newUsersMock(t)
+	defer srv.Close()
+
+	client := newUserClient(srv)
+	got, err := client.Me(context.Background())
+	if err != nil {
+		t.Fatalf("Me: %v", err)
+	}
+	if got.Type != "bot" {
+		t.Errorf("Type=%q want=bot", got.Type)
+	}
+	if got.Bot == nil || got.Bot.WorkspaceName != "Acme" {
+		t.Errorf("unexpected Bot: %+v", got.Bot)
+	}
+}
+
+// TestMe_HTTPError asserts a non-2xx response from /users/me
+// is surfaced as an error.
+func TestMe_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"object":"error"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	client := NewUserClient(NewClient("test-key", WithBaseURL(srv.URL)))
+	if _, err := client.Me(context.Background()); err == nil {
+		t.Fatal("Me: want error on 401, got nil")
+	}
+}
+
+// Keep the unused helper referenced so go vet doesn't complain during
+// maintenance when a caller is removed.
+var _ = pagedUsersBaseURL

--- a/utils/users_test.go
+++ b/utils/users_test.go
@@ -82,13 +82,6 @@ func newUserClient(srv *httptest.Server) *UserClient {
 	return NewUserClient(NewClient("test-key", WithBaseURL(srv.URL)))
 }
 
-// pagedUsersBaseURL lets a test request a specific fixture by appending
-// a synthetic ?page= query parameter that the mock server reads. This
-// is simpler than mutating WithBaseURL per-case.
-func pagedUsersBaseURL(srv *httptest.Server, page string) string {
-	return srv.URL + "?page=" + page
-}
-
 // TestList_Empty exercises the pagination-walk on an empty
 // workspace. The returned slice must be non-nil so downstream JSON
 // callers emit [] rather than null.
@@ -275,7 +268,3 @@ func TestMe_HTTPError(t *testing.T) {
 		t.Fatal("Me: want error on 401, got nil")
 	}
 }
-
-// Keep the unused helper referenced so go vet doesn't complain during
-// maintenance when a caller is removed.
-var _ = pagedUsersBaseURL


### PR DESCRIPTION
## Summary

Implements the user-facing scope of [#9](https://github.com/jordan8037310/notion-cli-go/issues/9):

- `utils.UserClient` with `List` (walks pagination), `ListPage` (single-page), `Get(id)`, and `Me()` against the pinned Notion-Version 2022-06-28. Typed `User`, `UserPerson`, `UserBot`, and `UserList` for both person and bot variants.
- `utils.TeamClient` as a typed stub surfacing `ErrTeamsNotSupported`; see rationale below.
- `notioncli users {list,get,whoami}` with `--json` on every subcommand.
- `notioncli teams list` dispatches the stub and exits 1 with a clear message.

## Teams stub rationale

Notion's `2022-06-28` API version does not expose a teams endpoint — MCP's `notion-get-teams` tool is implemented against a newer API surface. Rather than silently bump `NotionAPIVersion` in this PR (which would conflict with the foundation invariant and pre-empt scope owned by [#11](https://github.com/jordan8037310/notion-cli-go/issues/11)), `TeamClient.List` / `ListPage` return a typed `ErrTeamsNotSupported` that references issue #11 in its message so operators can find the tracking work. The client shape is stable; #11 will flip the implementation without a breaking change.

## Test evidence

- `utils/users_test.go`: list (empty / single page / paginated), listpage cursor encoding, get (happy / 404 / empty-id), me (happy / 401).
- `utils/teams_test.go`: stub returns `errors.Is(err, ErrTeamsNotSupported)` for `List` and `ListPage`; error message mentions `2022-06-28` and `#11`.
- `cmd/users_test.go`: subcommand registration, `--json` flag parsing, `ExactArgs(1)` for `get`, happy-path dispatch per subcommand with mock HTTP.
- `cmd/teams_test.go`: subcommand registration + dispatch exits 1 cleanly through the `osExit` shim.

## Coverage delta

Baseline (`feature/foundation` @ `e6b3b3e`):

```
utils: 78.8%
cmd:   68.9%
total: 79.9%
```

After this PR:

```
utils: 79.5%
cmd:   65.5%    (added surface; tests only cover dispatch + flag parsing by design per go-unit-tester.md)
total: 80.5%
```

Gate: 70%. `make ci` green locally: `fmt-check vet test-race cover check-test-gaps` all pass.

## Test plan

- [ ] `make ci` green in CI
- [ ] `notioncli users list --json` against a real workspace returns a JSON array
- [ ] `notioncli users whoami` matches the integration's registered bot
- [ ] `notioncli teams list` exits non-zero with the `#11` reference message