### PR TITLE
feat: file upload client + image/file/icon/cover commands (closes #10)

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -1,0 +1,165 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// Flag vars for the file-upload subcommands. Package-level to match the
+// existing blocks.go / pages.go pattern and let cobra bind them via init().
+var (
+	blocksAddFileName string
+)
+
+// newFileClient constructs a *utils.FileClient using the CLI's shared config
+// loader. Mirrors cmd/pages.go's newPageClient — one helper per resource so
+// missing-key handling is identical across subcommands. Surfaces
+// utils.ErrMissingAPIKey when NOTION_API_KEY resolves empty so operators get
+// a clear configuration error instead of a downstream 401.
+func newFileClient() (*utils.FileClient, error) {
+	apiKey, _ := utils.SetAPIConfig()
+	if apiKey == "" {
+		return nil, fmt.Errorf("files client: %w", utils.ErrMissingAPIKey)
+	}
+	c := utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))
+	return utils.NewFileClient(c), nil
+}
+
+// blocksAddImageCmd is wired under `blocks` (not a new top-level group)
+// because the user-facing intent is appending a block — the upload is an
+// implementation detail. Today it returns the stub error; once #11 lands
+// the `utils.FileClient.Upload` switches to the real two-step flow and
+// this subcommand begins appending an image block referencing the
+// resulting file_upload_id.
+var blocksAddImageCmd = &cobra.Command{
+	Use:   "add-image <path>",
+	Short: "Upload an image and append it as a block (pending API version bump)",
+	Long: `Upload a local image file and append it as an image block on the
+Notion page configured via NOTION_PAGE_ID.
+
+The Notion file-upload endpoints require a newer Notion-Version than this
+CLI currently pins; see issue #11 for the tracking bump. Today the command
+validates the path client-side and returns a clear error referencing #11.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fc, err := newFileClient()
+		if err != nil {
+			return err
+		}
+		ref, err := fc.Upload(context.Background(), args[0])
+		if err != nil {
+			return fmt.Errorf("add-image: %w", err)
+		}
+		// Unreachable on the pinned version — kept so the happy-path
+		// output shape ships with the stub and #11's flip does not
+		// touch the cmd layer.
+		color.Green("Uploaded image %s (id=%s)", ref.Name, ref.ID)
+		return nil
+	},
+}
+
+// blocksAddFileCmd mirrors blocksAddImageCmd for non-image files. The
+// optional --name flag overrides the displayed filename in Notion;
+// otherwise the base name of the path is used.
+var blocksAddFileCmd = &cobra.Command{
+	Use:   "add-file <path>",
+	Short: "Upload a file and append it as a block (pending API version bump)",
+	Long: `Upload a local file and append it as a file block on the Notion
+page configured via NOTION_PAGE_ID.
+
+The Notion file-upload endpoints require a newer Notion-Version than this
+CLI currently pins; see issue #11 for the tracking bump. Today the command
+validates the path client-side and returns a clear error referencing #11.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fc, err := newFileClient()
+		if err != nil {
+			return err
+		}
+		ref, err := fc.Upload(context.Background(), args[0])
+		if err != nil {
+			return fmt.Errorf("add-file: %w", err)
+		}
+		name := blocksAddFileName
+		if name == "" {
+			name = ref.Name
+		}
+		color.Green("Uploaded file %s (id=%s)", name, ref.ID)
+		return nil
+	},
+}
+
+// pagesSetIconCmd uploads an image and PATCHes it as the page icon. Stub-
+// only today; the PATCH body ({"icon": {"type": "file_upload", ...}}) is
+// deferred to issue #11 since the reference format depends on the same
+// version bump as the upload endpoint.
+var pagesSetIconCmd = &cobra.Command{
+	Use:   "set-icon <page-id> <path>",
+	Short: "Upload an image and set it as a page icon (pending API version bump)",
+	Long: `Upload a local image and set it as the icon for a Notion page.
+
+The Notion file-upload endpoints require a newer Notion-Version than this
+CLI currently pins; see issue #11 for the tracking bump. Today the command
+validates the path client-side and returns a clear error referencing #11.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fc, err := newFileClient()
+		if err != nil {
+			return err
+		}
+		ref, err := fc.Upload(context.Background(), args[1])
+		if err != nil {
+			return fmt.Errorf("set-icon: %w", err)
+		}
+		color.Green("Set icon on page %s (file id=%s)", args[0], ref.ID)
+		return nil
+	},
+}
+
+// pagesSetCoverCmd uploads an image and PATCHes it as the page cover. Same
+// stub posture as set-icon.
+var pagesSetCoverCmd = &cobra.Command{
+	Use:   "set-cover <page-id> <path>",
+	Short: "Upload an image and set it as a page cover (pending API version bump)",
+	Long: `Upload a local image and set it as the cover for a Notion page.
+
+The Notion file-upload endpoints require a newer Notion-Version than this
+CLI currently pins; see issue #11 for the tracking bump. Today the command
+validates the path client-side and returns a clear error referencing #11.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fc, err := newFileClient()
+		if err != nil {
+			return err
+		}
+		ref, err := fc.Upload(context.Background(), args[1])
+		if err != nil {
+			return fmt.Errorf("set-cover: %w", err)
+		}
+		color.Green("Set cover on page %s (file id=%s)", args[0], ref.ID)
+		return nil
+	},
+}
+
+func init() {
+	// Register under the existing `blocks` and `pages` parents so the UX
+	// matches the issue spec (notioncli blocks add-image, etc.). Those
+	// parent commands are declared in blocks.go / pages.go respectively;
+	// we only attach the new children here so the scope of this change
+	// stays localized to a single new file.
+	blocksCmd.AddCommand(blocksAddImageCmd)
+	blocksCmd.AddCommand(blocksAddFileCmd)
+	pagesCmd.AddCommand(pagesSetIconCmd)
+	pagesCmd.AddCommand(pagesSetCoverCmd)
+
+	blocksAddFileCmd.Flags().StringVar(&blocksAddFileName, "name", "", "Override the filename displayed in Notion")
+}

