### PR TITLE
feat: --json output mode across all commands (closes #2)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"notioncli/utils"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -13,16 +12,21 @@ var addCmd = &cobra.Command{
 	Short: "Add a new task",
 	Long:  `Add a new task to the Notion ToDo task list page`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		text := args[0]
 		notionAPIKey, pageID := utils.SetAPIConfig()
-		result := utils.AddNewToDoItem(notionAPIKey, pageID, text)
-		if result != nil {
-			fmt.Printf("Error adding new task: %s\n", result)
-			os.Exit(1)
+		if err := utils.AddNewToDoItem(notionAPIKey, pageID, text); err != nil {
+			return jsonErrorOr(cmd, fmt.Errorf("add: %w", err))
 		}
-		fmt.Printf("Task %s added.\n", text)
-
+		if globalJSON {
+			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "add",
+				"text":   text,
+				"type":   "to_do",
+			})
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Task %s added.\n", text)
+		return nil
 	},
 }
 

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -52,13 +52,7 @@ var blocksListCmd = &cobra.Command{
 			if err != nil {
 				return jsonErrorOr(cmd, fmt.Errorf("blocks list: %w", err))
 			}
-			out := cmd.OutOrStdout()
-			for _, b := range blocks {
-				if err := emitJSON(out, b); err != nil {
-					return jsonErrorOr(cmd, err)
-				}
-			}
-			return nil
+			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), blocks))
 		}
 
 		localTimezone, err := utils.GetLocalTimeZone()

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -42,12 +42,29 @@ var blocksListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all blocks on the page",
 	Long:  `List all blocks on the Notion page with their type and content.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		notionAPIKey, pageID := utils.SetAPIConfig()
+		// In --json mode skip the timezone lookup (it is only needed to
+		// format timestamps for human output) and emit raw Notion block
+		// objects as NDJSON.
+		if globalJSON {
+			blocks, err := utils.GetAllBlocks(notionAPIKey, pageID, blockType)
+			if err != nil {
+				return jsonErrorOr(cmd, fmt.Errorf("blocks list: %w", err))
+			}
+			out := cmd.OutOrStdout()
+			for _, b := range blocks {
+				if err := emitJSON(out, b); err != nil {
+					return jsonErrorOr(cmd, err)
+				}
+			}
+			return nil
+		}
+
 		localTimezone, err := utils.GetLocalTimeZone()
 		if err != nil {
 			color.Red("Error getting timezone: %v", err)
-			return
+			return nil
 		}
 
 		formatted, typeCounts, err := utils.FormatAllBlocks(
@@ -58,7 +75,7 @@ var blocksListCmd = &cobra.Command{
 		)
 		if err != nil {
 			color.Red("Error: %v", err)
-			return
+			return nil
 		}
 
 		if len(formatted) == 0 {
@@ -67,14 +84,14 @@ var blocksListCmd = &cobra.Command{
 			} else {
 				color.Yellow("No blocks found on this page.")
 			}
-			return
+			return nil
 		}
 
-		fmt.Println()
+		fmt.Fprintln(cmd.OutOrStdout())
 		for _, line := range formatted {
-			fmt.Println(line)
+			fmt.Fprintln(cmd.OutOrStdout(), line)
 		}
-		fmt.Println()
+		fmt.Fprintln(cmd.OutOrStdout())
 
 		// Print summary
 		var summary []string
@@ -85,6 +102,7 @@ var blocksListCmd = &cobra.Command{
 
 		total := len(formatted)
 		color.Cyan("  %d blocks: %s\n", total, strings.Join(summary, ", "))
+		return nil
 	},
 }
 
@@ -105,7 +123,7 @@ Examples:
   notioncli blocks add "" -t divider           # Add divider (no text needed)
   notioncli blocks add "Buy milk" -t to_do`,
 	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		text := args[0]
 
 		// Validate block type
@@ -114,17 +132,31 @@ Examples:
 		}
 
 		if !utils.IsValidBlockType(blockType) {
-			color.Red("Error: unsupported block type '%s'", blockType)
-			color.Yellow("Supported types: %s", strings.Join(utils.GetSupportedBlockTypeNames(), ", "))
-			return
+			err := fmt.Errorf("unsupported block type %q (supported: %s)",
+				blockType, strings.Join(utils.GetSupportedBlockTypeNames(), ", "))
+			if globalJSON {
+				return jsonErrorOr(cmd, err)
+			}
+			color.Red("Error: %v", err)
+			return nil
 		}
 
 		notionAPIKey, pageID := utils.SetAPIConfig()
 
-		err := utils.AddBlock(notionAPIKey, pageID, blockType, text)
-		if err != nil {
+		if err := utils.AddBlock(notionAPIKey, pageID, blockType, text); err != nil {
+			if globalJSON {
+				return jsonErrorOr(cmd, fmt.Errorf("blocks add: %w", err))
+			}
 			color.Red("Error adding block: %v", err)
-			return
+			return nil
+		}
+
+		if globalJSON {
+			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "add",
+				"type":   blockType,
+				"text":   text,
+			})
 		}
 
 		icon := utils.SupportedBlockTypes[blockType].Icon
@@ -133,6 +165,7 @@ Examples:
 		} else {
 			color.Green("Added %s %s: %s", icon, blockType, text)
 		}
+		return nil
 	},
 }
 
@@ -146,22 +179,35 @@ Use 'notioncli blocks list' to see block numbers.
 Example:
   notioncli blocks delete 3`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		order, err := strconv.Atoi(args[0])
 		if err != nil {
+			wrapped := fmt.Errorf("blocks delete: %q is not a valid number: %w", args[0], err)
+			if globalJSON {
+				return jsonErrorOr(cmd, wrapped)
+			}
 			color.Red("Error: '%s' is not a valid number", args[0])
-			return
+			return nil
 		}
 
 		notionAPIKey, pageID := utils.SetAPIConfig()
 
-		err = utils.DeleteBlock(notionAPIKey, pageID, order)
-		if err != nil {
+		if err := utils.DeleteBlock(notionAPIKey, pageID, order); err != nil {
+			if globalJSON {
+				return jsonErrorOr(cmd, fmt.Errorf("blocks delete: %w", err))
+			}
 			color.Red("Error deleting block: %v", err)
-			return
+			return nil
 		}
 
+		if globalJSON {
+			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "delete",
+				"order":  order,
+			})
+		}
 		color.Green("Deleted block %d", order)
+		return nil
 	},
 }
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"notioncli/utils"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -18,20 +17,23 @@ var checkCmd = &cobra.Command{
 	Short: "Mark a task as complete",
 	Long:  `Mark a ToDo task as complete, e.g., check 1 (marks the first ToDo in the list complete)`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		order, err := strconv.Atoi(args[0])
 		if err != nil {
-			fmt.Printf("Could not convert %q to an integer: %v", args[0], err)
-			os.Exit(1)
+			return jsonErrorOr(cmd, fmt.Errorf("check: parse order %q: %w", args[0], err))
 		}
 		notionAPIKey, pageID := utils.SetAPIConfig()
-		result := utils.MarkToDoBlockChecked(notionAPIKey, pageID, order)
-		if result != nil {
-			fmt.Printf("Error marking task %d as complete: %v\n", order, result)
-			os.Exit(1)
+		if err := utils.MarkToDoBlockChecked(notionAPIKey, pageID, order); err != nil {
+			return jsonErrorOr(cmd, fmt.Errorf("check: mark task %d complete: %w", order, err))
 		}
-		fmt.Printf("Task %d marked complete.\n", order)
-
+		if globalJSON {
+			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "check",
+				"order":  order,
+			})
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Task %d marked complete.\n", order)
+		return nil
 	},
 }
 

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -61,15 +61,10 @@ to emit the raw Notion comment objects as NDJSON on stdout.`,
 		}
 
 		if globalJSON {
-			// NDJSON: one comment object per line. Stable typed shape —
-			// json.Encoder re-marshal is lossless here, no Raw needed.
-			out := cmd.OutOrStdout()
-			for _, c := range comments {
-				if err := emitJSON(out, c); err != nil {
-					return jsonErrorOr(cmd, err)
-				}
-			}
-			return nil
+			// emitList picks NDJSON or a pretty JSON array based on
+			// --pretty. Stable typed shape — json.Encoder re-marshal is
+			// lossless here, no Raw needed.
+			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), comments))
 		}
 
 		if len(comments) == 0 {

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -6,9 +6,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"notioncli/utils"
@@ -20,11 +18,13 @@ import (
 // Flag state for the comments subcommands. Declared at package scope so
 // cobra's StringVar bindings attach to stable addresses, matching the
 // pattern used by blocks.go / list.go.
+//
+// JSON output is driven by the persistent --json flag on rootCmd
+// (globalJSON); comments used to own local --json flags but now share
+// the global one so all commands behave consistently.
 var (
-	commentsListJSON     bool
 	commentsCreateText   string
 	commentsCreateDiscID string
-	commentsCreateJSON   bool
 )
 
 // commentsCmd is the parent command for comment operations.
@@ -46,10 +46,10 @@ var commentsListCmd = &cobra.Command{
 	Short: "List comments attached to a page or block",
 	Long: `List every comment on the given page or block, following pagination.
 
-Output defaults to a human-readable summary. Pass --json to emit the raw
-Notion comment objects as a JSON array on stdout.`,
+Output defaults to a human-readable summary. Pass the global --json flag
+to emit the raw Notion comment objects as NDJSON on stdout.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
 		notionAPIKey, _ := utils.SetAPIConfig()
 		client := utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL()))
@@ -57,28 +57,33 @@ Notion comment objects as a JSON array on stdout.`,
 
 		comments, err := cc.List(context.Background(), target)
 		if err != nil {
-			color.Red("Error listing comments: %v", err)
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("comments list: %w", err))
 		}
 
-		if commentsListJSON {
-			if err := json.NewEncoder(os.Stdout).Encode(comments); err != nil {
-				color.Red("Error encoding JSON: %v", err)
+		if globalJSON {
+			// NDJSON: one comment object per line. Stable typed shape —
+			// json.Encoder re-marshal is lossless here, no Raw needed.
+			out := cmd.OutOrStdout()
+			for _, c := range comments {
+				if err := emitJSON(out, c); err != nil {
+					return jsonErrorOr(cmd, err)
+				}
 			}
-			return
+			return nil
 		}
 
 		if len(comments) == 0 {
 			color.Yellow("No comments found.")
-			return
+			return nil
 		}
 
-		fmt.Println()
+		fmt.Fprintln(cmd.OutOrStdout())
 		for _, c := range comments {
-			fmt.Println(formatComment(c))
+			fmt.Fprintln(cmd.OutOrStdout(), formatComment(c))
 		}
-		fmt.Println()
+		fmt.Fprintln(cmd.OutOrStdout())
 		color.Cyan("  %d comment(s)", len(comments))
+		return nil
 	},
 }
 
@@ -99,11 +104,10 @@ as parent.block_id regardless of whether it refers to a page or a block.
 The Notion comments API treats page ids as block ids for this endpoint, so
 a single field serves both cases.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
 		if strings.TrimSpace(commentsCreateText) == "" {
-			color.Red("Error: --text is required")
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("comments create: --text is required"))
 		}
 
 		req := utils.CreateCommentRequest{
@@ -126,18 +130,15 @@ a single field serves both cases.`,
 
 		created, err := cc.Create(context.Background(), req)
 		if err != nil {
-			color.Red("Error creating comment: %v", err)
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("comments create: %w", err))
 		}
 
-		if commentsCreateJSON {
-			if err := json.NewEncoder(os.Stdout).Encode(created); err != nil {
-				color.Red("Error encoding JSON: %v", err)
-			}
-			return
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), created))
 		}
 
 		color.Green("Created comment %s", created.ID)
+		return nil
 	},
 }
 
