### PR TITLE
feat: views commands with #11-pending stub (closes #7)

### DIFF
--- a/cmd/views.go
+++ b/cmd/views.go
@@ -1,0 +1,208 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// Flag vars for the views subcommands. Package-level mirrors the pattern
+// used by pages.go/blocks.go so cobra can bind them in init().
+var (
+	viewsCreateName       string
+	viewsCreateType       string
+	viewsCreateConfigFile string
+	viewsUpdateName       string
+	viewsUpdateConfigFile string
+)
+
+// viewsCmd is the parent command for view-related operations. The views
+// endpoints are not available on the pinned Notion-Version (2022-06-28);
+// see issue #11 for the version bump that will enable the real
+// implementation. Until then every subcommand validates its input and
+// then surfaces utils.ErrViewsNotSupported so callers can branch on it
+// via errors.Is.
+var viewsCmd = &cobra.Command{
+	Use:   "views",
+	Short: "Manage Notion database views (pending API version bump)",
+	Long: `Create and update Notion database views.
+
+The views / data-sources endpoints require a newer Notion-Version than
+the one this CLI currently pins (2022-06-28). Issue #11 tracks the
+version bump that will enable the real implementation. Until then each
+subcommand validates its arguments and returns a clear "views not
+supported" error so shell callers see a non-zero exit code and can
+retry once #11 lands without changing their invocations.
+
+Examples (usable once #11 ships):
+  notioncli views create <database-id> --name "Backlog" --type board
+  notioncli views create <database-id> --name "Q2" --type timeline --config-json q2.json
+  notioncli views update <view-id> --name "Renamed"
+  notioncli views update <view-id> --config-json new-config.json`,
+}
+
+// newViewClient builds a ViewClient using the CLI's standard config
+// loading so every subcommand shares identical client construction.
+// Returns utils.ErrMissingAPIKey (wrapped) when NOTION_API_KEY resolves
+// empty so callers see a configuration error instead of a downstream
+// 401 once #11 lands.
+func newViewClient() (*utils.ViewClient, error) {
+	apiKey, _ := utils.SetAPIConfig()
+	if apiKey == "" {
+		return nil, fmt.Errorf("views client: %w", utils.ErrMissingAPIKey)
+	}
+	c := utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))
+	return utils.NewViewClient(c), nil
+}
+
+// readConfigJSON reads a JSON config file from disk and decodes it into
+// a loosely-typed map. An empty path returns (nil, nil) so callers can
+// use the helper unconditionally without branching on the optional flag.
+func readConfigJSON(path string) (map[string]interface{}, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open config-json: %w", err)
+	}
+	defer f.Close()
+	raw, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read config-json: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("config-json %q is empty", path)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("parse config-json: %w", err)
+	}
+	return out, nil
+}
+
+// viewsCreateCmd creates a new view on the given database. The command
+// is wired with RunE so the returned error drives cobra's exit code —
+// the shell sees a non-zero status without any call to os.Exit from
+// this file. Today the final error is always ErrViewsNotSupported
+// (except for validation / config-file errors which short-circuit it).
+var viewsCreateCmd = &cobra.Command{
+	Use:   "create <database-id>",
+	Short: "Create a new view on a database",
+	Long: `Create a new view on the given database.
+
+The --type flag must be one of: table, board, list, gallery, calendar,
+timeline. The optional --config-json flag points at a JSON file whose
+contents are forwarded verbatim as the view's configuration payload.
+
+Note: views are not supported on the pinned Notion-Version 2022-06-28;
+see issue #11 for the tracking bump.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if viewsCreateName == "" {
+			return fmt.Errorf("create view: --name is required")
+		}
+		if viewsCreateType == "" {
+			return fmt.Errorf("create view: --type is required")
+		}
+		config, err := readConfigJSON(viewsCreateConfigFile)
+		if err != nil {
+			return err
+		}
+		vc, err := newViewClient()
+		if err != nil {
+			return err
+		}
+		view, err := vc.Create(context.Background(), utils.CreateViewRequest{
+			DatabaseID: args[0],
+			Name:       viewsCreateName,
+			Type:       viewsCreateType,
+			Config:     config,
+		})
+		if err != nil {
+			return fmt.Errorf("create view: %w", err)
+		}
+		printView(cmd.OutOrStdout(), view)
+		return nil
+	},
+}
+
+// viewsUpdateCmd patches an existing view by ID.
+var viewsUpdateCmd = &cobra.Command{
+	Use:   "update <view-id>",
+	Short: "Update an existing view",
+	Long: `Update an existing view's name and/or configuration.
+
+At least one of --name or --config-json must be provided. The
+--config-json flag points at a JSON file whose contents are forwarded
+verbatim as the view's configuration payload.
+
+Note: views are not supported on the pinned Notion-Version 2022-06-28;
+see issue #11 for the tracking bump.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if viewsUpdateName == "" && viewsUpdateConfigFile == "" {
+			return fmt.Errorf("update view: at least one of --name or --config-json is required")
+		}
+		config, err := readConfigJSON(viewsUpdateConfigFile)
+		if err != nil {
+			return err
+		}
+		vc, err := newViewClient()
+		if err != nil {
+			return err
+		}
+		view, err := vc.Update(context.Background(), args[0], utils.UpdateViewRequest{
+			Name:   viewsUpdateName,
+			Config: config,
+		})
+		if err != nil {
+			return fmt.Errorf("update view: %w", err)
+		}
+		printView(cmd.OutOrStdout(), view)
+		return nil
+	},
+}
+
+// printView writes a human-readable JSON blob for the given View. This
+// is the v1 output format; a proper --json vs table split will land
+// with the wider --json rollout on the roadmap. Nil views are a no-op
+// so the caller can unconditionally invoke this after a successful API
+// call without a pre-check.
+func printView(w io.Writer, view *utils.View) {
+	if view == nil {
+		return
+	}
+	if w == nil {
+		w = os.Stdout
+	}
+	b, err := json.MarshalIndent(view, "", "  ")
+	if err != nil {
+		fmt.Fprintf(w, "Error formatting view: %v\n", err)
+		return
+	}
+	fmt.Fprintln(w, string(b))
+}
+
+func init() {
+	rootCmd.AddCommand(viewsCmd)
+	viewsCmd.AddCommand(viewsCreateCmd)
+	viewsCmd.AddCommand(viewsUpdateCmd)
+
+	viewsCreateCmd.Flags().StringVar(&viewsCreateName, "name", "", "Display name for the new view (required)")
+	viewsCreateCmd.Flags().StringVar(&viewsCreateType, "type", "", "View type: table|board|list|gallery|calendar|timeline (required)")
+	viewsCreateCmd.Flags().StringVar(&viewsCreateConfigFile, "config-json", "", "Path to a JSON file with extra view configuration")
+
+	viewsUpdateCmd.Flags().StringVar(&viewsUpdateName, "name", "", "New display name for the view")
+	viewsUpdateCmd.Flags().StringVar(&viewsUpdateConfigFile, "config-json", "", "Path to a JSON file with updated view configuration")
+}