--- a/cmd/files_test.go
+++ b/cmd/files_test.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"notioncli/utils"
+)
+
+// findBlocksSubcommand and findPagesSubcommand are defined in blocks_test.go
+// and pages_test.go respectively — this file reuses them without redeclaring.
+
+// TestFiles_Cmd_Registered asserts the four new subcommands (two under
+// blocks, two under pages) are wired into rootCmd. The cmd-layer gap check
+// looks for Test functions per exported command — this single test covers
+// all four to keep the test file flat.
+func TestFiles_Cmd_Registered(t *testing.T) {
+	wantBlocks := []string{"add-image", "add-file"}
+	for _, name := range wantBlocks {
+		if findBlocksSubcommand(t, name) == nil {
+			t.Errorf("blocks subcommand %q not registered", name)
+		}
+	}
+	wantPages := []string{"set-icon", "set-cover"}
+	for _, name := range wantPages {
+		if findPagesSubcommand(t, name) == nil {
+			t.Errorf("pages subcommand %q not registered", name)
+		}
+	}
+}
+
+// TestFiles_Cmd_AddFileHasNameFlag locks in the --name flag on add-file.
+// The flag exists so callers can override the displayed filename without
+// renaming the local file; a regression that dropped it would silently
+// change behavior.
+func TestFiles_Cmd_AddFileHasNameFlag(t *testing.T) {
+	addFile := findBlocksSubcommand(t, "add-file")
+	if addFile.Flags().Lookup("name") == nil {
+		t.Error("blocks add-file: --name flag not registered")
+	}
+}
+
+// TestFiles_NewFileClient_Cmd_ReturnsErrMissingAPIKey drives the cmd-layer
+// helper directly. When NOTION_API_KEY resolves empty the helper must
+// surface utils.ErrMissingAPIKey so operators get a configuration-specific
+// error (consistent with newPageClient). SetAPIConfig calls os.Exit when
+// the env var is unset, so we set it to a placeholder then clear it to
+// the empty string — which passes SetAPIConfig but trips the emptiness
+// check in newFileClient.
+func TestFiles_NewFileClient_Cmd_ReturnsErrMissingAPIKey(t *testing.T) {
+	// Env scaffolding: SetAPIConfig needs a loadable .env, HOME, and the
+	// two required env vars. We set NOTION_API_KEY to "" explicitly —
+	// LookupEnv returns ok=true for empty values, so SetAPIConfig returns
+	// ("", pageID) and newFileClient's emptiness check fires.
+	emptyCwd := t.TempDir()
+	emptyHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(emptyCwd, ".env"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(emptyCwd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("NOTION_API_KEY", "")
+	t.Setenv("NOTION_PAGE_ID", "pageID")
+	t.Setenv("LOCAL_TIMEZONE", "UTC")
+
+	got, err := newFileClient()
+	if err == nil {
+		t.Fatalf("newFileClient: want error, got %+v", got)
+	}
+	if !errors.Is(err, utils.ErrMissingAPIKey) {
+		t.Errorf("newFileClient: want errors.Is ErrMissingAPIKey, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("newFileClient: want nil client, got %+v", got)
+	}
+}
+
+// runFilesCmd is a tiny helper that runs a files-related subcommand
+// through rootCmd with its full arg list, captures stdout+stderr into buf,
+// and returns whatever cobra's Execute returned. RunE errors surface
+// through the return, not via cmd.SetErr, so callers assert on both.
+func runFilesCmd(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	resetRootCmdArgs()
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// TestFiles_Cmd_DispatchReturnsStub is the end-to-end smoke test for every
+// new subcommand. Each row dispatches through rootCmd with valid args
+// (including a real on-disk file), the env fully wired, and asserts the
+// stub sentinel bubbles up with the right prefix. This ensures the cmd
+// layer threads the error cleanly (no silent swallow) and that the RunE
+// return value carries #11 so users see it in their terminal.
+func TestFiles_Cmd_DispatchReturnsStub(t *testing.T) {
+	// Shared env + filesystem setup for every row.
+	withCmdEnv(t)
+
+	// A small real file that passes validateUploadPath; 1 byte suffices.
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "hello.png")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write tmp file: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantPrefix string
+	}{
+		{
+			name:       "blocks add-image",
+			args:       []string{"blocks", "add-image", filePath},
+			wantPrefix: "add-image",
+		},
+		{
+			name:       "blocks add-file",
+			args:       []string{"blocks", "add-file", filePath},
+			wantPrefix: "add-file",
+		},
+		{
+			name:       "blocks add-file with --name",
+			args:       []string{"blocks", "add-file", filePath, "--name", "nice-name.txt"},
+			wantPrefix: "add-file",
+		},
+		{
+			name:       "pages set-icon",
+			args:       []string{"pages", "set-icon", "page-abc", filePath},
+			wantPrefix: "set-icon",
+		},
+		{
+			name:       "pages set-cover",
+			args:       []string{"pages", "set-cover", "page-abc", filePath},
+			wantPrefix: "set-cover",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := runFilesCmd(t, tt.args)
+			if err == nil {
+				t.Fatalf("%s: want error, got nil", tt.name)
+			}
+			if !errors.Is(err, utils.ErrFileUploadNotSupported) {
+				t.Errorf("%s: want errors.Is ErrFileUploadNotSupported, got %v", tt.name, err)
+			}
+			if !strings.HasPrefix(err.Error(), tt.wantPrefix+":") {
+				t.Errorf("%s: want error to start with %q, got %v", tt.name, tt.wantPrefix+":", err)
+			}
+			if !strings.Contains(err.Error(), "#11") {
+				t.Errorf("%s: want error to mention #11, got %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestFiles_Cmd_Dispatch_PathValidation confirms the cmd layer surfaces
+// per-path validation errors (missing file, directory, oversize) rather
+// than the stub sentinel. Operators who typo a path need the specific
+// error, not the "will be enabled by #11" noise.
+func TestFiles_Cmd_Dispatch_PathValidation(t *testing.T) {
+	withCmdEnv(t)
+
+	dir := t.TempDir()
+	// Missing path.
+	missing := filepath.Join(dir, "nope.bin")
+	// Directory path.
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantFrag string
+	}{
+		{
+			name:     "add-image missing path",
+			args:     []string{"blocks", "add-image", missing},
+			wantFrag: "nope.bin",
+		},
+		{
+			name:     "add-file directory",
+			args:     []string{"blocks", "add-file", subdir},
+			wantFrag: "directory",
+		},
+		{
+			name:     "set-icon missing path",
+			args:     []string{"pages", "set-icon", "page-abc", missing},
+			wantFrag: "nope.bin",
+		},
+		{
+			name:     "set-cover directory",
+			args:     []string{"pages", "set-cover", "page-abc", subdir},
+			wantFrag: "directory",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := runFilesCmd(t, tt.args)
+			if err == nil {
+				t.Fatalf("%s: want error, got nil", tt.name)
+			}
+			// Validation errors must not be wrapped as the stub
+			// sentinel — they are a separate failure class.
+			if errors.Is(err, utils.ErrFileUploadNotSupported) {
+				t.Errorf("%s: validation error should not wrap ErrFileUploadNotSupported, got %v", tt.name, err)
+			}
+			if !strings.Contains(err.Error(), tt.wantFrag) {
+				t.Errorf("%s: want error to contain %q, got %v", tt.name, tt.wantFrag, err)
+			}
+		})
+	}
+}
+
+// TestFiles_Cmd_Dispatch_ArgValidation asserts cobra's positional-arg
+// constraints for each command. add-image/add-file require exactly one
+// arg, set-icon/set-cover require exactly two. A missing path must return
+// a cobra usage error, not run the stub.
+func TestFiles_Cmd_Dispatch_ArgValidation(t *testing.T) {
+	withCmdEnv(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "add-image no args", args: []string{"blocks", "add-image"}},
+		{name: "add-file no args", args: []string{"blocks", "add-file"}},
+		{name: "set-icon one arg", args: []string{"pages", "set-icon", "page-abc"}},
+		{name: "set-cover one arg", args: []string{"pages", "set-cover", "page-abc"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Silence cobra's usage dump by pointing the command
+			// output at a throwaway buffer; we only care about
+			// the returned error.
+			_, err := runFilesCmd(t, tt.args)
+			if err == nil {
+				t.Fatalf("%s: want cobra arg error, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/utils/files.go
+++ b/utils/files.go
@@ -32,20 +32,41 @@ var ErrFileUploadNotSupported = errors.New("file uploads are not supported on No
 // keep working when the stub flips to a real upload.
 const MaxFileUploadBytes int64 = 20 * 1024 * 1024
 
+// FileRefTypeFileUpload is the Notion "type" discriminator for a file
+// reference created through /v1/file_uploads. Exposed as a constant so block
+// and page payload builders spell the literal exactly once — prevents typo
+// drift (e.g. "file-upload", "fileupload") that a string-typed field would
+// otherwise allow.
+const FileRefTypeFileUpload = "file_upload"
+
 // FileRef is the shape returned by a successful upload. Type is always
-// "file_upload" for files created via /v1/file_uploads — the constant lets
-// callers feed a FileRef directly into block create / page icon / page cover
-// payloads without caring where the reference came from.
+// FileRefTypeFileUpload for files created via /v1/file_uploads — the
+// constant lets callers feed a FileRef directly into block create / page
+// icon / page cover payloads without caring where the reference came from.
 //
 // Name and ExpiryTime are populated when Notion returns them. ExpiryTime is
 // an RFC3339 timestamp (per the Notion API) kept as a string so the envelope
 // round-trips unchanged even if Notion adds timezone or precision variants
 // in a future version.
+//
+// Prefer NewFileRef for construction so Type is pinned to the constant.
 type FileRef struct {
 	ID         string `json:"id"`
 	Type       string `json:"type"`
 	Name       string `json:"name,omitempty"`
 	ExpiryTime string `json:"expiry_time,omitempty"`
+}
+
+// NewFileRef builds a FileRef with Type pinned to FileRefTypeFileUpload. The
+// real upload implementation (#11) should prefer this constructor over
+// struct-literal construction so the discriminator cannot drift. ExpiryTime
+// is set separately by the caller when the upload response carries it.
+func NewFileRef(id, name string) *FileRef {
+	return &FileRef{
+		ID:   id,
+		Type: FileRefTypeFileUpload,
+		Name: name,
+	}
 }
 
 // FileUploadRequest is the body for POST /v1/file_uploads. Mode selects the

--- a/utils/files.go
+++ b/utils/files.go
@@ -1,0 +1,161 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrFileUploadNotSupported is returned by FileClient methods when the pinned
+// Notion API version does not expose the file-upload endpoints. The
+// /v1/file_uploads surface was introduced in a Notion-Version newer than the
+// 2022-06-28 value this CLI currently pins (the Notion docs for
+// POST /v1/file_uploads require at least 2026-03-11). Issue #11 tracks the
+// version bump that will enable the real two-step upload flow; until then
+// this client surfaces a typed sentinel so callers can check for it with
+// errors.Is.
+var ErrFileUploadNotSupported = errors.New("file uploads are not supported on Notion-Version " + NotionAPIVersion + "; will be enabled by issue #11")
+
+// MaxFileUploadBytes is the client-side cap applied before we even contact
+// Notion. Notion caps single-part uploads at 20MB (multi-part is larger), so
+// 20MB is a conservative default that keeps the single-part flow simple for
+// v1. Larger files will be rejected with a clear error referencing this cap.
+//
+// This constant lives alongside the stub deliberately — issue #11's real
+// implementation will honor the same size gate so callers that branch on it
+// keep working when the stub flips to a real upload.
+const MaxFileUploadBytes int64 = 20 * 1024 * 1024
+
+// FileRef is the shape returned by a successful upload. Type is always
+// "file_upload" for files created via /v1/file_uploads — the constant lets
+// callers feed a FileRef directly into block create / page icon / page cover
+// payloads without caring where the reference came from.
+//
+// Name and ExpiryTime are populated when Notion returns them. ExpiryTime is
+// an RFC3339 timestamp (per the Notion API) kept as a string so the envelope
+// round-trips unchanged even if Notion adds timezone or precision variants
+// in a future version.
+type FileRef struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Name       string `json:"name,omitempty"`
+	ExpiryTime string `json:"expiry_time,omitempty"`
+}
+
+// FileUploadRequest is the body for POST /v1/file_uploads. Mode selects the
+// upload style — "single_part" is the v1 default and the only mode the stub
+// will exercise when issue #11 flips the implementation. Filename is the
+// human-readable name shown in Notion after the upload completes.
+type FileUploadRequest struct {
+	Mode        string `json:"mode,omitempty"`
+	Filename    string `json:"filename,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+}
+
+// FileUploadResponse is the envelope Notion returns from
+// POST /v1/file_uploads. The stub defines the shape so callers can start
+// consuming it today and the real implementation is a drop-in.
+//
+// UploadURL is the pre-signed URL to which raw bytes are PUT as
+// multipart/form-data in step 2. It is separate from ID because the URL
+// expires once the upload completes, while ID continues to reference the
+// uploaded file.
+type FileUploadResponse struct {
+	Object     string `json:"object"`
+	ID         string `json:"id"`
+	UploadURL  string `json:"upload_url"`
+	Status     string `json:"status"`
+	ExpiryTime string `json:"expiry_time,omitempty"`
+	Filename   string `json:"filename,omitempty"`
+}
+
+// FileClient is the typed resource client for the Notion file-uploads API.
+//
+// The methods currently return ErrFileUploadNotSupported because the pinned
+// Notion-Version does not expose the /v1/file_uploads endpoint. The client
+// shape is kept stable so issue #11 can flip the implementation without
+// breaking callers.
+type FileClient struct {
+	c *Client
+}
+
+// NewFileClient wraps a *Client with file-upload methods.
+func NewFileClient(c *Client) *FileClient {
+	return &FileClient{c: c}
+}
+
+// checkAuth mirrors PageClient.checkAuth so missing-credential errors surface
+// as ErrMissingAPIKey rather than a bare Notion 401.
+func (f *FileClient) checkAuth() error {
+	if f == nil || f.c == nil || f.c.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	return nil
+}
+
+// validateUploadPath performs the client-side checks that apply regardless of
+// whether the real upload flow is wired. Exported so the cmd/ layer (and any
+// future alternative transport) can reuse exactly the same rules.
+//
+// The checks, in order, are:
+//  1. path is non-empty
+//  2. path refers to an existing file (not a directory, not a symlink-to-dir)
+//  3. file size is within MaxFileUploadBytes
+//
+// All failure paths return errors suitable for human display — they name the
+// path and cite the size cap in bytes so an operator can act on them without
+// reading source.
+func validateUploadPath(path string) (os.FileInfo, error) {
+	if path == "" {
+		return nil, fmt.Errorf("file upload: path is required")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("file upload: stat %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("file upload: %q is a directory, not a file", path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("file upload: %q is not a regular file", path)
+	}
+	if info.Size() > MaxFileUploadBytes {
+		return nil, fmt.Errorf("file upload: %q is %d bytes, exceeds client cap of %d bytes", path, info.Size(), MaxFileUploadBytes)
+	}
+	return info, nil
+}
+
+// Upload is the primary entry point for a file upload. It validates the path
+// client-side, then attempts the two-step Notion upload. On the pinned
+// Notion-Version it always returns ErrFileUploadNotSupported AFTER successful
+// path validation, so callers that feed bad paths still get a specific path
+// error (easier to act on than the sentinel). Issue #11 will flip the body
+// to perform:
+//
+//  1. POST /v1/file_uploads with a FileUploadRequest derived from path +
+//     filename, reading back a FileUploadResponse.
+//  2. PUT to FileUploadResponse.UploadURL with the file's bytes encoded as
+//     multipart/form-data.
+//  3. Return a FileRef built from the response plus the caller's filename.
+//
+// The returned FileRef is safe to feed into block or page payloads that
+// reference "file_upload" resources.
+func (f *FileClient) Upload(ctx context.Context, path string) (*FileRef, error) {
+	if err := f.checkAuth(); err != nil {
+		return nil, fmt.Errorf("upload file: %w", err)
+	}
+	if _, err := validateUploadPath(path); err != nil {
+		return nil, err
+	}
+	// ctx is accepted for API stability; the real implementation will thread
+	// it into both HTTP calls. Referencing it here keeps the import required
+	// and prevents accidental removal during the issue #11 switchover.
+	_ = ctx
+	return nil, fmt.Errorf("upload %q: %w", filepath.Base(path), ErrFileUploadNotSupported)
+}

--- a/utils/files.go
+++ b/utils/files.go
@@ -151,24 +151,28 @@ func (f *FileClient) checkAuth() error {
 // All failure paths return errors suitable for human display — they name the
 // path and cite the size cap in bytes so an operator can act on them without
 // reading source.
-func validateUploadPath(path string) (os.FileInfo, error) {
+//
+// Returns only error: #11's real implementation will re-stat the file when
+// it needs content_length for the multipart PUT, so there is no callsite
+// that benefits from an os.FileInfo return today.
+func validateUploadPath(path string) error {
 	if path == "" {
-		return nil, fmt.Errorf("file upload: path is required")
+		return fmt.Errorf("file upload: path is required")
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("file upload: stat %q: %w", path, err)
+		return fmt.Errorf("file upload: stat %q: %w", path, err)
 	}
 	if info.IsDir() {
-		return nil, fmt.Errorf("file upload: %q is a directory, not a file", path)
+		return fmt.Errorf("file upload: %q is a directory, not a file", path)
 	}
 	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("file upload: %q is not a regular file", path)
+		return fmt.Errorf("file upload: %q is not a regular file", path)
 	}
 	if info.Size() > MaxFileUploadBytes {
-		return nil, fmt.Errorf("file upload: %q is %d bytes, exceeds client cap of %d bytes", path, info.Size(), MaxFileUploadBytes)
+		return fmt.Errorf("file upload: %q is %d bytes, exceeds client cap of %d bytes", path, info.Size(), MaxFileUploadBytes)
 	}
-	return info, nil
+	return nil
 }
 
 // Upload is the primary entry point for a file upload. It validates the path
@@ -190,7 +194,7 @@ func (f *FileClient) Upload(ctx context.Context, path string) (*FileRef, error) 
 	if err := f.checkAuth(); err != nil {
 		return nil, fmt.Errorf("upload file: %w", err)
 	}
-	if _, err := validateUploadPath(path); err != nil {
+	if err := validateUploadPath(path); err != nil {
 		return nil, err
 	}
 	// ctx is accepted for API stability; the real implementation will thread

--- a/utils/files.go
+++ b/utils/files.go
@@ -52,6 +52,25 @@ type FileRef struct {
 // upload style — "single_part" is the v1 default and the only mode the stub
 // will exercise when issue #11 flips the implementation. Filename is the
 // human-readable name shown in Notion after the upload completes.
+//
+// TODO(#11): multi-part uploads. Per the Notion 2026-03-11 docs for
+// POST /v1/file_uploads, switching Mode to "multi_part" requires these
+// additional fields on the request body:
+//
+//   - number_of_parts (int) — total parts the caller will PUT; required and
+//     must be >= 2 when Mode == "multi_part".
+//   - part_number (int) — 1-indexed part identifier supplied on each PUT to
+//     the pre-signed UploadURL (not on the initial POST — kept here for
+//     symmetry so #11's implementer can add it alongside number_of_parts and
+//     decide whether to model a separate PartUploadRequest struct).
+//   - external_url (string, optional) — mutually exclusive with multipart
+//     bytes; used for "upload by URL" mode which is a third variant beyond
+//     single_part / multi_part.
+//
+// The fields are documented rather than declared so a zero-value
+// FileUploadRequest still serializes cleanly on the pinned version. Issue
+// #11 should add them as exported fields with `omitempty` tags so the
+// single-part path's JSON shape stays unchanged.
 type FileUploadRequest struct {
 	Mode        string `json:"mode,omitempty"`
 	Filename    string `json:"filename,omitempty"`

--- a/utils/files.go
+++ b/utils/files.go
@@ -106,6 +106,12 @@ type FileUploadRequest struct {
 // multipart/form-data in step 2. It is separate from ID because the URL
 // expires once the upload completes, while ID continues to reference the
 // uploaded file.
+//
+// Filename is what Notion echoes back from the request; FileRef.Name is the
+// canonical display name callers hydrate into their block/page payloads.
+// #11's implementer should treat FileRef.Name as canonical (feed it from
+// filepath.Base(path) or the caller's --name override) and use Filename
+// only for round-trip verification against the response.
 type FileUploadResponse struct {
 	Object     string `json:"object"`
 	ID         string `json:"id"`
@@ -197,9 +203,11 @@ func (f *FileClient) Upload(ctx context.Context, path string) (*FileRef, error) 
 	if err := validateUploadPath(path); err != nil {
 		return nil, err
 	}
-	// ctx is accepted for API stability; the real implementation will thread
-	// it into both HTTP calls. Referencing it here keeps the import required
-	// and prevents accidental removal during the issue #11 switchover.
-	_ = ctx
+	// Respect caller cancellation even on the stub path — zero behavioral
+	// cost for the synchronous not-supported return, but it exercises ctx
+	// today so #11's switchover doesn't need to re-wire context plumbing.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("upload %q: %w", filepath.Base(path), err)
+	}
 	return nil, fmt.Errorf("upload %q: %w", filepath.Base(path), ErrFileUploadNotSupported)
 }

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -29,6 +29,33 @@ func TestNewFileClient(t *testing.T) {
 	}
 }
 
+// TestFiles_NewFileRef pins the constructor's contract: Type is always the
+// FileRefTypeFileUpload constant, ID and Name are passed through verbatim,
+// and ExpiryTime is empty for caller assignment. A test here means a change
+// to the "file_upload" literal has to break either the constant or the
+// struct tag — it cannot silently drift.
+func TestFiles_NewFileRef(t *testing.T) {
+	got := NewFileRef("abc-123", "hello.png")
+	if got == nil {
+		t.Fatal("NewFileRef: got nil")
+	}
+	if got.ID != "abc-123" {
+		t.Errorf("NewFileRef: ID = %q, want %q", got.ID, "abc-123")
+	}
+	if got.Name != "hello.png" {
+		t.Errorf("NewFileRef: Name = %q, want %q", got.Name, "hello.png")
+	}
+	if got.Type != FileRefTypeFileUpload {
+		t.Errorf("NewFileRef: Type = %q, want %q", got.Type, FileRefTypeFileUpload)
+	}
+	if got.Type != "file_upload" {
+		t.Errorf("NewFileRef: Type = %q, want the exact Notion discriminator %q", got.Type, "file_upload")
+	}
+	if got.ExpiryTime != "" {
+		t.Errorf("NewFileRef: ExpiryTime = %q, want empty", got.ExpiryTime)
+	}
+}
+
 // TestFiles_ErrFileUploadNotSupported_MessageReferences11 asserts the error
 // message mentions the pinned version and issue #11, so an operator reading
 // a CLI error knows which tracking issue to watch. Mirrors the teams

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -29,12 +29,15 @@ func TestNewFileClient(t *testing.T) {
 	}
 }
 
-// TestFiles_NewFileRef pins the constructor's contract: Type is always the
+// TestNewFileRef pins the constructor's contract: Type is always the
 // FileRefTypeFileUpload constant, ID and Name are passed through verbatim,
 // and ExpiryTime is empty for caller assignment. A test here means a change
 // to the "file_upload" literal has to break either the constant or the
 // struct tag — it cannot silently drift.
-func TestFiles_NewFileRef(t *testing.T) {
+//
+// Name intentionally uses TestNewFileRef (no _Files infix) so
+// scripts/check-test-coverage.sh matches Test<FuncName>.
+func TestNewFileRef(t *testing.T) {
 	got := NewFileRef("abc-123", "hello.png")
 	if got == nil {
 		t.Fatal("NewFileRef: got nil")
@@ -215,6 +218,32 @@ func TestFiles_Upload_ValidationErrors(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestFiles_Upload_RespectsCtxCancel asserts the stub returns a
+// context-cancellation error rather than the stub sentinel when the caller
+// has already cancelled the ctx. The real #11 implementation will thread
+// ctx into both HTTP calls; locking the cancel-first behavior here means a
+// switchover that loses the ctx.Err() check fails this test.
+func TestFiles_Upload_RespectsCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := NewFileClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	path := writeTempFile(t, 8)
+	got, err := client.Upload(ctx, path)
+	if err == nil {
+		t.Fatalf("Upload: want ctx.Canceled error, got %+v", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Upload: want errors.Is context.Canceled, got %v", err)
+	}
+	if errors.Is(err, ErrFileUploadNotSupported) {
+		t.Errorf("Upload: cancelled ctx should not surface ErrFileUploadNotSupported, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("Upload: want nil FileRef, got %+v", got)
 	}
 }
 

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -1,0 +1,218 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNewFileClient is a smoke test for the constructor so the gap-check
+// script sees a matching Test function for NewFileClient. It also pins the
+// behavior that the wrapper stores the caller's *Client verbatim (no copy,
+// no indirection), which matters for tests that construct one client and
+// reuse it across resource clients.
+//
+// Name intentionally uses TestNewFileClient (no _Files infix) so
+// scripts/check-test-coverage.sh matches Test<FuncName>. TestFiles_* is
+// the prefix for every other test in this file per the agent brief.
+func TestNewFileClient(t *testing.T) {
+	c := NewClient("k", WithBaseURL("http://example"))
+	got := NewFileClient(c)
+	if got == nil {
+		t.Fatal("NewFileClient: got nil")
+	}
+	if got.c != c {
+		t.Fatalf("NewFileClient: c = %p, want %p", got.c, c)
+	}
+}
+
+// TestFiles_ErrFileUploadNotSupported_MessageReferences11 asserts the error
+// message mentions the pinned version and issue #11, so an operator reading
+// a CLI error knows which tracking issue to watch. Mirrors the teams
+// pattern exactly — if these drift, grepping for "#11" across error
+// messages will lose a hit and the PR that removes it gets flagged.
+func TestFiles_ErrFileUploadNotSupported_MessageReferences11(t *testing.T) {
+	msg := ErrFileUploadNotSupported.Error()
+	if !strings.Contains(msg, NotionAPIVersion) {
+		t.Errorf("ErrFileUploadNotSupported message = %q; want it to mention %q", msg, NotionAPIVersion)
+	}
+	if !strings.Contains(msg, "#11") {
+		t.Errorf("ErrFileUploadNotSupported message = %q; want it to mention %q", msg, "#11")
+	}
+}
+
+// writeTempFile creates a file of the requested size under t.TempDir and
+// returns the absolute path. Size is exact — the file is filled with a
+// repeating byte so callers can round-trip a content assertion without
+// parsing.
+func writeTempFile(t *testing.T, size int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "upload.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create tempfile: %v", err)
+	}
+	defer f.Close()
+	if size > 0 {
+		buf := make([]byte, size)
+		for i := range buf {
+			buf[i] = byte('a')
+		}
+		if _, err := f.Write(buf); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+	}
+	return path
+}
+
+// TestUpload_NotSupported is the headline assertion for the stub: a
+// correctly-validated path still returns ErrFileUploadNotSupported, and the
+// returned FileRef is nil. Uses a tiny real file so the size-cap branch is
+// NOT exercised here — that branch has its own test below.
+//
+// Name intentionally starts with TestUpload so the gap checker matches
+// FileClient.Upload via Test<FuncName>. Remaining upload tests in this
+// file use the TestFiles_Upload_* prefix.
+func TestUpload_NotSupported(t *testing.T) {
+	client := NewFileClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	path := writeTempFile(t, 16)
+	got, err := client.Upload(context.Background(), path)
+	if err == nil {
+		t.Fatalf("Upload: want error, got FileRef %+v", got)
+	}
+	if !errors.Is(err, ErrFileUploadNotSupported) {
+		t.Errorf("Upload: want errors.Is ErrFileUploadNotSupported, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("Upload: want nil FileRef, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "upload.bin") {
+		t.Errorf("Upload: want error to name the file, got %v", err)
+	}
+}
+
+// TestFiles_Upload_MissingAPIKey asserts an unconfigured Client is caught
+// BEFORE path validation, matching PageClient.checkAuth's posture. A missing
+// key is an operator error; surfacing it through ErrMissingAPIKey lets the
+// CLI show a configuration-specific message instead of a generic 401.
+func TestFiles_Upload_MissingAPIKey(t *testing.T) {
+	client := NewFileClient(NewClient("", WithBaseURL("http://127.0.0.1:0")))
+	// A real file is fine — we expect the auth check to short-circuit.
+	path := writeTempFile(t, 1)
+	got, err := client.Upload(context.Background(), path)
+	if err == nil {
+		t.Fatalf("Upload: want error, got %+v", got)
+	}
+	if !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Upload: want errors.Is ErrMissingAPIKey, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("Upload: want nil FileRef, got %+v", got)
+	}
+}
+
+// TestFiles_Upload_ValidationErrors table-drives every client-side rejection
+// path (empty, missing, directory, oversize). Each row asserts the error
+// mentions the path or the cap so operators can action the message.
+func TestFiles_Upload_ValidationErrors(t *testing.T) {
+	// Prepare fixtures once, reuse across rows.
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist.bin")
+	// A directory path.
+	subdir := filepath.Join(dir, "a-dir")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// An oversize file.
+	bigPath := filepath.Join(dir, "big.bin")
+	big, err := os.Create(bigPath)
+	if err != nil {
+		t.Fatalf("create big: %v", err)
+	}
+	if err := big.Truncate(MaxFileUploadBytes + 1); err != nil {
+		t.Fatalf("truncate big: %v", err)
+	}
+	_ = big.Close()
+
+	tests := []struct {
+		name          string
+		path          string
+		wantFragments []string
+	}{
+		{
+			name:          "empty path",
+			path:          "",
+			wantFragments: []string{"path is required"},
+		},
+		{
+			name:          "missing file",
+			path:          missing,
+			wantFragments: []string{"stat", "does-not-exist.bin"},
+		},
+		{
+			name:          "directory",
+			path:          subdir,
+			wantFragments: []string{"a-dir", "directory"},
+		},
+		{
+			name:          "oversize file",
+			path:          bigPath,
+			wantFragments: []string{"big.bin", "exceeds client cap"},
+		},
+	}
+
+	client := NewFileClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.Upload(context.Background(), tt.path)
+			if err == nil {
+				t.Fatalf("Upload(%q): want error, got %+v", tt.path, got)
+			}
+			if got != nil {
+				t.Errorf("Upload(%q): want nil FileRef, got %+v", tt.path, got)
+			}
+			// Validation errors must NOT be wrapped as
+			// ErrFileUploadNotSupported — operators need to see the
+			// specific path problem, not the version-bump stub error.
+			if errors.Is(err, ErrFileUploadNotSupported) {
+				t.Errorf("Upload(%q): validation error should not wrap ErrFileUploadNotSupported, got %v", tt.path, err)
+			}
+			msg := err.Error()
+			for _, frag := range tt.wantFragments {
+				if !strings.Contains(msg, frag) {
+					t.Errorf("Upload(%q): error %q missing fragment %q", tt.path, msg, frag)
+				}
+			}
+		})
+	}
+}
+
+// TestFiles_Upload_ExactlyAtSizeCap verifies the boundary between the
+// accepted and rejected branches. A file of exactly MaxFileUploadBytes must
+// pass validation (and therefore surface the stub error, not a size error).
+// This locks in the ">= vs >" choice so a later refactor cannot drift it
+// without a failing test.
+func TestFiles_Upload_ExactlyAtSizeCap(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "at-cap.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := f.Truncate(MaxFileUploadBytes); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	_ = f.Close()
+
+	client := NewFileClient(NewClient("k", WithBaseURL("http://127.0.0.1:0")))
+	_, err = client.Upload(context.Background(), path)
+	if err == nil {
+		t.Fatal("Upload: want stub error, got nil")
+	}
+	if !errors.Is(err, ErrFileUploadNotSupported) {
+		t.Errorf("Upload at exact cap: want errors.Is ErrFileUploadNotSupported, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #10 — Notion file-upload surface for images, files, page icons, and page covers.

- `utils/files.go`: `FileClient` with `NewFileClient` + `Upload(ctx, path) (*FileRef, error)`. Client-side validation (empty path, missing file, directory, non-regular file, 20MB cap) runs first; then `Upload` returns `ErrFileUploadNotSupported` referencing #11.
- `cmd/files.go`: four new subcommands — `blocks add-image`, `blocks add-file` (with `--name`), `pages set-icon`, `pages set-cover`. All use `RunE` for clean exit codes.

## API version determination — why this is a stub

The Notion docs for `POST /v1/file_uploads` (https://developers.notion.com/reference/create-a-file-upload) enumerate `Notion-Version: 2026-03-11` as the only accepted value. This CLI pins `2022-06-28` (see `utils/client.go:19`), and per the agent brief we do not bump the version in this PR.

**Decision: stub with `ErrFileUploadNotSupported`**, shaped so issue #11's version-bump PR can flip the `Upload` body to the real two-step flow (`POST /v1/file_uploads` → `PUT upload_url`) without changing any caller. `FileRef`, `FileUploadRequest`, and `FileUploadResponse` are exported now so consumers can start building against the surface.

Path validation runs BEFORE the stub error, so operators who typo a path get the specific file error, not the "#11" sentinel.

## Size cap

`utils.MaxFileUploadBytes = 20MB`. Notion itself caps single-part uploads around this range (multi-part goes higher per plan); 20MB is a conservative default that keeps the single-part flow simple for v1. The constant is exported so #11 can revisit without breaking callers.

## Scope discipline

New files only:
- `utils/files.go`, `utils/files_test.go`
- `cmd/files.go`, `cmd/files_test.go`

`cmd/blocks.go` and `cmd/pages.go` are **not touched** — the new subcommands attach to `blocksCmd` / `pagesCmd` from `files.go`'s own `init()`.

## Test evidence

- `make ci` passes (`fmt-check`, `vet`, `test-race`, `cover`, `check-test-gaps`).
- `go test -race ./...` clean.
- Coverage: **86.3% → 86.7%** (total). `utils/files.go` 91.7–100% per function; `cmd/files.go` 100% on helpers.
- Gap check ✓ — `TestNewFileClient` and `TestUpload_NotSupported` satisfy the script; every other test uses the `TestFiles_*` prefix per the agent brief.
- Race detector clean on both packages.

Tests cover:
- `ErrFileUploadNotSupported` mentions `#11` and the pinned version.
- `Upload` with a valid file returns the stub sentinel; a missing-key client returns `ErrMissingAPIKey`; the four validation branches (empty / missing / directory / oversize) return specific errors that do **not** wrap the stub sentinel.
- Exact-boundary test at `MaxFileUploadBytes`.
- `cmd` layer: subcommand registration, `--name` flag presence, full dispatch through `rootCmd.Execute` for all four subcommands (stub path and validation paths), and cobra arg-count enforcement.

## Test plan

- [ ] CI green (dispatched via `gh workflow run test.yml`).
- [ ] Once #11 lands, flip `utils.FileClient.Upload` to do the real two-step flow; no cmd-layer changes needed.