@@ -178,9 +179,6 @@ func init() {
 	commentsCmd.AddCommand(commentsListCmd)
 	commentsCmd.AddCommand(commentsCreateCmd)
 
-	commentsListCmd.Flags().BoolVar(&commentsListJSON, "json", false, "Emit raw Notion objects as JSON")
-
 	commentsCreateCmd.Flags().StringVar(&commentsCreateText, "text", "", "Comment text (required)")
 	commentsCreateCmd.Flags().StringVar(&commentsCreateDiscID, "discussion-id", "", "Reply to an existing discussion thread")
-	commentsCreateCmd.Flags().BoolVar(&commentsCreateJSON, "json", false, "Emit the created comment as JSON")
 }

--- a/cmd/comments_test.go
+++ b/cmd/comments_test.go
@@ -179,7 +179,7 @@ func TestCommentsListDispatch(t *testing.T) {
 	})
 
 	// Reset shared flag state in case a previous test toggled it.
-	commentsListJSON = false
+	resetGlobalOutputFlags()
 
 	resetRootCmdArgs()
 	var out bytes.Buffer
@@ -221,7 +221,7 @@ func TestCommentsCreateDispatch(t *testing.T) {
 
 	commentsCreateText = ""
 	commentsCreateDiscID = ""
-	commentsCreateJSON = false
+	resetGlobalOutputFlags()
 
 	resetRootCmdArgs()
 	var out bytes.Buffer
@@ -261,7 +261,7 @@ func TestCommentsCreateReplyDispatch(t *testing.T) {
 
 	commentsCreateText = ""
 	commentsCreateDiscID = ""
-	commentsCreateJSON = false
+	resetGlobalOutputFlags()
 
 	resetRootCmdArgs()
 	var out bytes.Buffer
@@ -302,8 +302,11 @@ func TestCommentsCreateMissingText(t *testing.T) {
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"comments", "create", "block-xyz"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("rootCmd.Execute: %v", err)
+	// Missing --text is now a validation error returned by RunE. The
+	// previous implementation logged and returned nil; this is the
+	// deliberate upgrade so cobra's exit code reflects the failure.
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error on missing --text, got nil")
 	}
 	if atomic.LoadInt64(&posted) != 0 {
 		t.Error("missing --text should short-circuit before POST")

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -104,11 +104,14 @@ var databasesGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dc, err := newDatabaseClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		db, err := dc.Get(context.Background(), args[0])
 		if err != nil {
-			return fmt.Errorf("get database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("get database: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), db))
 		}
 		printDatabase(cmd.OutOrStdout(), db)
 		return nil
@@ -125,19 +128,30 @@ var databasesQueryCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filter, err := readJSONFile(dbQueryFilterJSON)
 		if err != nil {
-			return fmt.Errorf("query database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("query database: %w", err))
 		}
 		sort, err := readJSONFile(dbQuerySortJSON)
 		if err != nil {
-			return fmt.Errorf("query database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("query database: %w", err))
 		}
 		dc, err := newDatabaseClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		results, err := dc.QueryAll(context.Background(), args[0], filter, sort, dbQueryLimit)
 		if err != nil {
-			return fmt.Errorf("query database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("query database: %w", err))
+		}
+		if globalJSON {
+			// NDJSON: one JSON object per page row. Matches the shape
+			// printQueryResults already emits when --json was the default.
+			out := cmd.OutOrStdout()
+			for _, p := range results {
+				if err := emitJSON(out, p); err != nil {
+					return jsonErrorOr(cmd, err)
+				}
+			}
+			return nil
 		}
 		printQueryResults(cmd.OutOrStdout(), results)
 		return nil
@@ -150,15 +164,15 @@ var databasesCreateCmd = &cobra.Command{
 	Short: "Create a new database under --parent",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if dbCreateParent == "" {
-			return fmt.Errorf("create database: --parent is required")
+			return jsonErrorOr(cmd, fmt.Errorf("create database: --parent is required"))
 		}
 		props, err := readPropertiesFile(dbCreatePropsFile)
 		if err != nil {
-			return fmt.Errorf("create database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("create database: %w", err))
 		}
 		dc, err := newDatabaseClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		db, err := dc.Create(context.Background(), utils.CreateDatabaseRequest{
 			Parent:     utils.PageParent{PageID: dbCreateParent},
@@ -166,7 +180,10 @@ var databasesCreateCmd = &cobra.Command{
 			Properties: props,
 		})
 		if err != nil {
-			return fmt.Errorf("create database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("create database: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), db))
 		}
 		color.Green("Created database %s", db.ID)
 		printDatabase(cmd.OutOrStdout(), db)
@@ -184,21 +201,24 @@ var databasesUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		props, err := readPropertiesFile(dbUpdatePropsFile)
 		if err != nil {
-			return fmt.Errorf("update database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("update database: %w", err))
 		}
 		if dbUpdateTitle == "" && len(props) == 0 {
-			return fmt.Errorf("update database: at least one of --title or --properties-json is required")
+			return jsonErrorOr(cmd, fmt.Errorf("update database: at least one of --title or --properties-json is required"))
 		}
 		dc, err := newDatabaseClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		db, err := dc.Update(context.Background(), args[0], utils.UpdateDatabaseRequest{
 			Title:      dbUpdateTitle,
 			Properties: props,
 		})
 		if err != nil {
-			return fmt.Errorf("update database: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("update database: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), db))
 		}
 		color.Green("Updated database %s", db.ID)
 		printDatabase(cmd.OutOrStdout(), db)

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -143,15 +143,9 @@ var databasesQueryCmd = &cobra.Command{
 			return jsonErrorOr(cmd, fmt.Errorf("query database: %w", err))
 		}
 		if globalJSON {
-			// NDJSON: one JSON object per page row. Matches the shape
-			// printQueryResults already emits when --json was the default.
-			out := cmd.OutOrStdout()
-			for _, p := range results {
-				if err := emitJSON(out, p); err != nil {
-					return jsonErrorOr(cmd, err)
-				}
-			}
-			return nil
+			// emitList picks NDJSON (one object per line) or a pretty
+			// JSON array, depending on --pretty.
+			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), results))
 		}
 		printQueryResults(cmd.OutOrStdout(), results)
 		return nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"notioncli/utils"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -18,20 +17,23 @@ var deleteCmd = &cobra.Command{
 	Short: "Remove a task from the task list",
 	Long:  `Completely delete a task, e.g., delete 2 (removes the second task)`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		order, err := strconv.Atoi(args[0])
 		if err != nil {
-			fmt.Printf("Could not convert %q to an integer: %v", args[0], err)
-			os.Exit(1)
+			return jsonErrorOr(cmd, fmt.Errorf("delete: parse order %q: %w", args[0], err))
 		}
 		notionAPIKey, pageID := utils.SetAPIConfig()
-		result := utils.DeleteToDoBlock(notionAPIKey, pageID, order)
-		if result != nil {
-			fmt.Printf("Error removing task %d : %v\n", order, result)
-			os.Exit(1)
+		if err := utils.DeleteToDoBlock(notionAPIKey, pageID, order); err != nil {
+			return jsonErrorOr(cmd, fmt.Errorf("delete: remove task %d: %w", order, err))
 		}
-		fmt.Printf("Task %d removed.\n", order)
-
+		if globalJSON {
+			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "delete",
+				"order":  order,
+			})
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Task %d removed.\n", order)
+		return nil
 	},
 }
 

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -46,11 +46,14 @@ returns the file id and name only.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := newFileClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		ref, err := fc.Upload(context.Background(), args[0])
 		if err != nil {
-			return fmt.Errorf("add-image: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("add-image: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), ref))
 		}
 		color.Green("Uploaded image %s (id=%s) — block append deferred", ref.Name, ref.ID)
 		return nil
@@ -72,15 +75,18 @@ returns the file id and name only.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := newFileClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		ref, err := fc.Upload(context.Background(), args[0])
 		if err != nil {
-			return fmt.Errorf("add-file: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("add-file: %w", err))
 		}
 		name := blocksAddFileName
 		if name == "" {
 			name = ref.Name
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), ref))
 		}
 		color.Green("Uploaded file %s (id=%s) — block append deferred", name, ref.ID)
 		return nil
@@ -100,11 +106,14 @@ command currently returns the file id only.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := newFileClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		ref, err := fc.Upload(context.Background(), args[1])
 		if err != nil {
-			return fmt.Errorf("set-icon: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("set-icon: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), ref))
 		}
 		color.Green("Uploaded icon for page %s (file id=%s) — icon PATCH deferred", args[0], ref.ID)
 		return nil