--- a/cmd/views.go
+++ b/cmd/views.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"notioncli/utils"
 
@@ -220,7 +221,9 @@ func init() {
 	viewsCmd.AddCommand(viewsUpdateCmd)
 
 	viewsCreateCmd.Flags().StringVar(&viewsCreateName, "name", "", "Display name for the new view (required)")
-	viewsCreateCmd.Flags().StringVar(&viewsCreateType, "type", "", "View type: table|board|list|gallery|calendar|timeline (required)")
+	// The suffix is generated from utils.ValidViewTypes so the help
+	// text can't drift from the validator's accepted set.
+	viewsCreateCmd.Flags().StringVar(&viewsCreateType, "type", "", "View type: "+strings.Join(utils.ValidViewTypes, "|")+" (required)")
 	viewsCreateCmd.Flags().StringVar(&viewsCreateConfigFile, "config-json", "", "Path to a JSON file with extra view configuration")
 
 	viewsUpdateCmd.Flags().StringVar(&viewsUpdateName, "name", "", "New display name for the view")

--- a/cmd/views.go
+++ b/cmd/views.go
@@ -65,10 +65,14 @@ func newViewClient() (*utils.ViewClient, error) {
 	return utils.NewViewClient(c), nil
 }
 
-// readConfigJSON reads a JSON config file from disk and decodes it into
-// a loosely-typed map. An empty path returns (nil, nil) so callers can
-// use the helper unconditionally without branching on the optional flag.
-func readConfigJSON(path string) (map[string]interface{}, error) {
+// readConfigJSON reads a JSON config file from disk and returns its
+// bytes as a json.RawMessage so the view-configuration payload passes
+// through unchanged (preserving key order and avoiding float64 coercion
+// of numeric IDs). An empty path returns (nil, nil) so callers can use
+// the helper unconditionally without branching on the optional flag.
+// The bytes are validated as JSON syntax so a malformed file surfaces a
+// parse error at the CLI layer rather than after the wire call.
+func readConfigJSON(path string) (json.RawMessage, error) {
 	if path == "" {
 		return nil, nil
 	}
@@ -84,11 +88,10 @@ func readConfigJSON(path string) (map[string]interface{}, error) {
 	if len(raw) == 0 {
 		return nil, fmt.Errorf("config-json %q is empty", path)
 	}
-	var out map[string]interface{}
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("parse config-json: %w", err)
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("parse config-json: invalid JSON in %q", path)
 	}
-	return out, nil
+	return json.RawMessage(raw), nil
 }
 
 // viewsCreateCmd creates a new view on the given database. The command

--- a/cmd/views.go
+++ b/cmd/views.go
@@ -119,16 +119,23 @@ see issue #11 for the tracking bump.`,
 		if err != nil {
 			return err
 		}
-		vc, err := newViewClient()
-		if err != nil {
-			return err
-		}
-		view, err := vc.Create(context.Background(), utils.CreateViewRequest{
+		// Validate the request before paying the env/config cost of
+		// building the client so bad input (e.g. --type bogus) surfaces
+		// as an input error rather than behind an auth/config failure.
+		req := utils.CreateViewRequest{
 			DatabaseID: args[0],
 			Name:       viewsCreateName,
 			Type:       viewsCreateType,
 			Config:     config,
-		})
+		}
+		if err := req.Validate(); err != nil {
+			return err
+		}
+		vc, err := newViewClient()
+		if err != nil {
+			return err
+		}
+		view, err := vc.Create(context.Background(), req)
 		if err != nil {
 			return fmt.Errorf("create view: %w", err)
 		}
@@ -158,14 +165,24 @@ see issue #11 for the tracking bump.`,
 		if err != nil {
 			return err
 		}
+		// Validate the request (and the id) before building the client
+		// so bad input surfaces as an input error rather than behind an
+		// auth/config failure.
+		if args[0] == "" {
+			return fmt.Errorf("update view: id is required")
+		}
+		req := utils.UpdateViewRequest{
+			Name:   viewsUpdateName,
+			Config: config,
+		}
+		if err := req.Validate(); err != nil {
+			return err
+		}
 		vc, err := newViewClient()
 		if err != nil {
 			return err
 		}
-		view, err := vc.Update(context.Background(), args[0], utils.UpdateViewRequest{
-			Name:   viewsUpdateName,
-			Config: config,
-		})
+		view, err := vc.Update(context.Background(), args[0], req)
 		if err != nil {
 			return fmt.Errorf("update view: %w", err)
 		}

--- a/cmd/views_test.go
+++ b/cmd/views_test.go
@@ -38,6 +38,22 @@ func findViewsSubcommand(t *testing.T, name string) *cobra.Command {
 	return nil
 }
 
+// TestViews_CreateTypeFlagHelpFromValidViewTypes asserts the --type
+// flag's help text lists every value in utils.ValidViewTypes so the
+// help can't drift if the validator's accepted set changes.
+func TestViews_CreateTypeFlagHelpFromValidViewTypes(t *testing.T) {
+	sub := findViewsSubcommand(t, "create")
+	typeFlag := sub.Flags().Lookup("type")
+	if typeFlag == nil {
+		t.Fatal("--type flag not registered on views create")
+	}
+	for _, vt := range utils.ValidViewTypes {
+		if !strings.Contains(typeFlag.Usage, vt) {
+			t.Errorf("--type help %q missing ValidViewTypes entry %q", typeFlag.Usage, vt)
+		}
+	}
+}
+
 // TestViews_CmdRegistered verifies `views` is a top-level command with
 // `create` and `update` subcommands.
 func TestViews_CmdRegistered(t *testing.T) {

--- a/cmd/views_test.go
+++ b/cmd/views_test.go
@@ -313,11 +313,40 @@ func TestViews_Update_WithConfigJSON(t *testing.T) {
 	}
 }
 
-// TestViews_MissingAPIKey asserts that newViewClient returns
-// ErrMissingAPIKey (wrapped) when NOTION_API_KEY resolves empty rather
-// than silently building a Client that would later 401 on the real #11
-// implementation.
-func TestViews_MissingAPIKey(t *testing.T) {
+// TestViews_Create_ValidationBeforeClientBuild asserts that a bad
+// --type value surfaces the request-validation error and does NOT leak
+// the ErrMissingAPIKey that newViewClient would otherwise return when
+// the env is blank. Ordering: validate request first, then build client.
+func TestViews_Create_ValidationBeforeClientBuild(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	// Force the client-build path to fail if it runs, so we can prove
+	// validation ran first by observing the precise validation error
+	// instead of ErrMissingAPIKey.
+	t.Setenv("NOTION_API_KEY", "")
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n", "--type", "bogus"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if errors.Is(err, utils.ErrMissingAPIKey) {
+		t.Errorf("client build ran before validation: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid type") {
+		t.Errorf("error = %q; want substring %q", err.Error(), "invalid type")
+	}
+}
+
+// TestViews_NewViewClient_MissingAPIKey asserts that newViewClient
+// returns ErrMissingAPIKey (wrapped) when NOTION_API_KEY resolves empty
+// rather than silently building a Client that would later 401 on the
+// real #11 implementation.
+func TestViews_NewViewClient_MissingAPIKey(t *testing.T) {
 	_ = withCmdEnv(t)
 	resetViewsFlags()
 	resetRootCmdArgs()

--- a/cmd/views_test.go
+++ b/cmd/views_test.go
@@ -378,7 +378,8 @@ func TestViews_ErrExposedViaUtils(t *testing.T) {
 
 // TestViews_ReadConfigJSON covers readConfigJSON directly so the helper
 // has coverage independent of the RunE paths. Exercises the empty-path
-// shortcut and the empty-file rejection.
+// shortcut, the empty-file rejection, and the round-trip-fidelity goal
+// of json.RawMessage (bytes preserved verbatim, numbers not coerced).
 func TestViews_ReadConfigJSON(t *testing.T) {
 	if got, err := readConfigJSON(""); err != nil || got != nil {
 		t.Errorf("readConfigJSON(\"\") = (%v, %v); want (nil, nil)", got, err)
@@ -394,15 +395,16 @@ func TestViews_ReadConfigJSON(t *testing.T) {
 	}
 
 	good := filepath.Join(dir, "good.json")
-	if err := os.WriteFile(good, []byte(`{"a":1}`), 0o600); err != nil {
+	payload := []byte(`{"a":1,"big":12345678901234567890}`)
+	if err := os.WriteFile(good, payload, 0o600); err != nil {
 		t.Fatalf("write good: %v", err)
 	}
 	got, err := readConfigJSON(good)
 	if err != nil {
 		t.Fatalf("readConfigJSON(good) err = %v", err)
 	}
-	if got["a"] != float64(1) { // JSON numbers decode to float64
-		t.Errorf("readConfigJSON(good)[a] = %v, want 1", got["a"])
+	if string(got) != string(payload) {
+		t.Errorf("readConfigJSON(good) = %q; want bytes preserved %q", string(got), string(payload))
 	}
 }
 

--- a/cmd/views_test.go
+++ b/cmd/views_test.go
@@ -1,0 +1,396 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"notioncli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// resetViewsFlags restores package-level view flag vars to their zero
+// values between tests. cobra persists flag state on the shared command
+// instances, so tests that share rootCmd must reset between runs.
+func resetViewsFlags() {
+	viewsCreateName = ""
+	viewsCreateType = ""
+	viewsCreateConfigFile = ""
+	viewsUpdateName = ""
+	viewsUpdateConfigFile = ""
+}
+
+// findViewsSubcommand walks the views command's children and returns
+// the child matching name, or fails the test.
+func findViewsSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	viewsC := findTopLevelCmd(t, "views")
+	for _, c := range viewsC.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("views subcommand %q not found", name)
+	return nil
+}
+
+// TestViews_CmdRegistered verifies `views` is a top-level command with
+// `create` and `update` subcommands.
+func TestViews_CmdRegistered(t *testing.T) {
+	viewsC := findTopLevelCmd(t, "views")
+	want := map[string]bool{"create": false, "update": false}
+	for _, c := range viewsC.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("views subcommand %q not registered", name)
+		}
+	}
+}
+
+// TestViews_SubcommandsValid asserts each subcommand is a non-empty
+// *cobra.Command (catches nil-pointer registration bugs).
+func TestViews_SubcommandsValid(t *testing.T) {
+	for _, name := range []string{"create", "update"} {
+		sub := findViewsSubcommand(t, name)
+		if sub.Use == "" {
+			t.Errorf("views %s: Use field is empty", name)
+		}
+		if sub.RunE == nil {
+			t.Errorf("views %s: RunE is nil (expected for proper exit-code propagation)", name)
+		}
+	}
+}
+
+// TestViews_Create_DispatchSurfacesStub runs `views create ...` and
+// asserts that rootCmd.Execute returns a non-nil error — proving the
+// stub's ErrViewsNotSupported propagates up through cobra so shell
+// callers see a non-zero exit code.
+func TestViews_Create_DispatchSurfacesStub(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "My View", "--type", "table"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("views create: expected non-nil error from stub, got nil")
+	}
+	if !errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("views create: want errors.Is ErrViewsNotSupported, got %v", err)
+	}
+}
+
+// TestViews_Create_MissingName asserts the --name flag is required and
+// that RunE returns a non-nil error (before ever touching the stub).
+func TestViews_Create_MissingName(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--type", "table"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --name missing, got nil")
+	}
+	if errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("expected flag-validation error, got stub sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--name") {
+		t.Errorf("error = %q; want substring %q", err.Error(), "--name")
+	}
+}
+
+// TestViews_Create_MissingType asserts the --type flag is required.
+func TestViews_Create_MissingType(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --type missing, got nil")
+	}
+	if errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("expected flag-validation error, got stub sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--type") {
+		t.Errorf("error = %q; want substring %q", err.Error(), "--type")
+	}
+}
+
+// TestViews_Create_WrongArgCount asserts cobra enforces exactly one
+// positional argument (the database-id).
+func TestViews_Create_WrongArgCount(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "create", "--name", "n", "--type", "table"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when database-id missing, got nil")
+	}
+}
+
+// TestViews_Create_AllTypesDispatchStub cycles through every supported
+// --type value and verifies each dispatches to the stub (vs being
+// rejected as invalid at the CLI layer). Guards against silently
+// dropping a supported type during refactors.
+func TestViews_Create_AllTypesDispatchStub(t *testing.T) {
+	for _, vt := range utils.ValidViewTypes {
+		t.Run(vt, func(t *testing.T) {
+			_ = withCmdEnv(t)
+			resetViewsFlags()
+			resetRootCmdArgs()
+
+			rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n", "--type", vt})
+			rootCmd.SilenceUsage = true
+			rootCmd.SilenceErrors = true
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("views create --type %s: expected error, got nil", vt)
+			}
+			if !errors.Is(err, utils.ErrViewsNotSupported) {
+				t.Errorf("views create --type %s: want ErrViewsNotSupported, got %v", vt, err)
+			}
+		})
+	}
+}
+
+// TestViews_Create_WithConfigJSON asserts --config-json is read from
+// disk and forwarded into the request (still dispatching to the stub
+// today).
+func TestViews_Create_WithConfigJSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(`{"sort":"asc"}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n", "--type", "table", "--config-json", path})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected stub error, got nil")
+	}
+	if !errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("want ErrViewsNotSupported, got %v", err)
+	}
+}
+
+// TestViews_Create_BadConfigJSON asserts a malformed JSON file produces
+// a parse error ahead of the stub.
+func TestViews_Create_BadConfigJSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte(`{not json`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n", "--type", "table", "--config-json", path})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("parse error swallowed by stub: %v", err)
+	}
+	if !strings.Contains(err.Error(), "config-json") {
+		t.Errorf("error = %q; want substring %q", err.Error(), "config-json")
+	}
+}
+
+// TestViews_Create_MissingConfigJSONFile asserts a non-existent config
+// file produces an open error ahead of the stub.
+func TestViews_Create_MissingConfigJSONFile(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n", "--type", "table", "--config-json", "/does/not/exist.json"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected open error, got nil")
+	}
+	if errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("open error swallowed by stub: %v", err)
+	}
+}
+
+// TestViews_Update_DispatchSurfacesStub runs `views update <id> --name`
+// and asserts the stub error propagates.
+func TestViews_Update_DispatchSurfacesStub(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "update", "viewID", "--name", "Renamed"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("views update: expected non-nil error from stub, got nil")
+	}
+	if !errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("views update: want errors.Is ErrViewsNotSupported, got %v", err)
+	}
+}
+
+// TestViews_Update_NoFlags asserts at least one mutation flag is
+// required. The error must precede the stub.
+func TestViews_Update_NoFlags(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"views", "update", "viewID"})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no mutation flags, got nil")
+	}
+	if errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("expected flag-validation error, got stub sentinel: %v", err)
+	}
+}
+
+// TestViews_Update_WithConfigJSON asserts config-only updates are
+// accepted and dispatched to the stub.
+func TestViews_Update_WithConfigJSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(`{"filter":{"status":"done"}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"views", "update", "viewID", "--config-json", path})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected stub error, got nil")
+	}
+	if !errors.Is(err, utils.ErrViewsNotSupported) {
+		t.Errorf("want ErrViewsNotSupported, got %v", err)
+	}
+}
+
+// TestViews_MissingAPIKey asserts that newViewClient returns
+// ErrMissingAPIKey (wrapped) when NOTION_API_KEY resolves empty rather
+// than silently building a Client that would later 401 on the real #11
+// implementation.
+func TestViews_MissingAPIKey(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetViewsFlags()
+	resetRootCmdArgs()
+
+	// Blank out the API key after the usual cmd env has been set up.
+	// withCmdEnv's .env file is empty so the Setenv below wins.
+	t.Setenv("NOTION_API_KEY", "")
+
+	vc, err := newViewClient()
+	if err == nil {
+		t.Fatal("expected error when NOTION_API_KEY empty, got nil")
+	}
+	if vc != nil {
+		t.Errorf("expected nil client on error, got %+v", vc)
+	}
+	if !errors.Is(err, utils.ErrMissingAPIKey) {
+		t.Errorf("expected errors.Is ErrMissingAPIKey, got %v", err)
+	}
+}
+
+// TestViews_ErrExposedViaUtils is a belt-and-braces check that the cmd
+// layer is paired with the utils stub so a future refactor can't
+// silently drop the error.
+func TestViews_ErrExposedViaUtils(t *testing.T) {
+	if utils.ErrViewsNotSupported == nil {
+		t.Fatal("utils.ErrViewsNotSupported must be non-nil for views commands to surface a stable error")
+	}
+}
+
+// TestViews_ReadConfigJSON covers readConfigJSON directly so the helper
+// has coverage independent of the RunE paths. Exercises the empty-path
+// shortcut and the empty-file rejection.
+func TestViews_ReadConfigJSON(t *testing.T) {
+	if got, err := readConfigJSON(""); err != nil || got != nil {
+		t.Errorf("readConfigJSON(\"\") = (%v, %v); want (nil, nil)", got, err)
+	}
+
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(empty, []byte{}, 0o600); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	if got, err := readConfigJSON(empty); err == nil {
+		t.Errorf("readConfigJSON(empty) = (%v, nil); want error", got)
+	}
+
+	good := filepath.Join(dir, "good.json")
+	if err := os.WriteFile(good, []byte(`{"a":1}`), 0o600); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+	got, err := readConfigJSON(good)
+	if err != nil {
+		t.Fatalf("readConfigJSON(good) err = %v", err)
+	}
+	if got["a"] != float64(1) { // JSON numbers decode to float64
+		t.Errorf("readConfigJSON(good)[a] = %v, want 1", got["a"])
+	}
+}
+
+// TestViews_PrintView drives printView to cover both the nil-view and
+// happy-path branches. Writes into a bytes.Buffer so output assertions
+// are deterministic.
+func TestViews_PrintView(t *testing.T) {
+	var buf bytes.Buffer
+	printView(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("printView(nil) wrote %q; want empty", buf.String())
+	}
+
+	buf.Reset()
+	printView(&buf, &utils.View{Object: "view", ID: "v1", Name: "My View", Type: "table"})
+	out := buf.String()
+	if !strings.Contains(out, "v1") || !strings.Contains(out, "table") {
+		t.Errorf("printView JSON missing expected fields:\n%s", out)
+	}
+}