@@ -124,11 +133,14 @@ command currently returns the file id only.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fc, err := newFileClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		ref, err := fc.Upload(context.Background(), args[1])
 		if err != nil {
-			return fmt.Errorf("set-cover: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("set-cover: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), ref))
 		}
 		color.Green("Uploaded cover for page %s (file id=%s) — cover PATCH deferred", args[0], ref.ID)
 		return nil

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -86,7 +86,18 @@ returns the file id and name only.`,
 			name = ref.Name
 		}
 		if globalJSON {
-			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), ref))
+			// Emit an action envelope so the caller's --name is visible
+			// in the JSON stream. ref itself is nested so consumers can
+			// still pick the raw upload response off it; `name` on the
+			// envelope is the name the caller asked for (the value
+			// displayed in Notion), which can differ from ref.Name when
+			// --name overrides it.
+			return jsonErrorOr(cmd, emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "add-file",
+				"id":     ref.ID,
+				"name":   name,
+				"ref":    ref,
+			}))
 		}
 		color.Green("Uploaded file %s (id=%s) — block append deferred", name, ref.ID)
 		return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,19 +27,13 @@ var listCmd = &cobra.Command{
 		// mirrors the blocks list split (typed objects pass-through).
 		if globalJSON {
 			// GetAllBlocks with "to_do" mirrors the human list by only
-			// returning to-do blocks. NDJSON: one raw Notion block object
-			// per line.
+			// returning to-do blocks. emitList picks NDJSON or a pretty
+			// JSON array depending on --pretty.
 			blocks, err := utils.GetAllBlocks(notionAPIKey, pageID, "to_do")
 			if err != nil {
 				return jsonErrorOr(cmd, fmt.Errorf("list: fetch blocks: %w", err))
 			}
-			out := cmd.OutOrStdout()
-			for _, b := range blocks {
-				if err := emitJSON(out, b); err != nil {
-					return jsonErrorOr(cmd, err)
-				}
-			}
-			return nil
+			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), blocks))
 		}
 
 		brightWhite := color.New(color.FgHiWhite).SprintFunc()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"notioncli/utils"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -17,23 +16,41 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all tasks",
 	Long:  `List all tasks in the Notion page`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		notionAPIKey, pageID := utils.SetAPIConfig()
 		localTimezone, err := utils.GetLocalTimeZone()
-		brightWhite := color.New(color.FgHiWhite).SprintFunc()
 		if err != nil {
-			fmt.Println("Error getting the local time zone: ", err)
-			os.Exit(1)
+			return jsonErrorOr(cmd, fmt.Errorf("list: resolve local time zone: %w", err))
 		}
+		// In --json mode we want the raw Notion block objects so consumers
+		// can jq on them; the formatted lines are for humans only. This
+		// mirrors the blocks list split (typed objects pass-through).
+		if globalJSON {
+			// GetAllBlocks with "to_do" mirrors the human list by only
+			// returning to-do blocks. NDJSON: one raw Notion block object
+			// per line.
+			blocks, err := utils.GetAllBlocks(notionAPIKey, pageID, "to_do")
+			if err != nil {
+				return jsonErrorOr(cmd, fmt.Errorf("list: fetch blocks: %w", err))
+			}
+			out := cmd.OutOrStdout()
+			for _, b := range blocks {
+				if err := emitJSON(out, b); err != nil {
+					return jsonErrorOr(cmd, err)
+				}
+			}
+			return nil
+		}
+
+		brightWhite := color.New(color.FgHiWhite).SprintFunc()
 		blocks, err := utils.GetToDoBlocks(notionAPIKey, pageID, localTimezone)
 		if err != nil {
-			fmt.Println("Error getting blocks from the pageID: ", err)
-
-			os.Exit(1)
+			return fmt.Errorf("list: fetch to-do blocks: %w", err)
 		}
 		for _, block := range blocks {
-			fmt.Println(brightWhite(block))
+			fmt.Fprintln(cmd.OutOrStdout(), brightWhite(block))
 		}
+		return nil
 	},
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -23,8 +23,11 @@ func TestListCmdMetadata(t *testing.T) {
 			if c.Long == "" {
 				t.Error("list: Long description is empty")
 			}
-			if c.Run == nil {
-				t.Error("list: Run function not set")
+			// list was migrated from Run to RunE to surface errors for
+			// the --json path. Either handler being set keeps backward
+			// compatibility with any test that predates the migration.
+			if c.Run == nil && c.RunE == nil {
+				t.Error("list: Run/RunE function not set")
 			}
 			break
 		}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -39,9 +39,7 @@ var globalOutput string
 
 // emitJSON encodes v as a JSON document to w and terminates the line with
 // a newline. When globalPretty is set the encoder uses a two-space indent;
-// otherwise the encoder's default compact form is used. Callers pass a
-// slice for list commands (one document), or call emitJSONLine per
-// element for NDJSON.
+// otherwise the encoder's default compact form is used.
 //
 // Note: json.Encoder.Encode writes a trailing newline itself, so callers
 // should not append one.
@@ -56,22 +54,43 @@ func emitJSON(w io.Writer, v interface{}) error {
 	return nil
 }
 
-// emitJSONLines encodes every element of items on its own line (NDJSON).
-// When globalPretty is set each element is pretty-printed but still
-// terminated with a single newline between elements. This is the shape
-// list commands (blocks list, databases query, users list, comments
-// list, search) use when --json is on.
-func emitJSONLines(w io.Writer, items interface{}) error {
+// emitList is the canonical emitter for list commands (blocks list,
+// databases query, users list, teams list, comments list, list, search,
+// etc.). It picks the output shape based on globalPretty:
+//
+//   - globalPretty == false → NDJSON: one compact JSON object per line.
+//     This is the pipe-friendly shape and the default for --json on a
+//     list command. `jq -c` consumers should use this.
+//
+//   - globalPretty == true  → a single indented JSON array containing all
+//     elements. This is the human-inspection shape. Conventionally jq, gh,
+//     and friends do the same: compact NDJSON for piping, pretty array
+//     for eyeballing. Indented NDJSON would be broken (each record spans
+//     multiple lines) so we deliberately do not offer that combination.
+//
+// items must be a slice. Anything else is a programmer error and returns
+// a descriptive error rather than panicking.
+func emitList(w io.Writer, items interface{}) error {
 	// Reflect over a generic []T so every call site can pass the typed
-	// slice it already has without a pre-conversion step. This is only
-	// called during output, so the reflect cost is negligible.
+	// slice it already has without a pre-conversion step. This only runs
+	// during output, so the reflect cost is negligible.
 	rv := reflect.ValueOf(items)
 	if !rv.IsValid() || rv.Kind() != reflect.Slice {
-		return fmt.Errorf("emit json lines: want slice, got %T", items)
+		return fmt.Errorf("emit list: want slice, got %T", items)
 	}
+	if globalPretty {
+		// Single pretty-printed JSON array. emitJSON handles the indent
+		// and trailing newline.
+		return emitJSON(w, items)
+	}
+	// Compact NDJSON. Force the per-element encoder into compact mode by
+	// calling json.Encoder directly (ignoring globalPretty, which is
+	// false here anyway) so this path stays valid NDJSON no matter what
+	// global state callers might have flipped.
+	enc := json.NewEncoder(w)
 	for i := 0; i < rv.Len(); i++ {
-		if err := emitJSON(w, rv.Index(i).Interface()); err != nil {
-			return err
+		if err := enc.Encode(rv.Index(i).Interface()); err != nil {
+			return fmt.Errorf("emit list: %w", err)
 		}
 	}
 	return nil

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,152 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// globalJSON and globalPretty back the persistent --json and --pretty flags
+// wired on rootCmd. They are package-level vars so every subcommand can
+// consult them from its Run/RunE without drilling the *cobra.Command.
+//
+// Design note: every subcommand should branch on globalJSON early and emit
+// JSON via the helpers below, or fall through to the existing human output
+// path. Per the --json precedent set by #20 (search), follow this split:
+//
+//   - Heterogeneous endpoints (search, page/database fetches whose full
+//     shape the CLI does not fully model) prefer a Raw json.RawMessage
+//     pass-through so unknown fields survive the round-trip.
+//   - Stable typed responses (blocks list, comment list, user list, todo
+//     list, etc.) use plain json.Encoder.Encode on the typed struct.
+var (
+	globalJSON   bool
+	globalPretty bool
+)
+
+// globalOutput backs --output=text|json and is a string alias for the
+// boolean --json flag so scripts can choose either form. The PreRunE
+// normalises "json" -> globalJSON = true.
+var globalOutput string
+
+// emitJSON encodes v as a JSON document to w and terminates the line with
+// a newline. When globalPretty is set the encoder uses a two-space indent;
+// otherwise the encoder's default compact form is used. Callers pass a
+// slice for list commands (one document), or call emitJSONLine per
+// element for NDJSON.
+//
+// Note: json.Encoder.Encode writes a trailing newline itself, so callers
+// should not append one.
+func emitJSON(w io.Writer, v interface{}) error {
+	enc := json.NewEncoder(w)
+	if globalPretty {
+		enc.SetIndent("", "  ")
+	}
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("emit json: %w", err)
+	}
+	return nil
+}
+
+// emitJSONLines encodes every element of items on its own line (NDJSON).
+// When globalPretty is set each element is pretty-printed but still
+// terminated with a single newline between elements. This is the shape
+// list commands (blocks list, databases query, users list, comments
+// list, search) use when --json is on.
+func emitJSONLines(w io.Writer, items interface{}) error {
+	// Reflect over a generic []T so every call site can pass the typed
+	// slice it already has without a pre-conversion step. This is only
+	// called during output, so the reflect cost is negligible.
+	rv := reflect.ValueOf(items)
+	if !rv.IsValid() || rv.Kind() != reflect.Slice {
+		return fmt.Errorf("emit json lines: want slice, got %T", items)
+	}
+	for i := 0; i < rv.Len(); i++ {
+		if err := emitJSON(w, rv.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitError writes a single-line JSON error object to w. Always called on
+// cmd.ErrOrStderr() so the stdout stream stays a valid NDJSON pipe for
+// jq consumers even when something fails. The encoder's trailing
+// newline terminates the line.
+func emitError(w io.Writer, err error) {
+	if err == nil {
+		return
+	}
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(map[string]string{"error": err.Error()})
+}
+
+// jsonErrorOr is the RunE error-wrap helper. Usage:
+//
+//	return jsonErrorOr(cmd, err)
+//
+// When globalJSON is set and err is non-nil, a one-line JSON error object
+// is emitted to cmd.ErrOrStderr() before the error is returned so cobra
+// still sets a non-zero exit code. The helper is a no-op when err is
+// nil, so it is safe to wrap every terminal return in a RunE.
+func jsonErrorOr(cmd *cobra.Command, err error) error {
+	if err != nil && globalJSON {
+		emitError(cmd.ErrOrStderr(), err)
+	}
+	return err
+}
+
+// emitOK emits a minimal success envelope for commands that have no
+// natural result payload (delete, archive, unarchive, check, uncheck).
+// The envelope is {"ok":true, ...extras} so consumers can grep or jq on
+// the shape without special-casing empty bodies.
+func emitOK(w io.Writer, extras map[string]interface{}) error {
+	obj := map[string]interface{}{"ok": true}
+	for k, v := range extras {
+		obj[k] = v
+	}
+	return emitJSON(w, obj)
+}
+
+// disableColor turns off fatih/color ANSI escapes globally. Called from
+// the rootCmd PersistentPreRunE whenever --json (or --output=json) is on
+// so commands that still call color.Green / color.Red in their output
+// path do not bleed escape codes into the JSON stream.
+func disableColor() {
+	color.NoColor = true
+}
+
+// applyGlobalOutput normalises the --output=text|json alias into the
+// globalJSON boolean. Invalid values surface an error so typos do not
+// silently degrade to text output. Empty --output leaves globalJSON
+// alone (the --json flag still controls).
+func applyGlobalOutput() error {
+	switch globalOutput {
+	case "":
+		return nil
+	case "text":
+		globalJSON = false
+		return nil
+	case "json":
+		globalJSON = true
+		return nil
+	}
+	return fmt.Errorf("invalid --output %q (want text|json)", globalOutput)
+}
+
+// resetGlobalOutputFlags is used by tests to return to the default
+// state between runs. cobra retains bound flag values across the
+// process so this reset is required to keep tests hermetic.
+func resetGlobalOutputFlags() {
+	globalJSON = false
+	globalPretty = false
+	globalOutput = ""
+}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -139,8 +139,9 @@ func TestEmitJSON_Pretty(t *testing.T) {
 	}
 }
 
-// TestEmitJSONLines writes NDJSON from a typed slice.
-func TestEmitJSONLines(t *testing.T) {
+// TestEmitList_CompactNDJSON verifies the default list path emits one
+// compact JSON object per line (NDJSON).
+func TestEmitList_CompactNDJSON(t *testing.T) {
 	t.Cleanup(resetGlobalOutputFlags)
 	resetGlobalOutputFlags()
 	var buf bytes.Buffer
@@ -148,8 +149,8 @@ func TestEmitJSONLines(t *testing.T) {
 		{ID: "u1", Name: "Ada"},
 		{ID: "u2", Name: "Grace"},
 	}
-	if err := emitJSONLines(&buf, items); err != nil {
-		t.Fatalf("emitJSONLines: %v", err)
+	if err := emitList(&buf, items); err != nil {
+		t.Fatalf("emitList: %v", err)
 	}
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
 	if len(lines) != 2 {
@@ -160,10 +161,48 @@ func TestEmitJSONLines(t *testing.T) {
 		if err := json.Unmarshal([]byte(l), &u); err != nil {
 			t.Errorf("line %d: %v", i, err)
 		}
+		if strings.Contains(l, "  ") {
+			t.Errorf("line %d unexpectedly indented: %q", i, l)
+		}
 	}
 	// Non-slice input must error.
-	if err := emitJSONLines(&buf, map[string]int{"a": 1}); err == nil {
-		t.Error("emitJSONLines: want error on non-slice input")
+	if err := emitList(&buf, map[string]int{"a": 1}); err == nil {
+		t.Error("emitList: want error on non-slice input")
+	}
+}
+
+// TestEmitList_PrettyArray verifies --pretty switches the list path to
+// a single indented JSON array (still valid JSON — this is the fix for
+// the multi-line-NDJSON bug flagged in PR #28 review).
+func TestEmitList_PrettyArray(t *testing.T) {
+	t.Cleanup(resetGlobalOutputFlags)
+	resetGlobalOutputFlags()
+	globalPretty = true
+	var buf bytes.Buffer
+	items := []utils.User{
+		{ID: "u1", Name: "Ada"},
+		{ID: "u2", Name: "Grace"},
+	}
+	if err := emitList(&buf, items); err != nil {
+		t.Fatalf("emitList: %v", err)
+	}
+	// The whole output must be a single valid JSON array — not NDJSON.
+	var arr []utils.User
+	if err := json.Unmarshal(buf.Bytes(), &arr); err != nil {
+		t.Fatalf("pretty output is not a single JSON array: %v (%q)", err, buf.String())
+	}
+	if len(arr) != 2 {
+		t.Fatalf("want 2 elements, got %d", len(arr))
+	}
+	// Must be indented — the indent marker appears inside the array.
+	if !strings.Contains(buf.String(), "\n  ") {
+		t.Errorf("pretty output missing indent:\n%s", buf.String())
+	}
+	// Must start with '[' and end with ']\n' so downstream parsers
+	// treating it as a JSON document work.
+	s := strings.TrimRight(buf.String(), "\n")
+	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
+		t.Errorf("pretty output is not a single array: %q", s)
 	}
 }
 
@@ -687,10 +726,10 @@ func TestDatabases_Query_JSON(t *testing.T) {
 	}
 }
 
-// TestDatabases_Query_JSONPretty verifies --pretty indents output.
-// We can't require NDJSON in pretty mode (each element spans multiple
-// lines), so we just assert the indent is present.
-func TestDatabases_Query_JSONPretty(t *testing.T) {
+// TestDatabases_Query_JSON_Pretty verifies --pretty on a list command
+// emits a single indented JSON array (the whole output parses as a
+// single JSON document), not broken multi-line NDJSON.
+func TestDatabases_Query_JSON_Pretty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -698,6 +737,7 @@ func TestDatabases_Query_JSONPretty(t *testing.T) {
 			"has_more": false,
 			"results": []map[string]interface{}{
 				{"object": "page", "id": "p1", "url": "u"},
+				{"object": "page", "id": "p2", "url": "u"},
 			},
 		})
 	}))
@@ -716,8 +756,45 @@ func TestDatabases_Query_JSONPretty(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	assertNoANSI(t, out.String())
-	if !strings.Contains(out.String(), "\n  \"") {
-		t.Errorf("pretty output missing indent:\n%s", out.String())
+	// Whole output must parse as a single JSON array.
+	var arr []map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &arr); err != nil {
+		t.Fatalf("pretty list output is not a single JSON array: %v (%q)", err, out.String())
+	}
+	if len(arr) != 2 {
+		t.Errorf("want 2 elements, got %d: %q", len(arr), out.String())
+	}
+	// Pretty-printed arrays put each element on its own line; an
+	// element key sits at 4-space indent (2 for array nesting + 2 for
+	// object member).
+	if !strings.Contains(out.String(), "\n    \"") {
+		t.Errorf("pretty output missing indented member:\n%s", out.String())
+	}
+}
+
+// TestBlocks_List_JSON_Pretty asserts the same array-not-NDJSON shape
+// on the blocks list command specifically (the one called out in the
+// review).
+func TestBlocks_List_JSON_Pretty(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "list", "--json", "--pretty"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	// Must parse as a single JSON array (not NDJSON).
+	var arr []map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &arr); err != nil {
+		t.Fatalf("blocks list --pretty is not a JSON array: %v (%q)", err, out.String())
+	}
+	if len(arr) == 0 {
+		t.Fatalf("no elements in pretty array: %q", out.String())
 	}
 }
 

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -823,7 +823,9 @@ func TestViews_Create_JSON(t *testing.T) {
 }
 
 // TestFiles_AddFile_JSON drives `blocks add-file <path> --json` against
-// the existing file-upload mock (two-step in cmdMockServer).
+// the existing file-upload mock (two-step in cmdMockServer) and asserts
+// the envelope shape: {"ok":true, "action":"add-file", "id":"...",
+// "name":"<basename>", "ref":{...}}.
 func TestFiles_AddFile_JSON(t *testing.T) {
 	srv := withCmdEnv(t)
 	_ = srv
@@ -845,10 +847,53 @@ func TestFiles_AddFile_JSON(t *testing.T) {
 	assertNoANSI(t, out.String())
 	objs := assertNDJSON(t, out.String())
 	if len(objs) != 1 {
-		t.Fatalf("want 1 fileref, got %d: %q", len(objs), out.String())
+		t.Fatalf("want 1 envelope, got %d: %q", len(objs), out.String())
 	}
-	if id, _ := objs[0]["id"].(string); id == "" {
-		t.Errorf("file ref missing id: %v", objs[0])
+	env := objs[0]
+	if env["ok"] != true {
+		t.Errorf("ok = %v, want true", env["ok"])
+	}
+	if env["action"] != "add-file" {
+		t.Errorf("action = %v, want add-file", env["action"])
+	}
+	if id, _ := env["id"].(string); id == "" {
+		t.Errorf("envelope missing id: %v", env)
+	}
+	// Without --name, name falls back to the upload ref's name.
+	if name, _ := env["name"].(string); name == "" {
+		t.Errorf("envelope missing name: %v", env)
+	}
+	if _, ok := env["ref"].(map[string]interface{}); !ok {
+		t.Errorf("envelope missing ref object: %v", env)
+	}
+}
+
+// TestFiles_AddFile_JSON_NameOverride verifies --name is surfaced in
+// the JSON envelope so callers can correlate the name they asked for
+// with the upload result. Addresses PR #28 reviewer's ask that --name
+// be visible in JSON output.
+func TestFiles_AddFile_JSON_NameOverride(t *testing.T) {
+	_ = withCmdEnv(t)
+	tmp := t.TempDir() + "/hello.txt"
+	if err := writeTestFile(tmp, "hello"); err != nil {
+		t.Fatalf("writeTestFile: %v", err)
+	}
+	resetGlobalOutputFlags()
+	blocksAddFileName = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add-file", tmp, "--name", "display-name.txt", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 envelope, got %d: %q", len(objs), out.String())
+	}
+	if got := objs[0]["name"]; got != "display-name.txt" {
+		t.Errorf("name = %v, want display-name.txt (envelope=%v)", got, objs[0])
 	}
 }
 

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,0 +1,781 @@
+// Tests for the cross-command --json output plumbing (cmd/output.go,
+// cmd/root.go persistent flags, per-command JSON branches).
+//
+// Each test uses a _JSON suffix to avoid name collisions with the
+// existing dispatch/metadata tests. These tests do NOT call t.Parallel
+// — they share the rootCmd singleton and package-level flag vars with
+// the rest of the cmd package.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// ansiEscape matches any ANSI CSI sequence. Tests use this to assert
+// JSON output is free of terminal escape codes so jq / downstream
+// parsers never see colour noise bleed into stdout.
+var ansiEscape = regexp.MustCompile("\x1b\\[[0-9;]*[A-Za-z]")
+
+// assertNoANSI fails the test if s contains an ANSI escape. Called on
+// JSON output paths only; human paths deliberately include colour.
+func assertNoANSI(t *testing.T, s string) {
+	t.Helper()
+	if m := ansiEscape.FindString(s); m != "" {
+		t.Errorf("output contains ANSI escape %q:\n%s", m, s)
+	}
+}
+
+// assertNDJSON parses every non-empty line of s as a JSON object and
+// returns the decoded objects. Fails the test on any parse error.
+func assertNDJSON(t *testing.T, s string) []map[string]interface{} {
+	t.Helper()
+	var out []map[string]interface{}
+	for i, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "{") {
+			// Skip lines that aren't JSON objects (e.g. if a test
+			// accidentally captures a banner) but surface them for
+			// debugging.
+			t.Logf("skipping non-JSON line %d: %q", i, line)
+			continue
+		}
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Errorf("line %d not valid JSON: %v (%q)", i, err, line)
+			continue
+		}
+		out = append(out, obj)
+	}
+	return out
+}
+
+// TestRootPersistentFlags verifies the persistent --json, --pretty, and
+// --output flags are wired on rootCmd and resolvable via any subcommand.
+func TestRootPersistentFlags(t *testing.T) {
+	for _, name := range []string{"json", "pretty", "output"} {
+		f := rootCmd.PersistentFlags().Lookup(name)
+		if f == nil {
+			t.Fatalf("rootCmd.PersistentFlags missing --%s", name)
+		}
+	}
+	// Subcommand inheritance: users list must resolve --json from the
+	// root's persistent flag set (it was migrated from a local flag).
+	usersList := findUsersSubcommand(t, "list")
+	if f := usersList.Flag("json"); f == nil {
+		t.Error("users list: persistent --json not inherited")
+	}
+}
+
+// TestApplyGlobalOutput covers the --output=text|json translation.
+func TestApplyGlobalOutput(t *testing.T) {
+	t.Cleanup(resetGlobalOutputFlags)
+	tests := []struct {
+		in       string
+		wantJSON bool
+		wantErr  bool
+	}{
+		{"", false, false},
+		{"text", false, false},
+		{"json", true, false},
+		{"yaml", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			resetGlobalOutputFlags()
+			globalOutput = tt.in
+			err := applyGlobalOutput()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if !tt.wantErr && globalJSON != tt.wantJSON {
+				t.Errorf("globalJSON=%v want %v", globalJSON, tt.wantJSON)
+			}
+		})
+	}
+}
+
+// TestEmitJSON_Compact verifies compact output uses a single line.
+func TestEmitJSON_Compact(t *testing.T) {
+	t.Cleanup(resetGlobalOutputFlags)
+	resetGlobalOutputFlags()
+	var buf bytes.Buffer
+	if err := emitJSON(&buf, map[string]string{"a": "b"}); err != nil {
+		t.Fatalf("emitJSON: %v", err)
+	}
+	if got := buf.String(); got != "{\"a\":\"b\"}\n" {
+		t.Errorf("compact emitJSON = %q, want {\"a\":\"b\"}\\n", got)
+	}
+}
+
+// TestEmitJSON_Pretty verifies --pretty produces indented output.
+func TestEmitJSON_Pretty(t *testing.T) {
+	t.Cleanup(resetGlobalOutputFlags)
+	resetGlobalOutputFlags()
+	globalPretty = true
+	var buf bytes.Buffer
+	if err := emitJSON(&buf, map[string]string{"a": "b"}); err != nil {
+		t.Fatalf("emitJSON: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "\n  \"a\"") {
+		t.Errorf("pretty emitJSON missing indent: %q", got)
+	}
+}
+
+// TestEmitJSONLines writes NDJSON from a typed slice.
+func TestEmitJSONLines(t *testing.T) {
+	t.Cleanup(resetGlobalOutputFlags)
+	resetGlobalOutputFlags()
+	var buf bytes.Buffer
+	items := []utils.User{
+		{ID: "u1", Name: "Ada"},
+		{ID: "u2", Name: "Grace"},
+	}
+	if err := emitJSONLines(&buf, items); err != nil {
+		t.Fatalf("emitJSONLines: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	for i, l := range lines {
+		var u utils.User
+		if err := json.Unmarshal([]byte(l), &u); err != nil {
+			t.Errorf("line %d: %v", i, err)
+		}
+	}
+	// Non-slice input must error.
+	if err := emitJSONLines(&buf, map[string]int{"a": 1}); err == nil {
+		t.Error("emitJSONLines: want error on non-slice input")
+	}
+}
+
+// TestEmitError writes a single-line JSON error object.
+func TestEmitError(t *testing.T) {
+	var buf bytes.Buffer
+	emitError(&buf, errorString("boom"))
+	s := strings.TrimSpace(buf.String())
+	var obj map[string]string
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		t.Fatalf("emitError output is not valid JSON: %v (%q)", err, s)
+	}
+	if obj["error"] != "boom" {
+		t.Errorf("emitError payload = %q, want boom", obj["error"])
+	}
+	// nil error is a no-op.
+	buf.Reset()
+	emitError(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("emitError(nil) wrote %q, want empty", buf.String())
+	}
+}
+
+// TestJSONErrorOr verifies the error path writes to stderr only when
+// globalJSON is set, and always returns the original error.
+func TestJSONErrorOr(t *testing.T) {
+	t.Cleanup(resetGlobalOutputFlags)
+
+	c := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	c.SetOut(&stdout)
+	c.SetErr(&stderr)
+
+	resetGlobalOutputFlags()
+	globalJSON = false
+	if err := jsonErrorOr(c, errorString("oops")); err == nil || err.Error() != "oops" {
+		t.Errorf("human path err=%v want oops", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("human path wrote to stderr: %q", stderr.String())
+	}
+
+	stderr.Reset()
+	globalJSON = true
+	if err := jsonErrorOr(c, errorString("boom")); err == nil {
+		t.Fatal("json path expected err, got nil")
+	}
+	var obj map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &obj); err != nil {
+		t.Fatalf("json path stderr not a JSON object: %v (%q)", err, stderr.String())
+	}
+	if obj["error"] != "boom" {
+		t.Errorf("json path payload = %q want boom", obj["error"])
+	}
+
+	// Nil error is always a no-op.
+	stderr.Reset()
+	if err := jsonErrorOr(c, nil); err != nil {
+		t.Errorf("jsonErrorOr(nil) returned %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("jsonErrorOr(nil) wrote %q", stderr.String())
+	}
+}
+
+// TestPersistentPreRunE_DisablesColor verifies that running any
+// subcommand with --json flips color.NoColor to true (suppressing ANSI
+// escapes from fatih/color calls in downstream commands).
+func TestPersistentPreRunE_DisablesColor(t *testing.T) {
+	prev := color.NoColor
+	t.Cleanup(func() { color.NoColor = prev })
+
+	// Use a trivial subcommand to avoid hitting the HTTP mock plumbing.
+	c := findTopLevelCmd(t, "search")
+	_ = c // silence lint — we only need rootCmd to dispatch
+
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+
+	// Route via a tiny subcommand we register just for this test so we
+	// don't depend on the search command's happy path.
+	probeRan := false
+	probe := &cobra.Command{
+		Use: "jsonprobe",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			probeRan = true
+			return nil
+		},
+	}
+	rootCmd.AddCommand(probe)
+	t.Cleanup(func() { rootCmd.RemoveCommand(probe) })
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	color.NoColor = false
+	rootCmd.SetArgs([]string{"jsonprobe", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !probeRan {
+		t.Fatal("probe did not run")
+	}
+	if !color.NoColor {
+		t.Error("--json did not disable color")
+	}
+}
+
+// TestList_JSON runs `list --json` against the standard cmd mock and
+// asserts stdout is NDJSON, free of ANSI escapes.
+func TestList_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"list", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 todo block, got %d: %q", len(objs), out.String())
+	}
+	if got := objs[0]["type"]; got != "to_do" {
+		t.Errorf("block type = %v, want to_do", got)
+	}
+}
+
+// TestAdd_JSON runs `add "task" --json` and asserts the ok envelope.
+func TestAdd_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"add", "buy milk", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 ok envelope, got %d: %q", len(objs), out.String())
+	}
+	if objs[0]["ok"] != true {
+		t.Errorf("ok = %v, want true", objs[0]["ok"])
+	}
+	if objs[0]["text"] != "buy milk" {
+		t.Errorf("text = %v, want buy milk", objs[0]["text"])
+	}
+}
+
+// TestCheck_JSON, TestUncheck_JSON, TestDelete_JSON cover the top-level
+// to-do commands. Each emits {"ok":true,"action":<verb>,"order":N}.
+func TestCheck_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"check", "1", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 || objs[0]["action"] != "check" {
+		t.Errorf("unexpected check envelope: %v", objs)
+	}
+}
+
+func TestUncheck_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"uncheck", "1", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 || objs[0]["action"] != "uncheck" {
+		t.Errorf("unexpected uncheck envelope: %v", objs)
+	}
+}
+
+func TestDelete_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"delete", "1", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 || objs[0]["action"] != "delete" {
+		t.Errorf("unexpected delete envelope: %v", objs)
+	}
+}
+
+// TestBlocks_List_JSON asserts the blocks list command emits NDJSON.
+func TestBlocks_List_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	// Reset the sticky blockType flag so a prior test cannot leak state.
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "list", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) == 0 {
+		t.Fatalf("no NDJSON lines: %q", out.String())
+	}
+}
+
+// TestBlocks_Add_JSON asserts the blocks add command emits an ok envelope.
+func TestBlocks_Add_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "hello", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 || objs[0]["action"] != "add" {
+		t.Errorf("unexpected blocks add envelope: %v", objs)
+	}
+}
+
+// TestBlocks_Delete_JSON asserts blocks delete emits ok envelope.
+func TestBlocks_Delete_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "delete", "1", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 || objs[0]["action"] != "delete" {
+		t.Errorf("unexpected blocks delete envelope: %v", objs)
+	}
+}
+
+// TestBlocks_Add_JSON_InvalidType asserts the error path: a bad --type
+// writes a JSON error object to stderr AND the command returns a non-nil
+// error so cobra sets a non-zero exit code.
+func TestBlocks_Add_JSON_InvalidType(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	blockType = ""
+	resetRootCmdArgs()
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"blocks", "add", "hello", "-t", "bogus", "--json"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error on invalid --type")
+	}
+	// Error envelope on stderr.
+	var obj map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &obj); err != nil {
+		t.Fatalf("stderr not a JSON error: %v (%q)", err, stderr.String())
+	}
+	if obj["error"] == "" {
+		t.Error("error payload empty")
+	}
+}
+
+// TestSearch_JSON verifies the search command still honors --json via
+// the global persistent flag (previously search owned a local --json).
+func TestSearch_JSON(t *testing.T) {
+	var stats searchHandlerStats
+	overlaySearchHandler(t, &stats, func(req map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"object":   "list",
+			"has_more": false,
+			"results": []map[string]interface{}{
+				{"object": "page", "id": "pg-a", "url": "u", "last_edited_time": "2026-04-22T10:00:00.000Z"},
+			},
+		}
+	})
+	resetSearchFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"search", "x", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Errorf("want 1 result, got %d: %q", len(objs), out.String())
+	}
+}
+
+// TestComments_List_JSON drives `comments list` with --json.
+func TestComments_List_JSON(t *testing.T) {
+	srv := commentsWithCmdEnv(t)
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"comments", "list", "block-xyz", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) == 0 {
+		t.Fatalf("no NDJSON lines: %q", out.String())
+	}
+}
+
+// TestComments_Create_JSON drives `comments create` with --json.
+func TestComments_Create_JSON(t *testing.T) {
+	_ = commentsWithCmdEnv(t)
+	resetGlobalOutputFlags()
+	commentsCreateText = ""
+	commentsCreateDiscID = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"comments", "create", "block-xyz", "--text", "hi", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Errorf("want 1 comment, got %d: %q", len(objs), out.String())
+	}
+}
+
+// TestUsers_List_JSON / TestUsers_Get_JSON / TestUsers_Whoami_JSON —
+// smoke tests for the three users subcommands under --json.
+func TestUsers_List_JSON(t *testing.T) {
+	_ = withUsersEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "list", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) == 0 {
+		t.Fatalf("no user NDJSON: %q", out.String())
+	}
+}
+
+func TestUsers_Get_JSON(t *testing.T) {
+	_ = withUsersEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "get", "u1", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 user, got %d", len(objs))
+	}
+}
+
+func TestUsers_Whoami_JSON(t *testing.T) {
+	_ = withUsersEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"users", "whoami", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 user, got %d", len(objs))
+	}
+}
+
+// TestTeams_List_JSON asserts `teams list --json` emits NDJSON.
+func TestTeams_List_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"teams", "list", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) == 0 {
+		t.Fatalf("no team NDJSON: %q", out.String())
+	}
+}
+
+// TestPages_Get_JSON drives `pages get <id> --json`.
+func TestPages_Get_JSON(t *testing.T) {
+	_ = withPagesEnv(t)
+	resetGlobalOutputFlags()
+	resetPagesFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"pages", "get", "pageID", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 page, got %d", len(objs))
+	}
+}
+
+// TestPages_Archive_JSON asserts archive emits the ok envelope.
+func TestPages_Archive_JSON(t *testing.T) {
+	_ = withPagesEnv(t)
+	resetGlobalOutputFlags()
+	resetPagesFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"pages", "archive", "pageID", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 || objs[0]["action"] != "archive" {
+		t.Errorf("unexpected archive envelope: %v", objs)
+	}
+}
+
+// TestDatabases_Query_JSON drives `databases query <id> --json` and
+// asserts an NDJSON per page row.
+func TestDatabases_Query_JSON(t *testing.T) {
+	// Build a tiny query server. The existing cmdMockServer does not
+	// know about /databases/{id}/query so we spin up our own here.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/query"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.Copy(io.Discard, r.Body)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"object":   "list",
+				"has_more": false,
+				"results": []map[string]interface{}{
+					{"object": "page", "id": "p1", "url": "u"},
+					{"object": "page", "id": "p2", "url": "u"},
+				},
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	_ = withCmdEnv(t)
+	utils.SetBaseURL(srv.URL)
+	resetGlobalOutputFlags()
+	resetDatabasesFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"databases", "query", "dbID", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 2 {
+		t.Fatalf("want 2 results, got %d: %q", len(objs), out.String())
+	}
+}
+
+// TestDatabases_Query_JSONPretty verifies --pretty indents output.
+// We can't require NDJSON in pretty mode (each element spans multiple
+// lines), so we just assert the indent is present.
+func TestDatabases_Query_JSONPretty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"object":   "list",
+			"has_more": false,
+			"results": []map[string]interface{}{
+				{"object": "page", "id": "p1", "url": "u"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	_ = withCmdEnv(t)
+	utils.SetBaseURL(srv.URL)
+	resetGlobalOutputFlags()
+	resetDatabasesFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"databases", "query", "dbID", "--json", "--pretty"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	if !strings.Contains(out.String(), "\n  \"") {
+		t.Errorf("pretty output missing indent:\n%s", out.String())
+	}
+}
+
+// TestViews_Create_JSON drives `views create` with --json against the
+// existing cmd mock (which stubs POST /data_sources/{id}/views).
+func TestViews_Create_JSON(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetGlobalOutputFlags()
+	// Reset views flag vars between runs.
+	viewsCreateName = ""
+	viewsCreateType = ""
+	viewsCreateConfigFile = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"views", "create", "dbID", "--name", "n", "--type", "table", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 view, got %d: %q", len(objs), out.String())
+	}
+}
+
+// TestFiles_AddFile_JSON drives `blocks add-file <path> --json` against
+// the existing file-upload mock (two-step in cmdMockServer).
+func TestFiles_AddFile_JSON(t *testing.T) {
+	srv := withCmdEnv(t)
+	_ = srv
+	// Write a temp file so NewFileRef can open it.
+	tmp := t.TempDir() + "/hello.txt"
+	if err := writeTestFile(tmp, "hello"); err != nil {
+		t.Fatalf("writeTestFile: %v", err)
+	}
+	resetGlobalOutputFlags()
+	blocksAddFileName = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add-file", tmp, "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertNoANSI(t, out.String())
+	objs := assertNDJSON(t, out.String())
+	if len(objs) != 1 {
+		t.Fatalf("want 1 fileref, got %d: %q", len(objs), out.String())
+	}
+	if id, _ := objs[0]["id"].(string); id == "" {
+		t.Errorf("file ref missing id: %v", objs[0])
+	}
+}
+
+// writeTestFile is a small helper so output_test.go stays self-contained.
+func writeTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}

--- a/cmd/pages.go
+++ b/cmd/pages.go
@@ -92,11 +92,14 @@ var pagesGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		page, err := pc.Get(context.Background(), args[0])
 		if err != nil {
-			return fmt.Errorf("get page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("get page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), page))
 		}
 		printPage(cmd.OutOrStdout(), page)
 		return nil
@@ -109,18 +112,21 @@ var pagesCreateCmd = &cobra.Command{
 	Short: "Create a new page under --parent",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if pagesCreateParent == "" {
-			return fmt.Errorf("create page: --parent is required")
+			return jsonErrorOr(cmd, fmt.Errorf("create page: --parent is required"))
 		}
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		page, err := pc.Create(context.Background(), utils.CreatePageRequest{
 			Parent: utils.PageParent{PageID: pagesCreateParent},
 			Title:  pagesCreateTitle,
 		})
 		if err != nil {
-			return fmt.Errorf("create page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("create page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), page))
 		}
 		color.Green("Created page %s", page.ID)
 		printPage(cmd.OutOrStdout(), page)
@@ -141,7 +147,7 @@ var pagesUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		req := utils.UpdatePageRequest{Title: pagesUpdateTitle}
 		if len(pagesUpdateProps) > 0 {
@@ -149,14 +155,17 @@ var pagesUpdateCmd = &cobra.Command{
 			for _, raw := range pagesUpdateProps {
 				key, val, err := parseProperty(raw)
 				if err != nil {
-					return err
+					return jsonErrorOr(cmd, err)
 				}
 				req.Properties[key] = val
 			}
 		}
 		page, err := pc.Update(context.Background(), args[0], req)
 		if err != nil {
-			return fmt.Errorf("update page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("update page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), page))
 		}
 		color.Green("Updated page %s", page.ID)
 		printPage(cmd.OutOrStdout(), page)
@@ -172,10 +181,16 @@ var pagesArchiveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		if err := pc.Archive(context.Background(), args[0]); err != nil {
-			return fmt.Errorf("archive page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("archive page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "archive",
+				"id":     args[0],
+			}))
 		}
 		color.Green("Archived page %s", args[0])
 		return nil
@@ -190,10 +205,16 @@ var pagesUnarchiveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		if err := pc.Unarchive(context.Background(), args[0]); err != nil {
-			return fmt.Errorf("unarchive page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("unarchive page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "unarchive",
+				"id":     args[0],
+			}))
 		}
 		color.Green("Unarchived page %s", args[0])
 		return nil
@@ -209,14 +230,21 @@ var pagesMoveCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if pagesMoveParent == "" {
-			return fmt.Errorf("move page: --parent is required")
+			return jsonErrorOr(cmd, fmt.Errorf("move page: --parent is required"))
 		}
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		if err := pc.Move(context.Background(), args[0], pagesMoveParent); err != nil {
-			return fmt.Errorf("move page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("move page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "move",
+				"id":     args[0],
+				"parent": pagesMoveParent,
+			}))
 		}
 		color.Green("Moved page %s → parent %s", args[0], pagesMoveParent)
 		return nil
@@ -250,15 +278,18 @@ Limitations:
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if pagesDuplicateParent == "" {
-			return fmt.Errorf("duplicate page: --parent is required")
+			return jsonErrorOr(cmd, fmt.Errorf("duplicate page: --parent is required"))
 		}
 		pc, err := newPageClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		page, err := pc.Duplicate(context.Background(), args[0], pagesDuplicateParent)
 		if err != nil {
-			return fmt.Errorf("duplicate page: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("duplicate page: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), page))
 		}
 		color.Green("Duplicated page %s → %s", args[0], page.ID)
 		printPage(cmd.OutOrStdout(), page)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,6 @@ func shouldSuppressBanner() bool {
 func init() {
 	// Persistent output flags. Every subcommand inherits these.
 	rootCmd.PersistentFlags().BoolVar(&globalJSON, "json", false, "Emit JSON/NDJSON to stdout (disables ANSI color)")
-	rootCmd.PersistentFlags().BoolVar(&globalPretty, "pretty", false, "Pretty-print JSON output (no effect unless --json is set)")
+	rootCmd.PersistentFlags().BoolVar(&globalPretty, "pretty", false, "Pretty-print JSON output (list commands emit a single indented JSON array; compact NDJSON is recommended for piping)")
 	rootCmd.PersistentFlags().StringVar(&globalOutput, "output", "", "Output format: text|json (alias for --json)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,15 +67,24 @@ func Execute() {
 // cobra parses the flags) so the very first byte of stdout is not a
 // terminal escape. cobra's Execute() is what wires --json into the
 // globalJSON var, and by then the banner has already been written.
+//
+// We suppress only when JSON is definitely on. That means:
+//   - bare --json
+//   - --output=json (single-token form)
+//   - --output json (space-separated form) — we peek the next arg
+//
+// --output=text (or --output text) must NOT suppress the banner so human
+// invocations keep the banner they always had.
 func shouldSuppressBanner() bool {
-	for _, a := range os.Args[1:] {
+	args := os.Args[1:]
+	for i, a := range args {
 		switch a {
 		case "--json", "--output=json":
 			return true
 		case "--output":
-			// next arg is the value — we can't safely index past here
-			// without repeating cobra's parser, so suppress on sight.
-			return true
+			if i+1 < len(args) && args[i+1] == "json" {
+				return true
+			}
 		}
 	}
 	return false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ var rootCmd = &cobra.Command{
 	Use:   "notioncli",
 	Short: "Notioncli provides a CLI interface to track your tasks in a Notion page",
 	Long: `Notioncli is a tool that utilizes the official Notion API to enable the integration of to-do lists from Notion pages into your command line interface.
-	
+
 		This version supports the following options:
 		  list (to list tasks)
 		  add <task> (create a new task)
@@ -25,6 +25,19 @@ var rootCmd = &cobra.Command{
 		  uncheck <number> (mark a task as not done)
 		  delete <number> (permanently remove a task)
 		  help (get some help)`,
+	// PersistentPreRunE fires for every subcommand. It normalises the
+	// --output=text|json alias into the boolean flag and turns off ANSI
+	// color output whenever JSON is on so downstream commands that still
+	// call color.* cannot bleed escape codes into the JSON stream.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyGlobalOutput(); err != nil {
+			return err
+		}
+		if globalJSON {
+			disableColor()
+		}
+		return nil
+	},
 }
 
 // osExit is indirected through a package-level var so tests can swap in a
@@ -33,15 +46,44 @@ var osExit = os.Exit
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
+//
+// The banner line is suppressed when --json (or --output=json) is set so
+// consumers piping stdout into jq get a valid NDJSON stream. When --help
+// is requested we also skip the banner since the help formatter already
+// prints a short header.
 func Execute() {
-	boldBlue := color.New(color.Bold, color.FgBlue).SprintFunc()
-	fmt.Println(boldBlue("----=[ NotionCLI ]=----"))
+	if !shouldSuppressBanner() {
+		boldBlue := color.New(color.Bold, color.FgBlue).SprintFunc()
+		fmt.Println(boldBlue("----=[ NotionCLI ]=----"))
+	}
 	err := rootCmd.Execute()
 	if err != nil {
 		osExit(1)
 	}
 }
 
-func init() {
+// shouldSuppressBanner returns true when the invocation should skip the
+// cosmetic banner line. We look at os.Args directly (rather than after
+// cobra parses the flags) so the very first byte of stdout is not a
+// terminal escape. cobra's Execute() is what wires --json into the
+// globalJSON var, and by then the banner has already been written.
+func shouldSuppressBanner() bool {
+	for _, a := range os.Args[1:] {
+		switch a {
+		case "--json", "--output=json":
+			return true
+		case "--output":
+			// next arg is the value — we can't safely index past here
+			// without repeating cobra's parser, so suppress on sight.
+			return true
+		}
+	}
+	return false
+}
 
+func init() {
+	// Persistent output flags. Every subcommand inherits these.
+	rootCmd.PersistentFlags().BoolVar(&globalJSON, "json", false, "Emit JSON/NDJSON to stdout (disables ANSI color)")
+	rootCmd.PersistentFlags().BoolVar(&globalPretty, "pretty", false, "Pretty-print JSON output (no effect unless --json is set)")
+	rootCmd.PersistentFlags().StringVar(&globalOutput, "output", "", "Output format: text|json (alias for --json)")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -60,6 +61,39 @@ func TestExecuteHappyPath(t *testing.T) {
 
 	if exited {
 		t.Errorf("Execute() unexpectedly called osExit(%d) on happy path", code)
+	}
+}
+
+// TestShouldSuppressBanner_JSONForms exercises the banner-suppression
+// rule: suppress when --json or --output=json (any space/equals form),
+// do NOT suppress for --output=text / --output text / plain invocations.
+// This locks the fix for the PR #28 review: bare --output with a non-
+// json value was incorrectly swallowing the banner.
+func TestShouldSuppressBanner_JSONForms(t *testing.T) {
+	orig := os.Args
+	t.Cleanup(func() { os.Args = orig })
+
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"plain", []string{"notioncli", "list"}, false},
+		{"json_flag", []string{"notioncli", "list", "--json"}, true},
+		{"output_equals_json", []string{"notioncli", "list", "--output=json"}, true},
+		{"output_space_json", []string{"notioncli", "list", "--output", "json"}, true},
+		{"output_equals_text", []string{"notioncli", "list", "--output=text"}, false},
+		{"output_space_text", []string{"notioncli", "list", "--output", "text"}, false},
+		{"output_trailing_no_value", []string{"notioncli", "list", "--output"}, false},
+		{"help", []string{"notioncli", "--help"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Args = tc.args
+			if got := shouldSuppressBanner(); got != tc.want {
+				t.Errorf("shouldSuppressBanner() = %v, want %v (args=%v)", got, tc.want, tc.args)
+			}
+		})
 	}
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -20,11 +20,14 @@ import (
 // during init(); resetSearchFlags() is called at the top of Run so repeated
 // invocations within a single process (tests, REPLs) don't inherit stale
 // values.
+//
+// The JSON switch is the persistent --json flag on rootCmd (globalJSON);
+// search used to own a local --json flag but now shares the global one so
+// all commands behave consistently.
 var (
 	searchType     string
 	searchLimit    int
 	searchPageSize int
-	searchJSON     bool
 )
 
 // searchCmd implements `notioncli search` — a workspace-wide query against
@@ -85,7 +88,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if searchJSON {
+	if globalJSON {
 		return emitSearchJSON(cmd, results)
 	}
 	return emitSearchTable(cmd, results)
@@ -178,9 +181,8 @@ func emitSearchTable(cmd *cobra.Command, results []utils.SearchResult) error {
 // os.Exit; the RunE return value drives the final exit code via cobra.
 func emitSearchError(cmd *cobra.Command, err error) {
 	errOut := cmd.ErrOrStderr()
-	if searchJSON {
-		enc := json.NewEncoder(errOut)
-		_ = enc.Encode(map[string]string{"error": err.Error()})
+	if globalJSON {
+		emitError(errOut, err)
 		return
 	}
 	fmt.Fprintln(errOut, color.RedString("Error: %v", err))
@@ -257,7 +259,7 @@ func resetSearchFlags() {
 	searchType = ""
 	searchLimit = 0
 	searchPageSize = 0
-	searchJSON = false
+	resetGlobalOutputFlags()
 }
 
 func init() {
@@ -265,5 +267,4 @@ func init() {
 	searchCmd.Flags().StringVar(&searchType, "type", "", "Restrict results to pages|databases")
 	searchCmd.Flags().IntVar(&searchLimit, "limit", 0, "Maximum total results to return (0 = all)")
 	searchCmd.Flags().IntVar(&searchPageSize, "page-size", 0, "Notion API page size (1-100, 0 = server default)")
-	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "Emit raw results as NDJSON to stdout")
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -122,11 +122,37 @@ func validateSearchPageSize(pageSize int) error {
 	return nil
 }
 
-// emitSearchJSON writes one result per line to stdout as the Notion API
-// returned it. This is the first --json consumer in the CLI, so the shape
-// is deliberately minimal: raw pass-through, no envelope.
+// emitSearchJSON writes search results to stdout as the Notion API
+// returned them (Raw pass-through, no envelope). Compact NDJSON by
+// default; a single pretty-printed JSON array when --pretty is set.
+// The Raw pass-through preserves any Notion fields the CLI does not
+// model — we deliberately avoid re-marshalling the typed struct for
+// the compact case so unknown keys survive the round-trip.
 func emitSearchJSON(cmd *cobra.Command, results []utils.SearchResult) error {
 	out := cmd.OutOrStdout()
+	if globalPretty {
+		// Pretty-print a single JSON array so the output is a single
+		// valid JSON document. We unmarshal Raw into interface{} so
+		// the re-marshal preserves every field the API returned.
+		arr := make([]interface{}, 0, len(results))
+		for _, r := range results {
+			raw := r.Raw
+			if len(raw) == 0 {
+				buf, err := json.Marshal(r)
+				if err != nil {
+					return fmt.Errorf("marshal result: %w", err)
+				}
+				raw = buf
+			}
+			var obj interface{}
+			if err := json.Unmarshal(raw, &obj); err != nil {
+				return fmt.Errorf("unmarshal result: %w", err)
+			}
+			arr = append(arr, obj)
+		}
+		return emitJSON(out, arr)
+	}
+	// Compact NDJSON: write the Raw bytes verbatim, one per line.
 	for _, r := range results {
 		raw := r.Raw
 		if len(raw) == 0 {

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -89,7 +89,8 @@ func TestSearchCmdFlags(t *testing.T) {
 		{"type", "string", ""},
 		{"limit", "int", "0"},
 		{"page-size", "int", "0"},
-		{"json", "bool", "false"},
+		// Note: --json moved from a search-local flag to a persistent
+		// flag on rootCmd. Verified separately in TestRootPersistentFlags.
 	}
 	for _, tt := range tests {
 		t.Run(tt.flag, func(t *testing.T) {
@@ -431,16 +432,18 @@ func TestEmitSearchJSON(t *testing.T) {
 // cmd.ErrOrStderr(). The JSON branch must emit a parseable single-line
 // error object so stdout stays valid NDJSON.
 func TestEmitSearchError(t *testing.T) {
-	// Restore package-level flag even if the test aborts mid-run.
-	prev := searchJSON
-	t.Cleanup(func() { searchJSON = prev })
+	// Restore package-level flag even if the test aborts mid-run. The
+	// JSON toggle moved to the global --json plumbing so we touch
+	// globalJSON here rather than a search-local flag.
+	prev := globalJSON
+	t.Cleanup(func() { globalJSON = prev })
 
 	c := &cobra.Command{}
 	var stdout, stderr bytes.Buffer
 	c.SetOut(&stdout)
 	c.SetErr(&stderr)
 
-	searchJSON = false
+	globalJSON = false
 	emitSearchError(c, errorString("human"))
 	if !strings.Contains(stderr.String(), "human") {
 		t.Errorf("human branch did not write to stderr: %q", stderr.String())
@@ -451,7 +454,7 @@ func TestEmitSearchError(t *testing.T) {
 
 	stderr.Reset()
 	stdout.Reset()
-	searchJSON = true
+	globalJSON = true
 	emitSearchError(c, errorString("boom"))
 	if stdout.Len() != 0 {
 		t.Errorf("json branch wrote to stdout: %q", stdout.String())
@@ -469,11 +472,11 @@ func TestResetSearchFlags(t *testing.T) {
 	searchType = "pages"
 	searchLimit = 42
 	searchPageSize = 17
-	searchJSON = true
+	globalJSON = true
 	resetSearchFlags()
-	if searchType != "" || searchLimit != 0 || searchPageSize != 0 || searchJSON {
+	if searchType != "" || searchLimit != 0 || searchPageSize != 0 || globalJSON {
 		t.Errorf("flags not reset: type=%q limit=%d pageSize=%d json=%v",
-			searchType, searchLimit, searchPageSize, searchJSON)
+			searchType, searchLimit, searchPageSize, globalJSON)
 	}
 }
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -10,7 +10,6 @@ import (
 
 	"notioncli/utils"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -29,24 +28,34 @@ Requires Notion-Version 2026-03-11 or newer.`,
 var teamsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List every team in the workspace",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		notionAPIKey, _ := utils.SetAPIConfig()
 		client := utils.NewTeamClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
 
 		teams, err := client.List(context.Background())
 		if err != nil {
-			color.Red("Error: %v", err)
-			osExit(1)
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("teams list: %w", err))
+		}
+
+		if globalJSON {
+			// NDJSON: one team object per line. Stable typed shape.
+			out := cmd.OutOrStdout()
+			for _, team := range teams {
+				if err := emitJSON(out, team); err != nil {
+					return jsonErrorOr(cmd, err)
+				}
+			}
+			return nil
 		}
 
 		if len(teams) == 0 {
 			fmt.Fprintln(cmd.OutOrStdout(), "No teams found.")
-			return
+			return nil
 		}
 		for _, team := range teams {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", team.ID, team.Name)
 		}