--- a/utils/views.go
+++ b/utils/views.go
@@ -1,0 +1,154 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrViewsNotSupported is returned by ViewClient methods when the pinned
+// Notion API version does not expose the views / data-sources endpoints.
+// The MCP server's notion-create-view and notion-update-view are backed
+// by a newer Notion API surface than the 2022-06-28 version this CLI
+// currently pins. Issue #11 tracks the version bump that will enable a
+// real implementation; until then this client surfaces a typed error so
+// callers can check for it with errors.Is.
+var ErrViewsNotSupported = errors.New("views are not supported on Notion-Version " + NotionAPIVersion + "; will be enabled by issue #11")
+
+// ValidViewTypes is the closed set of view types accepted by
+// CreateViewRequest.Validate. It mirrors the MCP notion-create-view
+// surface so callers can rely on the same vocabulary once #11 swaps in
+// a real HTTP implementation.
+var ValidViewTypes = []string{"table", "board", "list", "gallery", "calendar", "timeline"}
+
+// View is a placeholder for the Notion view object. The concrete shape
+// depends on a newer Notion API version than the CLI currently pins, so
+// the fields here are deliberately minimal — do not rely on them yet.
+// Config is a loosely-typed map so callers can round-trip arbitrary
+// view-configuration payloads without losing fields once #11 lands.
+type View struct {
+	Object     string                 `json:"object"`
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	DatabaseID string                 `json:"database_id,omitempty"`
+	Config     map[string]interface{} `json:"config,omitempty"`
+}
+
+// CreateViewRequest is the body for a future POST to the views endpoint.
+// DatabaseID and Name are required. Type must be one of ValidViewTypes.
+// Config is an optional free-form payload that the upstream API accepts
+// to override column order, filters, sorts, etc.
+//
+// The field shape is chosen so that issue #11's implementation swap can
+// marshal this struct directly to the Notion API body with nothing more
+// than `json.Marshal`.
+type CreateViewRequest struct {
+	DatabaseID string                 `json:"database_id"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Config     map[string]interface{} `json:"config,omitempty"`
+}
+
+// Validate returns a non-nil error if the request is missing a required
+// field or carries an unknown Type. Validation runs before the stub
+// sentinel so callers always see the most actionable error first (e.g.
+// "empty name" beats "views not supported").
+func (r CreateViewRequest) Validate() error {
+	if r.DatabaseID == "" {
+		return errors.New("create view: database_id is required")
+	}
+	if r.Name == "" {
+		return errors.New("create view: name is required")
+	}
+	if r.Type == "" {
+		return errors.New("create view: type is required")
+	}
+	for _, t := range ValidViewTypes {
+		if r.Type == t {
+			return nil
+		}
+	}
+	return fmt.Errorf("create view: invalid type %q (want one of %v)", r.Type, ValidViewTypes)
+}
+
+// UpdateViewRequest is the body for a future PATCH to the views
+// endpoint. All fields are optional — Validate only rejects the
+// zero-value "nothing to update" case so callers don't silently hit the
+// wire with a no-op.
+type UpdateViewRequest struct {
+	Name   string                 `json:"name,omitempty"`
+	Config map[string]interface{} `json:"config,omitempty"`
+}
+
+// Validate returns a non-nil error when the update request carries no
+// fields at all. This mirrors PATCH semantics: sending an empty body
+// should be an authoring error, not a silent round-trip.
+func (r UpdateViewRequest) Validate() error {
+	if r.Name == "" && len(r.Config) == 0 {
+		return errors.New("update view: at least one of name or config is required")
+	}
+	return nil
+}
+
+// ViewClient is the typed resource client for the Notion views API.
+//
+// The methods currently return ErrViewsNotSupported because the pinned
+// Notion-Version does not expose the views / data-sources endpoints.
+// The client shape is kept stable so issue #11 can flip the
+// implementation without breaking callers — method signatures, request
+// types, and response types will not change.
+type ViewClient struct {
+	c *Client
+}
+
+// NewViewClient wraps a *Client with view-resource methods.
+func NewViewClient(c *Client) *ViewClient {
+	return &ViewClient{c: c}
+}
+
+// checkAuth ensures the underlying Client has a non-empty API key. Every
+// HTTP-calling method on ViewClient calls this before issuing a request
+// so missing-credential errors surface as ErrMissingAPIKey rather than
+// as an opaque 401 from Notion. ErrMissingAPIKey is defined in pages.go
+// and shared across typed resource clients.
+func (v *ViewClient) checkAuth() error {
+	if v == nil || v.c == nil || v.c.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	return nil
+}
+
+// Create would POST a new view under the given database. On the pinned
+// Notion-Version it validates the request and then returns
+// ErrViewsNotSupported. Validation runs first so bad input produces a
+// precise error instead of the sentinel.
+func (v *ViewClient) Create(ctx context.Context, req CreateViewRequest) (*View, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	if err := v.checkAuth(); err != nil {
+		return nil, err
+	}
+	return nil, ErrViewsNotSupported
+}
+
+// Update would PATCH an existing view by ID. On the pinned
+// Notion-Version it validates the request and then returns
+// ErrViewsNotSupported.
+func (v *ViewClient) Update(ctx context.Context, id string, req UpdateViewRequest) (*View, error) {
+	if id == "" {
+		return nil, errors.New("update view: id is required")
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	if err := v.checkAuth(); err != nil {
+		return nil, err
+	}
+	return nil, ErrViewsNotSupported
+}

--- a/utils/views.go
+++ b/utils/views.go
@@ -5,7 +5,9 @@
 package utils
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -28,15 +30,16 @@ var ValidViewTypes = []string{"table", "board", "list", "gallery", "calendar", "
 // View is a placeholder for the Notion view object. The concrete shape
 // depends on a newer Notion API version than the CLI currently pins, so
 // the fields here are deliberately minimal — do not rely on them yet.
-// Config is a loosely-typed map so callers can round-trip arbitrary
-// view-configuration payloads without losing fields once #11 lands.
+// Config is a json.RawMessage so callers can round-trip arbitrary
+// view-configuration payloads byte-for-byte (preserving key order and
+// avoiding the float64 coercion of numeric IDs) once #11 lands.
 type View struct {
-	Object     string                 `json:"object"`
-	ID         string                 `json:"id"`
-	Name       string                 `json:"name,omitempty"`
-	Type       string                 `json:"type,omitempty"`
-	DatabaseID string                 `json:"database_id,omitempty"`
-	Config     map[string]interface{} `json:"config,omitempty"`
+	Object     string          `json:"object"`
+	ID         string          `json:"id"`
+	Name       string          `json:"name,omitempty"`
+	Type       string          `json:"type,omitempty"`
+	DatabaseID string          `json:"database_id,omitempty"`
+	Config     json.RawMessage `json:"config,omitempty"`
 }
 
 // CreateViewRequest is the body for a future POST to the views endpoint.
@@ -48,10 +51,10 @@ type View struct {
 // marshal this struct directly to the Notion API body with nothing more
 // than `json.Marshal`.
 type CreateViewRequest struct {
-	DatabaseID string                 `json:"database_id"`
-	Name       string                 `json:"name"`
-	Type       string                 `json:"type"`
-	Config     map[string]interface{} `json:"config,omitempty"`
+	DatabaseID string          `json:"database_id"`
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Config     json.RawMessage `json:"config,omitempty"`
 }
 
 // Validate returns a non-nil error if the request is missing a required
@@ -81,18 +84,35 @@ func (r CreateViewRequest) Validate() error {
 // zero-value "nothing to update" case so callers don't silently hit the
 // wire with a no-op.
 type UpdateViewRequest struct {
-	Name   string                 `json:"name,omitempty"`
-	Config map[string]interface{} `json:"config,omitempty"`
+	Name   string          `json:"name,omitempty"`
+	Config json.RawMessage `json:"config,omitempty"`
 }
 
 // Validate returns a non-nil error when the update request carries no
-// fields at all. This mirrors PATCH semantics: sending an empty body
-// should be an authoring error, not a silent round-trip.
+// meaningful fields. An empty Name combined with an absent, empty, or
+// null Config is treated as "nothing to update" so callers don't
+// silently hit the wire with a no-op PATCH. A Config of `{}` or `[]` is
+// also rejected for the same reason — the caller clearly intended to
+// send something, but didn't.
 func (r UpdateViewRequest) Validate() error {
-	if r.Name == "" && len(r.Config) == 0 {
+	if r.Name == "" && isEmptyRawJSON(r.Config) {
 		return errors.New("update view: at least one of name or config is required")
 	}
 	return nil
+}
+
+// isEmptyRawJSON reports whether a json.RawMessage carries no useful
+// payload: nil, zero-length, literal null, {} or [] (with whitespace).
+func isEmptyRawJSON(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	trimmed := bytes.TrimSpace(raw)
+	switch string(trimmed) {
+	case "", "null", "{}", "[]":
+		return true
+	}
+	return false
 }
 
 // ViewClient is the typed resource client for the Notion views API.

--- a/utils/views.go
+++ b/utils/views.go
@@ -19,7 +19,7 @@ import (
 // currently pins. Issue #11 tracks the version bump that will enable a
 // real implementation; until then this client surfaces a typed error so
 // callers can check for it with errors.Is.
-var ErrViewsNotSupported = errors.New("views are not supported on Notion-Version " + NotionAPIVersion + "; will be enabled by issue #11")
+var ErrViewsNotSupported = fmt.Errorf("views are not supported on Notion-Version %s; will be enabled by issue #11", NotionAPIVersion)
 
 // ValidViewTypes is the closed set of view types accepted by
 // CreateViewRequest.Validate. It mirrors the MCP notion-create-view

--- a/utils/views_test.go
+++ b/utils/views_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -198,7 +199,7 @@ func TestViews_Update_ValidationBeforeStub(t *testing.T) {
 // name) passes validation and still dispatches to the stub.
 func TestViews_Update_ConfigOnly(t *testing.T) {
 	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
-	req := UpdateViewRequest{Config: map[string]interface{}{"sort": "asc"}}
+	req := UpdateViewRequest{Config: json.RawMessage(`{"sort":"asc"}`)}
 	_, err := client.Update(context.Background(), "view-id", req)
 	if !errors.Is(err, ErrViewsNotSupported) {
 		t.Errorf("Update: want ErrViewsNotSupported for config-only request, got %v", err)
@@ -250,13 +251,23 @@ func TestValidate_CreateViewRequest(t *testing.T) {
 
 // TestValidate_UpdateViewRequest exercises the update validator.
 // Named TestValidate_* for the same gap-check reason documented on
-// TestValidate_CreateViewRequest above.
+// TestValidate_CreateViewRequest above. Also locks in that an empty
+// RawMessage payload (nil, "", "null", "{}", "[]") is rejected the
+// same way as a missing field so callers can't silently send a no-op
+// PATCH once #11 wires up the real request.
 func TestValidate_UpdateViewRequest(t *testing.T) {
 	if err := (UpdateViewRequest{Name: "n"}).Validate(); err != nil {
 		t.Errorf("Validate name-only: %v", err)
 	}
-	if err := (UpdateViewRequest{Config: map[string]interface{}{"k": "v"}}).Validate(); err != nil {
+	if err := (UpdateViewRequest{Config: json.RawMessage(`{"k":"v"}`)}).Validate(); err != nil {
 		t.Errorf("Validate config-only: %v", err)
+	}
+	emptyCases := []string{``, `null`, `{}`, `[]`, `  {} `}
+	for _, c := range emptyCases {
+		got := UpdateViewRequest{Config: json.RawMessage(c)}
+		if err := got.Validate(); err == nil {
+			t.Errorf("Validate empty-config %q: want error, got nil", c)
+		}
 	}
 	if err := (UpdateViewRequest{}).Validate(); err == nil {
 		t.Errorf("Validate empty: want error, got nil")

--- a/utils/views_test.go
+++ b/utils/views_test.go
@@ -1,0 +1,259 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestNewViewClient is a smoke test for the constructor; it exists so
+// the gap-check script sees a matching Test function for the exported
+// NewViewClient symbol.
+func TestNewViewClient(t *testing.T) {
+	c := NewClient("k", WithBaseURL("http://example"))
+	got := NewViewClient(c)
+	if got == nil || got.c != c {
+		t.Fatalf("NewViewClient: %+v", got)
+	}
+}
+
+// TestViews_Create_NotSupported asserts that a fully-valid create
+// request surfaces ErrViewsNotSupported (the stub path) via errors.Is
+// so callers can branch on it without string-matching.
+func TestViews_Create_NotSupported(t *testing.T) {
+	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	req := CreateViewRequest{
+		DatabaseID: "db-id",
+		Name:       "My View",
+		Type:       "table",
+	}
+	got, err := client.Create(context.Background(), req)
+	if err == nil {
+		t.Fatalf("Create: want error, got view %+v", got)
+	}
+	if !errors.Is(err, ErrViewsNotSupported) {
+		t.Errorf("Create: want errors.Is ErrViewsNotSupported, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("Create: want nil view, got %+v", got)
+	}
+}
+
+// TestViews_Create_AllValidTypes exercises every type in ValidViewTypes
+// and confirms each still dispatches to the stub (ErrViewsNotSupported).
+// This locks in the vocabulary so a future refactor can't silently drop
+// a supported type.
+func TestViews_Create_AllValidTypes(t *testing.T) {
+	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	for _, vt := range ValidViewTypes {
+		t.Run(vt, func(t *testing.T) {
+			req := CreateViewRequest{
+				DatabaseID: "db-id",
+				Name:       "n",
+				Type:       vt,
+			}
+			_, err := client.Create(context.Background(), req)
+			if !errors.Is(err, ErrViewsNotSupported) {
+				t.Errorf("Create(%s): want ErrViewsNotSupported, got %v", vt, err)
+			}
+		})
+	}
+}
+
+// TestViews_Create_ValidationBeforeStub asserts that a missing required
+// field produces a precise validation error rather than the stub
+// sentinel. Ordering matters: bad input should not be masked by the
+// "views not supported" message.
+func TestViews_Create_ValidationBeforeStub(t *testing.T) {
+	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+
+	tests := []struct {
+		name    string
+		req     CreateViewRequest
+		wantSub string
+	}{
+		{
+			name:    "missing database_id",
+			req:     CreateViewRequest{Name: "n", Type: "table"},
+			wantSub: "database_id",
+		},
+		{
+			name:    "missing name",
+			req:     CreateViewRequest{DatabaseID: "d", Type: "table"},
+			wantSub: "name",
+		},
+		{
+			name:    "missing type",
+			req:     CreateViewRequest{DatabaseID: "d", Name: "n"},
+			wantSub: "type is required",
+		},
+		{
+			name:    "invalid type",
+			req:     CreateViewRequest{DatabaseID: "d", Name: "n", Type: "bogus"},
+			wantSub: "invalid type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.Create(context.Background(), tt.req)
+			if err == nil {
+				t.Fatalf("Create: want error, got %+v", got)
+			}
+			if errors.Is(err, ErrViewsNotSupported) {
+				t.Errorf("Create: validation error swallowed by stub sentinel: %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("Create error = %q; want substring %q", err.Error(), tt.wantSub)
+			}
+			if got != nil {
+				t.Errorf("Create: want nil view on validation error, got %+v", got)
+			}
+		})
+	}
+}
+
+// TestViews_Create_MissingAPIKey asserts that a client built without an
+// API key surfaces ErrMissingAPIKey rather than ErrViewsNotSupported.
+// Validation of the request itself still runs first.
+func TestViews_Create_MissingAPIKey(t *testing.T) {
+	client := NewViewClient(NewClient("", WithBaseURL("http://127.0.0.1:0")))
+	req := CreateViewRequest{
+		DatabaseID: "db-id",
+		Name:       "n",
+		Type:       "table",
+	}
+	_, err := client.Create(context.Background(), req)
+	if err == nil {
+		t.Fatal("Create: want error for empty API key")
+	}
+	if !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Create: want ErrMissingAPIKey, got %v", err)
+	}
+}
+
+// TestViews_Update_NotSupported asserts that a fully-valid update
+// request surfaces ErrViewsNotSupported.
+func TestViews_Update_NotSupported(t *testing.T) {
+	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	got, err := client.Update(context.Background(), "view-id", UpdateViewRequest{Name: "renamed"})
+	if err == nil {
+		t.Fatalf("Update: want error, got %+v", got)
+	}
+	if !errors.Is(err, ErrViewsNotSupported) {
+		t.Errorf("Update: want errors.Is ErrViewsNotSupported, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("Update: want nil view, got %+v", got)
+	}
+}
+
+// TestViews_Update_ValidationBeforeStub asserts update-time validation
+// runs ahead of the stub sentinel: a bad id or empty request should
+// produce a precise error, not "views not supported".
+func TestViews_Update_ValidationBeforeStub(t *testing.T) {
+	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+
+	tests := []struct {
+		name    string
+		id      string
+		req     UpdateViewRequest
+		wantSub string
+	}{
+		{
+			name:    "missing id",
+			id:      "",
+			req:     UpdateViewRequest{Name: "n"},
+			wantSub: "id is required",
+		},
+		{
+			name:    "empty request",
+			id:      "view-id",
+			req:     UpdateViewRequest{},
+			wantSub: "at least one of name or config is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.Update(context.Background(), tt.id, tt.req)
+			if err == nil {
+				t.Fatalf("Update: want error, got %+v", got)
+			}
+			if errors.Is(err, ErrViewsNotSupported) {
+				t.Errorf("Update: validation error swallowed by stub sentinel: %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("Update error = %q; want substring %q", err.Error(), tt.wantSub)
+			}
+			if got != nil {
+				t.Errorf("Update: want nil view on validation error, got %+v", got)
+			}
+		})
+	}
+}
+
+// TestViews_Update_ConfigOnly verifies that a config-only update (no
+// name) passes validation and still dispatches to the stub.
+func TestViews_Update_ConfigOnly(t *testing.T) {
+	client := NewViewClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	req := UpdateViewRequest{Config: map[string]interface{}{"sort": "asc"}}
+	_, err := client.Update(context.Background(), "view-id", req)
+	if !errors.Is(err, ErrViewsNotSupported) {
+		t.Errorf("Update: want ErrViewsNotSupported for config-only request, got %v", err)
+	}
+}
+
+// TestViews_Update_MissingAPIKey asserts that a client built without an
+// API key surfaces ErrMissingAPIKey (after validation).
+func TestViews_Update_MissingAPIKey(t *testing.T) {
+	client := NewViewClient(NewClient("", WithBaseURL("http://127.0.0.1:0")))
+	_, err := client.Update(context.Background(), "view-id", UpdateViewRequest{Name: "n"})
+	if err == nil {
+		t.Fatal("Update: want error for empty API key")
+	}
+	if !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Update: want ErrMissingAPIKey, got %v", err)
+	}
+}
+
+// TestViews_ErrViewsNotSupported_MessageReferences11 asserts the error
+// message mentions the pinned version and issue #11 so users can find
+// the tracking issue without reading the code.
+func TestViews_ErrViewsNotSupported_MessageReferences11(t *testing.T) {
+	msg := ErrViewsNotSupported.Error()
+	if !strings.Contains(msg, NotionAPIVersion) {
+		t.Errorf("ErrViewsNotSupported message = %q; want it to mention %q", msg, NotionAPIVersion)
+	}
+	if !strings.Contains(msg, "#11") {
+		t.Errorf("ErrViewsNotSupported message = %q; want it to mention %q", msg, "#11")
+	}
+}
+
+// TestViews_CreateViewRequest_Validate is a direct exercise of the
+// request's Validate method so gap-check sees coverage for the exported
+// method independently of ViewClient.Create.
+func TestViews_CreateViewRequest_Validate(t *testing.T) {
+	ok := CreateViewRequest{DatabaseID: "d", Name: "n", Type: "board"}
+	if err := ok.Validate(); err != nil {
+		t.Errorf("Validate(%+v) = %v, want nil", ok, err)
+	}
+	bad := CreateViewRequest{DatabaseID: "d", Name: "n", Type: "nope"}
+	if err := bad.Validate(); err == nil {
+		t.Errorf("Validate(%+v) = nil, want error", bad)
+	}
+}
+
+// TestViews_UpdateViewRequest_Validate exercises the update validator.
+func TestViews_UpdateViewRequest_Validate(t *testing.T) {
+	if err := (UpdateViewRequest{Name: "n"}).Validate(); err != nil {
+		t.Errorf("Validate name-only: %v", err)
+	}
+	if err := (UpdateViewRequest{Config: map[string]interface{}{"k": "v"}}).Validate(); err != nil {
+		t.Errorf("Validate config-only: %v", err)
+	}
+	if err := (UpdateViewRequest{}).Validate(); err == nil {
+		t.Errorf("Validate empty: want error, got nil")
+	}
+}

--- a/utils/views_test.go
+++ b/utils/views_test.go
@@ -231,10 +231,13 @@ func TestViews_ErrViewsNotSupported_MessageReferences11(t *testing.T) {
 	}
 }
 
-// TestViews_CreateViewRequest_Validate is a direct exercise of the
-// request's Validate method so gap-check sees coverage for the exported
-// method independently of ViewClient.Create.
-func TestViews_CreateViewRequest_Validate(t *testing.T) {
+// TestValidate_CreateViewRequest is a direct exercise of the request's
+// Validate method so gap-check sees coverage for the exported method
+// independently of ViewClient.Create. Named TestValidate_* (vs the
+// TestViews_* prefix used elsewhere in this file) so the gap-check
+// script's regex matches the bare Validate function name — no other
+// Validate methods exist in this module so there is no collision risk.
+func TestValidate_CreateViewRequest(t *testing.T) {
 	ok := CreateViewRequest{DatabaseID: "d", Name: "n", Type: "board"}
 	if err := ok.Validate(); err != nil {
 		t.Errorf("Validate(%+v) = %v, want nil", ok, err)
@@ -245,8 +248,10 @@ func TestViews_CreateViewRequest_Validate(t *testing.T) {
 	}
 }
 
-// TestViews_UpdateViewRequest_Validate exercises the update validator.
-func TestViews_UpdateViewRequest_Validate(t *testing.T) {
+// TestValidate_UpdateViewRequest exercises the update validator.
+// Named TestValidate_* for the same gap-check reason documented on
+// TestValidate_CreateViewRequest above.
+func TestValidate_UpdateViewRequest(t *testing.T) {
 	if err := (UpdateViewRequest{Name: "n"}).Validate(); err != nil {
 		t.Errorf("Validate name-only: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #7.

Adds \`notioncli views create <database-id>\` and \`notioncli views update <view-id>\` with the \`--name\` / \`--type\` / \`--config-json\` flag surface called out in the issue. The underlying \`utils.ViewClient\` types — \`View\`, \`CreateViewRequest\`, \`UpdateViewRequest\`, \`ValidViewTypes\` — are sized so #11 can swap in real HTTP calls with a drop-in change to \`Create\` and \`Update\`.

## Why the stub (Option A)

The Notion views / data-sources endpoints are not available on the pinned \`Notion-Version: 2022-06-28\`. Two options were on the table:

- **Option A (taken):** ship the command and client surface now, return \`ErrViewsNotSupported\` from the HTTP-calling methods. Same pattern used by the teams stub (#9). Keeps this PR small and safe; lets #7 close without entangling the version bump.
- **Option B:** bump the \`Notion-Version\` constant in \`utils/client.go\` just for views. Rejected — other resource clients assume 2022-06-28 semantics and the bump deserves its own coordination pass, which #11 owns.

Once #11 lands the version bump and the real endpoints are available, the swap is mechanical: replace the \`return nil, ErrViewsNotSupported\` lines in \`ViewClient.Create\` and \`ViewClient.Update\` with a \`c.newRequest → c.do → decodeInto\` sequence against the new paths. Request/response shapes and method signatures will not change.

## What ships

- \`utils/views.go\` — \`ViewClient\`, \`View\`, \`CreateViewRequest\` (with \`Validate()\`), \`UpdateViewRequest\` (with \`Validate()\`), \`ValidViewTypes\`, \`ErrViewsNotSupported\` (message references both \`2022-06-28\` and \`#11\`).
- \`cmd/views.go\` — parent \`views\` command, \`create\` and \`update\` subcommands wired with \`RunE\` so cobra drives the shell exit code. Both subcommands read \`--config-json\` from disk up front so I/O / parse errors short-circuit ahead of the stub sentinel. Long-form help explicitly calls out the #11-pending state.
- \`utils/views_test.go\` and \`cmd/views_test.go\` — all pass with \`-race\`.

## Validation ordering

Validation intentionally runs **before** the stub sentinel so bad input produces a precise, actionable error instead of a misleading "views not supported" message:

- \`CreateViewRequest.Validate()\` rejects empty \`database_id\` / \`name\` / \`type\` and unknown types against \`ValidViewTypes\`.
- \`UpdateViewRequest.Validate()\` rejects the zero-value "nothing to update" case.
- \`ViewClient.Update\` additionally rejects an empty \`id\`.

## Test evidence

\`make ci\` tail:

\`\`\`
notioncli/utils/views.go:61:    Validate        100.0%
notioncli/utils/views.go:91:    Validate        100.0%
notioncli/utils/views.go:110:   NewViewClient   100.0%
notioncli/utils/views.go:119:   checkAuth       100.0%
notioncli/utils/views.go:130:   Create          100.0%
notioncli/utils/views.go:143:   Update          100.0%
total:                          (statements)    86.8%
Total coverage: 86.8% (gate: 70%)
✓ Every exported function has a matching Test* (skips honored).
\`\`\`

- \`fmt-check\` clean
- \`go vet\` clean
- \`go test -race\` clean
- Coverage: 86.3% (baseline on \`feature/foundation\`) → **86.8%** (+0.5)
- Every new exported function in \`utils/views.go\` is at 100%

Test names use the \`TestViews_*\` prefix throughout to avoid collision with the other swarm PRs landing tests in \`cmd/\` and \`utils/\` simultaneously. The two \`Validate\` tests use \`TestValidate_*\` so the gap-check regex (\`^Test<FuncName>(\$|_)\`) picks them up; no other \`Validate\` functions exist in the module so there is no collision risk.

## Scope discipline

Changes are confined to four new files:

- \`utils/views.go\`
- \`utils/views_test.go\`
- \`cmd/views.go\`
- \`cmd/views_test.go\`

No other files were modified. The \`Notion-Version\` constant in \`utils/client.go\` was not touched.

## Test plan

- [x] \`make ci\` green
- [x] \`go test -race ./...\` clean
- [x] Coverage gate (≥70%) passes at 86.8%
- [x] \`check-test-gaps\` clean
- [ ] CI workflow run on \`feature/views\` branch (dispatched after PR open)