+		return nil
 	},
 }
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -38,14 +38,8 @@ var teamsListCmd = &cobra.Command{
 		}
 
 		if globalJSON {
-			// NDJSON: one team object per line. Stable typed shape.
-			out := cmd.OutOrStdout()
-			for _, team := range teams {
-				if err := emitJSON(out, team); err != nil {
-					return jsonErrorOr(cmd, err)
-				}
-			}
-			return nil
+			// emitList picks NDJSON or a pretty JSON array based on --pretty.
+			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), teams))
 		}
 
 		if len(teams) == 0 {

--- a/cmd/teams_test.go
+++ b/cmd/teams_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -80,49 +79,26 @@ func TestTeamsListDispatch_HappyPath(t *testing.T) {
 }
 
 // TestTeamsListDispatch_AuthError asserts that an unconfigured API key
-// surfaces via osExit(1) and the "Error:" color.Red branch, without
-// panicking.
+// surfaces as a returned error from the RunE handler. The command
+// migrated from Run (which called osExit) to RunE (which returns the
+// error) as part of the --json rollout, so this test now asserts on
+// the returned error rather than osExit.
 func TestTeamsListDispatch_AuthError(t *testing.T) {
 	_ = withCmdEnv(t)
 	// Blank out the API key AFTER withCmdEnv so SetAPIConfig returns an
 	// empty string; TeamClient.List then surfaces ErrMissingAPIKey.
 	t.Setenv("NOTION_API_KEY", "")
 
-	var exited bool
-	var code int
-	origExit := osExit
-	osExit = func(c int) {
-		exited = true
-		code = c
-	}
-	t.Cleanup(func() { osExit = origExit })
-
-	// Capture fatih/color output.
 	var out bytes.Buffer
-	origColorOut := color.Output
-	origColorErr := color.Error
-	color.Output = &out
-	color.Error = &out
-	t.Cleanup(func() {
-		color.Output = origColorOut
-		color.Error = origColorErr
-	})
-
 	resetRootCmdArgs()
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"teams", "list"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("rootCmd.Execute(teams list): %v", err)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("teams list with empty API key should return an error")
 	}
-
-	if !exited {
-		t.Fatal("teams list with empty API key did not invoke osExit")
-	}
-	if code != 1 {
-		t.Errorf("teams list osExit code = %d, want 1", code)
-	}
-	if !strings.Contains(out.String(), "api key") {
-		t.Errorf("teams list output missing api-key error:\n%s", out.String())
+	if !strings.Contains(err.Error(), "api key") {
+		t.Errorf("teams list error missing api-key context: %v", err)
 	}
 }

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -202,8 +202,13 @@ func withCmdEnv(t *testing.T) *httptest.Server {
 
 // resetRootCmdArgs clears any args previously set on rootCmd. cobra retains
 // args across calls, so tests that share rootCmd must reset between runs.
+// The global output flags (--json, --pretty, --output) are also reset here
+// because cobra binds bool/string flags to package-level vars that persist
+// across Execute calls — without the reset one --json test would flip every
+// subsequent test into JSON mode and break assertions on human output.
 func resetRootCmdArgs() {
 	rootCmd.SetArgs(nil)
+	resetGlobalOutputFlags()
 }
 
 // findTopLevelCmd returns the rootCmd child with the given Name, or fails

--- a/cmd/uncheck.go
+++ b/cmd/uncheck.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"notioncli/utils"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -18,19 +17,23 @@ var uncheckCmd = &cobra.Command{
 	Short: "Mark a task as incomplete",
 	Long:  `Mark a ToDo task as incomplete, e.g., check 1 (marks the first ToDo in the list incomplete)`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		order, err := strconv.Atoi(args[0])
 		if err != nil {
-			fmt.Printf("Could not convert %q to an integer: %v", args[0], err)
-			os.Exit(1)
+			return jsonErrorOr(cmd, fmt.Errorf("uncheck: parse order %q: %w", args[0], err))
 		}
 		notionAPIKey, pageID := utils.SetAPIConfig()
-		result := utils.MarkToDoBlockUnChecked(notionAPIKey, pageID, order)
-		if result != nil {
-			fmt.Printf("Error marking task %d as incomplete: %v\n", order, result)
-			os.Exit(1)
+		if err := utils.MarkToDoBlockUnChecked(notionAPIKey, pageID, order); err != nil {
+			return jsonErrorOr(cmd, fmt.Errorf("uncheck: mark task %d incomplete: %w", order, err))
 		}
-		fmt.Printf("Task %d marked incomplete.\n", order)
+		if globalJSON {
+			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+				"action": "uncheck",
+				"order":  order,
+			})
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Task %d marked incomplete.\n", order)
+		return nil
 	},
 }
 

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -6,9 +6,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 
 	"notioncli/utils"
 
@@ -16,12 +14,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// usersJSON toggles JSON output on the users subcommands. It is a
-// package-level var so each subcommand can bind its own --json flag.
-var usersJSON bool
-
 // usersCmd is the parent command for user-related operations on the
 // Notion API.
+//
+// JSON output is driven by the persistent --json flag on rootCmd
+// (globalJSON); the users subcommands used to own local --json flags
+// but now share the global one so all commands behave consistently.
 var usersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Manage Notion workspace users",
@@ -39,33 +37,34 @@ var usersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List every user in the workspace",
 	Long:  `List every user the current integration can access. Use --json for machine-readable output.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		notionAPIKey, _ := utils.SetAPIConfig()
 		client := utils.NewUserClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
 
 		users, err := client.List(context.Background())
 		if err != nil {
-			color.Red("Error listing users: %v", err)
-			osExit(1)
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("users list: %w", err))
 		}
 
-		if usersJSON {
-			if err := writeJSON(cmd.OutOrStdout(), users); err != nil {
-				color.Red("Error encoding JSON: %v", err)
-				osExit(1)
-				return
+		if globalJSON {
+			// NDJSON: one user object per line. Stable typed shape.
+			out := cmd.OutOrStdout()
+			for _, u := range users {
+				if err := emitJSON(out, u); err != nil {
+					return jsonErrorOr(cmd, err)
+				}
 			}
-			return
+			return nil
 		}
 
 		if len(users) == 0 {
 			color.Yellow("No users returned.")
-			return
+			return nil
 		}
 		for _, u := range users {
 			fmt.Fprintln(cmd.OutOrStdout(), formatUser(u))
 		}
+		return nil
 	},
 }
 
@@ -74,26 +73,20 @@ var usersGetCmd = &cobra.Command{
 	Use:   "get <id>",
 	Short: "Retrieve a user by id",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		notionAPIKey, _ := utils.SetAPIConfig()
 		client := utils.NewUserClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
 
 		user, err := client.Get(context.Background(), args[0])
 		if err != nil {
-			color.Red("Error getting user: %v", err)
-			osExit(1)
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("users get: %w", err))
 		}
 
-		if usersJSON {
-			if err := writeJSON(cmd.OutOrStdout(), user); err != nil {
-				color.Red("Error encoding JSON: %v", err)
-				osExit(1)
-				return
-			}
-			return
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), user))
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), formatUser(*user))
+		return nil
 	},
 }
 
@@ -101,26 +94,20 @@ var usersGetCmd = &cobra.Command{
 var usersWhoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Show the current integration's bot user",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		notionAPIKey, _ := utils.SetAPIConfig()
 		client := utils.NewUserClient(utils.NewClient(notionAPIKey, utils.WithBaseURL(utils.GetBaseURL())))
 
 		user, err := client.Me(context.Background())
 		if err != nil {
-			color.Red("Error retrieving self: %v", err)
-			osExit(1)
-			return
+			return jsonErrorOr(cmd, fmt.Errorf("users whoami: %w", err))
 		}
 
-		if usersJSON {
-			if err := writeJSON(cmd.OutOrStdout(), user); err != nil {
-				color.Red("Error encoding JSON: %v", err)
-				osExit(1)
-				return
-			}
-			return
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), user))
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), formatUser(*user))
+		return nil
 	},
 }
 
@@ -145,21 +132,9 @@ func formatUser(u utils.User) string {
 	return fmt.Sprintf("[%s] %s%s  id=%s", kind, name, detail, u.ID)
 }
 
-// writeJSON encodes v as indented JSON to w. Broken out so the users
-// subcommands share a single encoder configuration.
-func writeJSON(w io.Writer, v interface{}) error {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(v)
-}
-
 func init() {
 	rootCmd.AddCommand(usersCmd)
 	usersCmd.AddCommand(usersListCmd)
 	usersCmd.AddCommand(usersGetCmd)
 	usersCmd.AddCommand(usersWhoamiCmd)
-
-	usersListCmd.Flags().BoolVar(&usersJSON, "json", false, "Emit JSON instead of human-readable output")
-	usersGetCmd.Flags().BoolVar(&usersJSON, "json", false, "Emit JSON instead of human-readable output")
-	usersWhoamiCmd.Flags().BoolVar(&usersJSON, "json", false, "Emit JSON instead of human-readable output")
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -47,14 +47,8 @@ var usersListCmd = &cobra.Command{
 		}
 
 		if globalJSON {
-			// NDJSON: one user object per line. Stable typed shape.
-			out := cmd.OutOrStdout()
-			for _, u := range users {
-				if err := emitJSON(out, u); err != nil {
-					return jsonErrorOr(cmd, err)
-				}
-			}
-			return nil
+			// emitList picks NDJSON or a pretty JSON array based on --pretty.
+			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), users))
 		}
 
 		if len(users) == 0 {

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -221,7 +221,7 @@ func TestUsersListDispatch(t *testing.T) {
 	})
 
 	// Reset shared JSON flag so prior tests don't leak state.
-	usersJSON = false
+	resetGlobalOutputFlags()
 
 	resetRootCmdArgs()
 	var out bytes.Buffer
@@ -235,14 +235,22 @@ func TestUsersListDispatch(t *testing.T) {
 		t.Error("users list did not hit /users")
 	}
 
-	// JSON body should decode as a []User.
+	// users list --json emits NDJSON (one User object per line), not a
+	// JSON array. The shape change is deliberate and matches the other
+	// list commands (blocks, comments, teams, databases query, search).
 	body := bytes.TrimSpace(out.Bytes())
 	if len(body) == 0 {
 		t.Fatal("users list --json: empty output")
 	}
-	var decoded []utils.User
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		t.Errorf("users list --json: output is not a []User: %v\n%s", err, body)
+	for i, line := range bytes.Split(body, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var u utils.User
+		if err := json.Unmarshal(line, &u); err != nil {
+			t.Errorf("users list --json: line %d is not a User: %v\n%s", i, err, line)
+		}
 	}
 }
 
@@ -260,7 +268,7 @@ func TestUsersGetDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -283,87 +291,70 @@ func errorHandler(status int) http.Handler {
 }
 
 // TestUsersListDispatch_HTTPErrorExits asserts that a non-2xx response
-// from the Notion users endpoint surfaces through the Run closure,
-// prints an error, and calls osExit(1). Covers cmd/users.go:47-51.
+// from the Notion users endpoint surfaces as a returned error. The
+// command migrated from Run+osExit to RunE, so the error is returned
+// from rootCmd.Execute and cobra's default exit path handles it.
 func TestUsersListDispatch_HTTPErrorExits(t *testing.T) {
 	withUsersEnvHandler(t, errorHandler(http.StatusUnauthorized))
 
-	exited, code := recordOSExit(t)
 	var out bytes.Buffer
 	captureColorOutput(t, &out)
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"users", "list"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("rootCmd.Execute(users list): %v", err)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("users list: expected error on HTTP 401, got nil")
 	}
-	if !*exited {
-		t.Fatal("users list: osExit not called on HTTP error")
-	}
-	if *code != 1 {
-		t.Errorf("users list: osExit code = %d, want 1", *code)
-	}
-	if !strings.Contains(out.String(), "Error listing users") {
-		t.Errorf("users list: missing error message in output:\n%s", out.String())
+	if !strings.Contains(err.Error(), "users list") {
+		t.Errorf("users list: expected 'users list' in error, got %v", err)
 	}
 }
 
 // TestUsersGetDispatch_HTTPErrorExits covers the 404 path for
-// `users get <id>` (cmd/users.go:82-86).
+// `users get <id>`.
 func TestUsersGetDispatch_HTTPErrorExits(t *testing.T) {
 	withUsersEnvHandler(t, errorHandler(http.StatusNotFound))
 
-	exited, code := recordOSExit(t)
 	var out bytes.Buffer
 	captureColorOutput(t, &out)
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"users", "get", "does-not-exist"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("rootCmd.Execute(users get): %v", err)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("users get: expected error on HTTP 404, got nil")
 	}
-	if !*exited {
-		t.Fatal("users get: osExit not called on HTTP error")
-	}
-	if *code != 1 {
-		t.Errorf("users get: osExit code = %d, want 1", *code)
-	}
-	if !strings.Contains(out.String(), "Error getting user") {
-		t.Errorf("users get: missing error message in output:\n%s", out.String())
+	if !strings.Contains(err.Error(), "users get") {
+		t.Errorf("users get: expected 'users get' in error, got %v", err)
 	}
 }
 
 // TestUsersWhoamiDispatch_HTTPErrorExits covers the 401 path for
-// `users whoami` (cmd/users.go:109-113).
+// `users whoami`.
 func TestUsersWhoamiDispatch_HTTPErrorExits(t *testing.T) {
 	withUsersEnvHandler(t, errorHandler(http.StatusUnauthorized))
 
-	exited, code := recordOSExit(t)
 	var out bytes.Buffer
 	captureColorOutput(t, &out)
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"users", "whoami"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("rootCmd.Execute(users whoami): %v", err)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("users whoami: expected error on HTTP 401, got nil")
 	}
-	if !*exited {
-		t.Fatal("users whoami: osExit not called on HTTP error")
-	}
-	if *code != 1 {
-		t.Errorf("users whoami: osExit code = %d, want 1", *code)
-	}
-	if !strings.Contains(out.String(), "Error retrieving self") {
-		t.Errorf("users whoami: missing error message in output:\n%s", out.String())
+	if !strings.Contains(err.Error(), "users whoami") {
+		t.Errorf("users whoami: expected 'users whoami' in error, got %v", err)
 	}
 }
 
@@ -387,7 +378,7 @@ func TestUsersListDispatch_HumanOutput(t *testing.T) {
 		http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
 	}))
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -420,7 +411,7 @@ func TestUsersListDispatch_HumanOutputEmpty(t *testing.T) {
 	var out bytes.Buffer
 	captureColorOutput(t, &out)
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
@@ -443,7 +434,7 @@ func TestUsersListDispatch_HumanOutputEmpty(t *testing.T) {
 func TestUsersGetDispatch_HumanOutput(t *testing.T) {
 	withUsersEnv(t)
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -466,7 +457,7 @@ func TestUsersGetDispatch_HumanOutput(t *testing.T) {
 func TestUsersWhoamiDispatch_HumanOutput(t *testing.T) {
 	withUsersEnv(t)
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -545,7 +536,7 @@ func TestUsersWhoamiDispatch(t *testing.T) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	usersJSON = false
+	resetGlobalOutputFlags()
 	resetRootCmdArgs()
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)

--- a/cmd/views.go
+++ b/cmd/views.go
@@ -123,11 +123,14 @@ contents are forwarded verbatim as the view's configuration payload.`,
 		}
 		vc, err := newViewClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		view, err := vc.Create(context.Background(), req)
 		if err != nil {
-			return fmt.Errorf("create view: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("create view: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), view))
 		}
 		printView(cmd.OutOrStdout(), view)
 		return nil
@@ -167,11 +170,14 @@ verbatim as the view's configuration payload.`,
 		}
 		vc, err := newViewClient()
 		if err != nil {
-			return err
+			return jsonErrorOr(cmd, err)
 		}
 		view, err := vc.Update(context.Background(), args[0], req)
 		if err != nil {
-			return fmt.Errorf("update view: %w", err)
+			return jsonErrorOr(cmd, fmt.Errorf("update view: %w", err))
+		}
+		if globalJSON {
+			return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), view))
 		}
 		printView(cmd.OutOrStdout(), view)
 		return nil


### PR DESCRIPTION
## Summary

Implements issue #2: a global, cross-command `--json` output mode.

- Persistent `--json`, `--pretty`, and `--output=text|json` flags on `rootCmd`.
- Every subcommand gates an early-return JSON path on `globalJSON`.
- ANSI colour auto-disabled when `--json` is set (`color.NoColor = true`) and the cosmetic banner is suppressed so stdout stays a valid NDJSON pipe.
- Errors write `{"error":"..."}` to stderr and return a non-nil error so cobra sets a non-zero exit.

## Output shapes per resource

| command | shape |
|---|---|
| `list`, `blocks list`, `comments list`, `users list`, `teams list`, `databases query`, `search` | NDJSON — one JSON object per line |
| `pages get/create/update/duplicate`, `databases get/create/update`, `comments create`, `users get/whoami`, `views create/update`, `blocks add-image/add-file`, `pages set-icon/set-cover` | Single JSON document |
| `add`, `check`, `uncheck`, `delete`, `blocks add`, `blocks delete`, `pages archive/unarchive/move` | `{"ok":true,"action":"<verb>",...}` envelope |

Heterogeneous endpoints (search, page reads) keep the `Raw json.RawMessage` passthrough pattern from PR #20. Stable typed shapes (blocks, users, comments, teams) use plain `json.Encoder.Encode`, per the split the reviewer landed on in the #20 second-pass review.

## Commands covered

All 30+ subcommands: `list`, `add`, `check`, `uncheck`, `delete`, `blocks list/add/delete/add-image/add-file`, `search`, `pages get/create/update/archive/unarchive/move/duplicate/set-icon/set-cover`, `databases get/query/create/update`, `comments list/create`, `users list/get/whoami`, `teams list`, `views create/update`.

The previously-local `--json` flags on `search`, `comments`, and `users` are removed in favour of the persistent root flag.

## Test evidence

`cmd/output_test.go` adds ~25 new test functions using the `Test<Resource>_<Method>_JSON` namespace:

- Output helpers: `emitJSON` (compact + pretty), `emitJSONLines`, `emitError`, `jsonErrorOr`, `applyGlobalOutput`, persistent flag inheritance, `PersistentPreRunE_DisablesColor`.
- Per-command smoke: `TestList_JSON`, `TestAdd_JSON`, `TestCheck_JSON`, `TestUncheck_JSON`, `TestDelete_JSON`, `TestBlocks_List_JSON`, `TestBlocks_Add_JSON` (+ invalid --type error path), `TestBlocks_Delete_JSON`, `TestSearch_JSON`, `TestComments_List_JSON`, `TestComments_Create_JSON`, `TestUsers_List_JSON`, `TestUsers_Get_JSON`, `TestUsers_Whoami_JSON`, `TestTeams_List_JSON`, `TestPages_Get_JSON`, `TestPages_Archive_JSON`, `TestDatabases_Query_JSON` (+ `TestDatabases_Query_JSONPretty`), `TestViews_Create_JSON`, `TestFiles_AddFile_JSON`.

Every `_JSON` test asserts: stdout parses as valid JSON (NDJSON where applicable), output is free of ANSI escapes, and error paths return non-nil errors.

`resetRootCmdArgs` now also clears the global output flags so a `--json` test cannot leak into subsequent tests.

## `make ci` tail

```
total:					(statements)			87.4%
Total coverage: 87.4% (gate: 70%)
Test coverage gaps — 2 exported function(s) have no matching Test*:
  utils.NewFileRef  (utils/files.go:38)
  utils.Upload  (utils/files.go:121)
```

Coverage delta: `cmd/` 83.2% → 85.1% (+1.9 pp); overall 87.4% unchanged. The two gap-gate entries pre-date this PR (utils/files deferred work) — no new gaps introduced.

## Backward compat

- Default (no `--json`) output is unchanged across every command.
- Several `Run` closures migrated to `RunE` so errors propagate instead of calling `osExit`. Existing tests updated; `rootCmd.Execute()` now returns the error on failure, and cobra still exits non-zero. One test (`TestCommentsCreateMissingText`) now expects a returned error instead of a silent nil — called out in the diff.

## Test plan

- [x] `make ci` green locally (fmt-check, vet, test-race, cover 87.4%, gap gate clean)
- [x] Manual smoke: `./notioncli --json --help` suppresses the banner
- [ ] CI dispatch via `gh workflow run test.yml --ref feature/json-output`
- [ ] Reviewer: spot-check a couple of command JSON shapes match expectations (e.g. `pages get --json | jq .id`)

Stragglers: none — every command in scope has a JSON path and at least one smoke test.