### PR TITLE
feat: extended block types — image/file/video/embed/bookmark/equation/table/synced/column (closes #26)

### DIFF
--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -17,11 +17,11 @@ import (
 )
 
 var (
-	blockType       string
-	blockURL        string
-	blockCaption    string
-	blockFileID     string
-	blockLanguage   string
+	blockType     string
+	blockURL      string
+	blockCaption  string
+	blockFileID   string
+	blockLanguage string
 )
 
 // blocksCmd represents the blocks command

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -39,7 +39,7 @@ not just to-do items. Supported block types:
 Layout / structural types (table, table_row, synced_block, column_list,
 column) are surfaced by ` + "`blocks list`" + ` but cannot be created through
 ` + "`blocks add`" + ` — they require children or references and will be
-addable once JSON-payload input lands.
+addable via a JSON-payload command in a future release.
 
 Examples:
   notioncli blocks list              # List all blocks
@@ -167,7 +167,7 @@ Examples:
 		}
 
 		if !utils.IsAddableBlockType(blockType) {
-			err := fmt.Errorf("block type %q cannot be created via `blocks add` (needs children or a reference); use a JSON-payload path once --json-input lands", blockType)
+			err := fmt.Errorf("block type %q cannot be created via `blocks add` (needs children or a reference); use a JSON-payload command in a future release", blockType)
 			if globalJSON {
 				return jsonErrorOr(cmd, err)
 			}
@@ -299,6 +299,6 @@ func init() {
 	blocksAddCmd.Flags().StringVarP(&blockType, "type", "t", "paragraph", "Block type to add")
 	blocksAddCmd.Flags().StringVar(&blockURL, "url", "", "URL for image/file/video/embed/bookmark blocks (overrides positional text)")
 	blocksAddCmd.Flags().StringVar(&blockCaption, "caption", "", "Optional caption for image/file/video/embed/bookmark blocks")
-	blocksAddCmd.Flags().StringVar(&blockFileID, "file-upload-id", "", "Notion file_upload id for image/file/video blocks (see files upload)")
+	blocksAddCmd.Flags().StringVar(&blockFileID, "file-upload-id", "", "Notion file_upload id for image/file/video blocks (overrides --url and positional text when set; see files upload)")
 	blocksAddCmd.Flags().StringVar(&blockLanguage, "language", "plain text", "Language for code blocks")
 }

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -300,5 +300,5 @@ func init() {
 	blocksAddCmd.Flags().StringVar(&blockURL, "url", "", "URL for image/file/video/embed/bookmark blocks (overrides positional text)")
 	blocksAddCmd.Flags().StringVar(&blockCaption, "caption", "", "Optional caption for image/file/video/embed/bookmark blocks")
 	blocksAddCmd.Flags().StringVar(&blockFileID, "file-upload-id", "", "Notion file_upload id for image/file/video blocks (see files upload)")
-	blocksAddCmd.Flags().StringVar(&blockLanguage, "language", "", "Language for code blocks (default \"plain text\")")
+	blocksAddCmd.Flags().StringVar(&blockLanguage, "language", "plain text", "Language for code blocks")
 }

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -16,7 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var blockType string
+var (
+	blockType       string
+	blockURL        string
+	blockCaption    string
+	blockFileID     string
+	blockLanguage   string
+)
 
 // blocksCmd represents the blocks command
 var blocksCmd = &cobra.Command{
@@ -27,13 +33,22 @@ not just to-do items. Supported block types:
 
   paragraph, heading_1, heading_2, heading_3,
   bulleted_list_item, numbered_list_item, to_do,
-  toggle, quote, callout, divider, code
+  toggle, quote, callout, divider, code,
+  image, file, video, embed, bookmark, equation
+
+Layout / structural types (table, table_row, synced_block, column_list,
+column) are surfaced by ` + "`blocks list`" + ` but cannot be created through
+` + "`blocks add`" + ` — they require children or references and will be
+addable once JSON-payload input lands.
 
 Examples:
   notioncli blocks list              # List all blocks
   notioncli blocks list --type to_do # List only to-do blocks
   notioncli blocks add "Hello"       # Add a paragraph
   notioncli blocks add "Title" -t heading_1  # Add a heading
+  notioncli blocks add "https://example.com/pic.png" -t image
+  notioncli blocks add "caption" -t bookmark --url https://example.com
+  notioncli blocks add "E=mc^2" -t equation
   notioncli blocks delete 5          # Delete block at index 5`,
 }
 
@@ -113,13 +128,25 @@ var blocksAddCmd = &cobra.Command{
 Supported types:
   paragraph, heading_1, heading_2, heading_3,
   bulleted_list_item, numbered_list_item, to_do,
-  toggle, quote, callout, divider, code
+  toggle, quote, callout, divider, code,
+  image, file, video, embed, bookmark, equation
+
+Media (image/file/video) and URL (embed/bookmark) blocks read their URL from
+the positional text argument by default, or from --url when supplied. Media
+blocks can reference an uploaded file via --file-upload-id instead.
+
+Layout / structural types (table, table_row, synced_block, column_list,
+column) require children or references and cannot be created here yet.
 
 Examples:
   notioncli blocks add "Hello world"           # Add paragraph
   notioncli blocks add "Section Title" -t heading_1
   notioncli blocks add "" -t divider           # Add divider (no text needed)
-  notioncli blocks add "Buy milk" -t to_do`,
+  notioncli blocks add "Buy milk" -t to_do
+  notioncli blocks add "https://example.com/pic.png" -t image
+  notioncli blocks add "" -t image --file-upload-id abc-123
+  notioncli blocks add "caption" -t bookmark --url https://example.com
+  notioncli blocks add "E=mc^2" -t equation`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		text := args[0]
@@ -139,13 +166,24 @@ Examples:
 			return nil
 		}
 
+		if !utils.IsAddableBlockType(blockType) {
+			err := fmt.Errorf("block type %q cannot be created via `blocks add` (needs children or a reference); use a JSON-payload path once --json-input lands", blockType)
+			if globalJSON {
+				return jsonErrorOr(cmd, err)
+			}
+			color.Red("Error: %v", err)
+			return nil
+		}
+
 		notionAPIKey, _ := utils.SetAPIConfig()
 		pageID, err := resolvePageID()
 		if err != nil {
 			return jsonErrorOr(cmd, fmt.Errorf("blocks add: %w", err))
 		}
 
-		if err := utils.AddBlock(notionAPIKey, pageID, blockType, text); err != nil {
+		opts := blocksAddOptions()
+
+		if err := utils.AddBlock(notionAPIKey, pageID, blockType, text, opts...); err != nil {
 			if globalJSON {
 				return jsonErrorOr(cmd, fmt.Errorf("blocks add: %w", err))
 			}
@@ -154,11 +192,21 @@ Examples:
 		}
 
 		if globalJSON {
-			return emitOK(cmd.OutOrStdout(), map[string]interface{}{
+			payload := map[string]interface{}{
 				"action": "add",
 				"type":   blockType,
 				"text":   text,
-			})
+			}
+			if blockURL != "" {
+				payload["url"] = blockURL
+			}
+			if blockCaption != "" {
+				payload["caption"] = blockCaption
+			}
+			if blockFileID != "" {
+				payload["file_upload_id"] = blockFileID
+			}
+			return emitOK(cmd.OutOrStdout(), payload)
 		}
 
 		icon := utils.SupportedBlockTypes[blockType].Icon
@@ -169,6 +217,27 @@ Examples:
 		}
 		return nil
 	},
+}
+
+// blocksAddOptions translates the --url / --caption / --file-upload-id /
+// --language cmd-level flags into the utils.BlockOption slice consumed by
+// utils.AddBlock. Kept separate so the flag wiring is easy to extend and
+// trivial to unit-test in isolation.
+func blocksAddOptions() []utils.BlockOption {
+	var opts []utils.BlockOption
+	if blockURL != "" {
+		opts = append(opts, utils.WithURL(blockURL))
+	}
+	if blockCaption != "" {
+		opts = append(opts, utils.WithCaption(blockCaption))
+	}
+	if blockFileID != "" {
+		opts = append(opts, utils.WithFileUploadID(blockFileID))
+	}
+	if blockLanguage != "" {
+		opts = append(opts, utils.WithLanguage(blockLanguage))
+	}
+	return opts
 }
 
 // blocksDeleteCmd deletes a block by index
@@ -228,4 +297,8 @@ func init() {
 
 	// Flags for add command
 	blocksAddCmd.Flags().StringVarP(&blockType, "type", "t", "paragraph", "Block type to add")
+	blocksAddCmd.Flags().StringVar(&blockURL, "url", "", "URL for image/file/video/embed/bookmark blocks (overrides positional text)")
+	blocksAddCmd.Flags().StringVar(&blockCaption, "caption", "", "Optional caption for image/file/video/embed/bookmark blocks")
+	blocksAddCmd.Flags().StringVar(&blockFileID, "file-upload-id", "", "Notion file_upload id for image/file/video blocks (see files upload)")
+	blocksAddCmd.Flags().StringVar(&blockLanguage, "language", "", "Language for code blocks (default \"plain text\")")
 }

--- a/cmd/blocks_test.go
+++ b/cmd/blocks_test.go
@@ -170,7 +170,8 @@ func TestBlocksAddDispatch(t *testing.T) {
 
 // TestBlocksAdd_ExtendedFlags verifies the extended --url / --caption /
 // --file-upload-id / --language flags are registered and that --url defaults
-// to empty (the positional text remains the default URL source).
+// to empty (the positional text remains the default URL source). --language
+// defaults to "plain text" so Cobra's help output matches runtime behaviour.
 func TestBlocksAdd_ExtendedFlags(t *testing.T) {
 	add := findBlocksSubcommand(t, "add")
 
@@ -181,7 +182,7 @@ func TestBlocksAdd_ExtendedFlags(t *testing.T) {
 		{"url", ""},
 		{"caption", ""},
 		{"file-upload-id", ""},
-		{"language", ""},
+		{"language", "plain text"},
 	} {
 		t.Run(tc.flag, func(t *testing.T) {
 			f := add.Flag(tc.flag)
@@ -201,13 +202,14 @@ func TestBlocksAdd_ExtendedFlags(t *testing.T) {
 // resetBlocksAddFlags clears every package-level flag variable the add
 // command binds to. Cobra keeps these alive across rootCmd.Execute calls, so
 // tests that flip --url or --file-upload-id would leak those settings into
-// later tests without this reset.
+// later tests without this reset. blockLanguage resets to the Cobra default
+// ("plain text") so code-block tests see the same value the CLI user sees.
 func resetBlocksAddFlags() {
 	blockType = ""
 	blockURL = ""
 	blockCaption = ""
 	blockFileID = ""
-	blockLanguage = ""
+	blockLanguage = "plain text"
 }
 
 // TestBlocksAddDispatch_Image runs `blocks add https://... -t image` and

--- a/cmd/blocks_test.go
+++ b/cmd/blocks_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -163,6 +165,232 @@ func TestBlocksAddDispatch(t *testing.T) {
 
 	if atomic.LoadInt64(&patched) == 0 {
 		t.Error("blocks add did not PATCH /blocks/pageID/children")
+	}
+}
+
+// TestBlocksAdd_ExtendedFlags verifies the extended --url / --caption /
+// --file-upload-id / --language flags are registered and that --url defaults
+// to empty (the positional text remains the default URL source).
+func TestBlocksAdd_ExtendedFlags(t *testing.T) {
+	add := findBlocksSubcommand(t, "add")
+
+	for _, tc := range []struct {
+		flag string
+		want string
+	}{
+		{"url", ""},
+		{"caption", ""},
+		{"file-upload-id", ""},
+		{"language", ""},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			f := add.Flag(tc.flag)
+			if f == nil {
+				t.Fatalf("blocks add: --%s flag not registered", tc.flag)
+			}
+			if f.DefValue != tc.want {
+				t.Errorf("blocks add: --%s default = %q, want %q", tc.flag, f.DefValue, tc.want)
+			}
+			if f.Value.Type() != "string" {
+				t.Errorf("blocks add: --%s type = %q, want string", tc.flag, f.Value.Type())
+			}
+		})
+	}
+}
+
+// resetBlocksAddFlags clears every package-level flag variable the add
+// command binds to. Cobra keeps these alive across rootCmd.Execute calls, so
+// tests that flip --url or --file-upload-id would leak those settings into
+// later tests without this reset.
+func resetBlocksAddFlags() {
+	blockType = ""
+	blockURL = ""
+	blockCaption = ""
+	blockFileID = ""
+	blockLanguage = ""
+}
+
+// TestBlocksAddDispatch_Image runs `blocks add https://... -t image` and
+// asserts the wire-level JSON has an image.external.url payload.
+func TestBlocksAddDispatch_Image(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var captured []byte
+	var patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			body, _ := io.ReadAll(r.Body)
+			captured = body
+			atomic.AddInt64(&patched, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetBlocksAddFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "https://example.com/p.png", "-t", "image"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(blocks add image): %v", err)
+	}
+
+	if atomic.LoadInt64(&patched) == 0 {
+		t.Fatal("blocks add image did not PATCH children endpoint")
+	}
+	var parsed struct {
+		Children []struct {
+			Type  string `json:"type"`
+			Image struct {
+				Type     string `json:"type"`
+				External struct {
+					URL string `json:"url"`
+				} `json:"external"`
+			} `json:"image"`
+		} `json:"children"`
+	}
+	if err := json.Unmarshal(captured, &parsed); err != nil {
+		t.Fatalf("unmarshal captured: %v", err)
+	}
+	if len(parsed.Children) != 1 {
+		t.Fatalf("want 1 child, got %d", len(parsed.Children))
+	}
+	child := parsed.Children[0]
+	if child.Type != "image" || child.Image.Type != "external" || child.Image.External.URL != "https://example.com/p.png" {
+		t.Errorf("unexpected child payload: %+v", child)
+	}
+}
+
+// TestBlocksAddDispatch_Equation exercises the equation path through the
+// cmd layer and asserts the expression lands in the PATCH body.
+func TestBlocksAddDispatch_Equation(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var captured []byte
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			captured, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetBlocksAddFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "E=mc^2", "-t", "equation"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(blocks add equation): %v", err)
+	}
+
+	var parsed struct {
+		Children []struct {
+			Equation struct {
+				Expression string `json:"expression"`
+			} `json:"equation"`
+		} `json:"children"`
+	}
+	if err := json.Unmarshal(captured, &parsed); err != nil {
+		t.Fatalf("unmarshal captured: %v", err)
+	}
+	if len(parsed.Children) != 1 || parsed.Children[0].Equation.Expression != "E=mc^2" {
+		t.Errorf("expression not propagated: %s", captured)
+	}
+}
+
+// TestBlocksAddDispatch_BookmarkWithURLFlag confirms --url overrides the
+// positional text as the URL source for bookmark blocks.
+func TestBlocksAddDispatch_BookmarkWithURLFlag(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var captured []byte
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blocks/pageID/children") {
+			captured, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetBlocksAddFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{
+		"blocks", "add", "home page", "-t", "bookmark",
+		"--url", "https://example.com",
+		"--caption", "the site",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(blocks add bookmark): %v", err)
+	}
+
+	var parsed struct {
+		Children []struct {
+			Bookmark struct {
+				URL     string `json:"url"`
+				Caption []struct {
+					Text struct {
+						Content string `json:"content"`
+					} `json:"text"`
+				} `json:"caption"`
+			} `json:"bookmark"`
+		} `json:"children"`
+	}
+	if err := json.Unmarshal(captured, &parsed); err != nil {
+		t.Fatalf("unmarshal captured: %v", err)
+	}
+	if len(parsed.Children) != 1 {
+		t.Fatalf("want 1 child, got %d", len(parsed.Children))
+	}
+	bk := parsed.Children[0].Bookmark
+	if bk.URL != "https://example.com" {
+		t.Errorf("bookmark url = %q, want https://example.com", bk.URL)
+	}
+	if len(bk.Caption) != 1 || bk.Caption[0].Text.Content != "the site" {
+		t.Errorf("caption not propagated: %+v", bk.Caption)
+	}
+}
+
+// TestBlocksAdd_RejectsNonAddable asserts that `blocks add … -t table`
+// surfaces a human-readable error and does NOT issue a PATCH.
+func TestBlocksAdd_RejectsNonAddable(t *testing.T) {
+	srv := withCmdEnv(t)
+
+	var patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			atomic.AddInt64(&patched, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetBlocksAddFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "ignored", "-t", "table"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute returned err: %v (expected swallowed)", err)
+	}
+	if atomic.LoadInt64(&patched) != 0 {
+		t.Error("blocks add -t table should not PATCH the API")
 	}
 }
 

--- a/utils/block.go
+++ b/utils/block.go
@@ -5,7 +5,9 @@
 package utils
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -56,6 +58,50 @@ var SupportedBlockTypes = map[string]BlockTypeInfo{
 	"callout":            {Icon: "💡", Color: "yellow"},
 	"divider":            {Icon: "—", Color: "white"},
 	"code":               {Icon: "<>", Color: "blue"},
+	// Extended block types (issue #26).
+	"image":        {Icon: "🖼", Color: "magenta"},
+	"file":         {Icon: "📎", Color: "magenta"},
+	"video":        {Icon: "🎬", Color: "magenta"},
+	"embed":        {Icon: "🔗", Color: "blue"},
+	"bookmark":     {Icon: "🔖", Color: "blue"},
+	"equation":     {Icon: "∑", Color: "cyan"},
+	"table":        {Icon: "▦", Color: "white"},
+	"table_row":    {Icon: "│", Color: "white"},
+	"synced_block": {Icon: "⟳", Color: "magenta"},
+	"column_list":  {Icon: "⫴", Color: "white"},
+	"column":       {Icon: "│", Color: "white"},
+}
+
+// AddableBlockTypes lists block types that can be appended via the simple
+// `blocks add` CLI path. Complex types (table, synced_block, column_list,
+// column) require children or references and are intentionally excluded —
+// CLI callers should use a JSON-payload path when that lands.
+var AddableBlockTypes = map[string]bool{
+	"paragraph":          true,
+	"heading_1":          true,
+	"heading_2":          true,
+	"heading_3":          true,
+	"bulleted_list_item": true,
+	"numbered_list_item": true,
+	"to_do":              true,
+	"toggle":             true,
+	"quote":              true,
+	"callout":            true,
+	"divider":            true,
+	"code":               true,
+	"image":              true,
+	"file":               true,
+	"video":              true,
+	"embed":              true,
+	"bookmark":           true,
+	"equation":           true,
+}
+
+// IsAddableBlockType reports whether a block type can be appended via the
+// simple AddBlock path. Types that require children (table, column_list,
+// column) or cross-block references (synced_block) return false.
+func IsAddableBlockType(blockType string) bool {
+	return AddableBlockTypes[blockType]
 }
 
 // GetSupportedBlockTypeNames returns a sorted list of supported block type names.
@@ -134,7 +180,94 @@ type Block struct {
 	Callout          *RichTextBlock `json:"callout,omitempty"`
 	Code             *RichTextBlock `json:"code,omitempty"`
 	Divider          *struct{}      `json:"divider,omitempty"`
+
+	// Extended block types (issue #26).
+	Image       *MediaBlock    `json:"image,omitempty"`
+	File        *MediaBlock    `json:"file,omitempty"`
+	Video       *MediaBlock    `json:"video,omitempty"`
+	Embed       *EmbedBlock    `json:"embed,omitempty"`
+	Bookmark    *BookmarkBlock `json:"bookmark,omitempty"`
+	Equation    *EquationBlock `json:"equation,omitempty"`
+	Table       *TableBlock    `json:"table,omitempty"`
+	TableRow    *TableRowBlock `json:"table_row,omitempty"`
+	SyncedBlock *SyncedBlock   `json:"synced_block,omitempty"`
+	ColumnList  *ColumnList    `json:"column_list,omitempty"`
+	Column      *Column        `json:"column,omitempty"`
 }
+
+// ExternalFile is the external-URL variant of a Notion media reference. Used
+// by image/file/video blocks whose Type is "external".
+type ExternalFile struct {
+	URL string `json:"url"`
+}
+
+// FileUploadRef is the file_upload-id variant of a Notion media reference.
+// Used by image/file/video blocks whose Type is "file_upload".
+type FileUploadRef struct {
+	ID string `json:"id"`
+}
+
+// MediaBlock is the shared shape for image, file, and video blocks. Exactly
+// one of External or FileUpload is set depending on Type ("external" or
+// "file_upload"). Caption is optional.
+type MediaBlock struct {
+	Type       string         `json:"type"`
+	External   *ExternalFile  `json:"external,omitempty"`
+	FileUpload *FileUploadRef `json:"file_upload,omitempty"`
+	Caption    []RichText     `json:"caption,omitempty"`
+}
+
+// EmbedBlock is a generic embed (Miro, Twitter, etc.) addressed by URL.
+type EmbedBlock struct {
+	URL     string     `json:"url"`
+	Caption []RichText `json:"caption,omitempty"`
+}
+
+// BookmarkBlock is a URL bookmark rendered inline on a page.
+type BookmarkBlock struct {
+	URL     string     `json:"url"`
+	Caption []RichText `json:"caption,omitempty"`
+}
+
+// EquationBlock carries a LaTeX-style math expression. The expression is
+// always present; there is no caption.
+type EquationBlock struct {
+	Expression string `json:"expression"`
+}
+
+// TableBlock describes the table envelope; the actual cell content lives in
+// the table's child blocks (each a TableRowBlock).
+type TableBlock struct {
+	TableWidth      int  `json:"table_width"`
+	HasColumnHeader bool `json:"has_column_header"`
+	HasRowHeader    bool `json:"has_row_header"`
+}
+
+// TableRowBlock is a single row of a Notion table. Cells is a slice of
+// cells; each cell is a slice of rich-text runs.
+type TableRowBlock struct {
+	Cells [][]RichText `json:"cells"`
+}
+
+// SyncedFromRef identifies the original block that a synced copy mirrors.
+// When nil on a SyncedBlock, the block is itself the original.
+type SyncedFromRef struct {
+	BlockID string `json:"block_id"`
+}
+
+// SyncedBlock is a shared-content block. If SyncedFrom is nil this is the
+// original; otherwise this block mirrors the referenced block id.
+type SyncedBlock struct {
+	SyncedFrom *SyncedFromRef `json:"synced_from"`
+}
+
+// ColumnList is the container for a multi-column layout. Columns live as
+// child blocks.
+type ColumnList struct{}
+
+// Column is a single column within a ColumnList. Its own children are the
+// blocks rendered in that column.
+type Column struct{}
 
 // BlockList is a single page of block results, as returned by
 // /blocks/{id}/children.
@@ -227,11 +360,13 @@ func FormatAllBlocks(notionAPIKey, pageID string, localTimezone *time.Location, 
 	return defaultBlockClient(notionAPIKey).FormatAllBlocks(defaultCtx(), pageID, localTimezone, filterType)
 }
 
-// AddBlock delegates to BlockClient.AddBlock on a default client.
+// AddBlock delegates to BlockClient.AddBlock on a default client. The
+// variadic opts argument passes media URLs, captions, and other per-type
+// metadata through to the block payload.
 //
 // Deprecated: prefer BlockClient.AddBlock.
-func AddBlock(notionAPIKey, pageID, blockType, text string) error {
-	return defaultBlockClient(notionAPIKey).AddBlock(defaultCtx(), pageID, blockType, text)
+func AddBlock(notionAPIKey, pageID, blockType, text string, opts ...BlockOption) error {
+	return defaultBlockClient(notionAPIKey).AddBlock(defaultCtx(), pageID, blockType, text, opts...)
 }
 
 // DeleteBlock delegates to BlockClient.DeleteBlock on a default client.
@@ -290,8 +425,87 @@ func GetBlockContent(block Block) string {
 		if block.Code != nil && len(block.Code.RichText) > 0 {
 			return block.Code.RichText[0].PlainText
 		}
+	case "image":
+		return mediaBlockContent(block.Image)
+	case "file":
+		return mediaBlockContent(block.File)
+	case "video":
+		return mediaBlockContent(block.Video)
+	case "embed":
+		if block.Embed != nil {
+			return block.Embed.URL
+		}
+	case "bookmark":
+		if block.Bookmark != nil {
+			s := block.Bookmark.URL
+			if len(block.Bookmark.Caption) > 0 {
+				s += " — " + block.Bookmark.Caption[0].PlainText
+			}
+			return s
+		}
+	case "equation":
+		if block.Equation != nil {
+			return "$" + block.Equation.Expression + "$"
+		}
+	case "table":
+		if block.Table != nil {
+			header := "no"
+			if block.Table.HasColumnHeader {
+				header = "yes"
+			}
+			return fmt.Sprintf("table (%d cols, %s header)", block.Table.TableWidth, header)
+		}
+	case "table_row":
+		if block.TableRow != nil {
+			return formatTableRow(block.TableRow)
+		}
+	case "synced_block":
+		if block.SyncedBlock != nil {
+			if block.SyncedBlock.SyncedFrom != nil {
+				return fmt.Sprintf("(synced from %s)", block.SyncedBlock.SyncedFrom.BlockID)
+			}
+			return "(synced original)"
+		}
+	case "column_list", "column":
+		return ""
 	}
 	return "(empty)"
+}
+
+// mediaBlockContent returns a human-readable one-liner for a MediaBlock.
+// External URLs are emitted verbatim; file_upload references render as
+// "[uploaded file <id>]". A nil pointer yields the generic "(empty)" used
+// elsewhere in GetBlockContent.
+func mediaBlockContent(m *MediaBlock) string {
+	if m == nil {
+		return "(empty)"
+	}
+	switch m.Type {
+	case "external":
+		if m.External != nil {
+			return m.External.URL
+		}
+	case "file_upload":
+		if m.FileUpload != nil {
+			return "[uploaded file " + m.FileUpload.ID + "]"
+		}
+	}
+	return "(empty)"
+}
+
+// formatTableRow joins a row's cells with " | ", taking the first plain-text
+// run of each cell. Empty cells render as an empty string, preserving column
+// positions in the output.
+func formatTableRow(row *TableRowBlock) string {
+	parts := make([]string, 0, len(row.Cells))
+	for _, cell := range row.Cells {
+		text := ""
+		if len(cell) > 0 {
+			text = cell[0].PlainText
+		}
+		parts = append(parts, text)
+	}
+	return "[ " + strings.Join(parts, " | ") + " ]"
 }
 
 // GetBlockIcon returns the display icon for a block.

--- a/utils/block.go
+++ b/utils/block.go
@@ -449,11 +449,15 @@ func GetBlockContent(block Block) string {
 		}
 	case "table":
 		if block.Table != nil {
-			header := "no"
+			col := "no"
 			if block.Table.HasColumnHeader {
-				header = "yes"
+				col = "yes"
 			}
-			return fmt.Sprintf("table (%d cols, %s header)", block.Table.TableWidth, header)
+			row := "no"
+			if block.Table.HasRowHeader {
+				row = "yes"
+			}
+			return fmt.Sprintf("table (%d cols, %s col header, %s row header)", block.Table.TableWidth, col, row)
 		}
 	case "table_row":
 		if block.TableRow != nil {

--- a/utils/block_extra_test.go
+++ b/utils/block_extra_test.go
@@ -324,10 +324,23 @@ func TestMarkToDoBlockUnCheckedBadOrder(t *testing.T) {
 func TestAddBlock_AllTypes(t *testing.T) {
 	withMock(t)
 	for _, typ := range GetSupportedBlockTypeNames() {
+		// Layout/structural types (table, synced_block, column_list,
+		// column, table_row) are not addable via the simple CLI path —
+		// they need children or a synced-from reference. Their own
+		// not-addable error path is covered by
+		// TestAddBlock_RejectsNonAddableType.
+		if !IsAddableBlockType(typ) {
+			continue
+		}
 		t.Run(typ, func(t *testing.T) {
 			text := "hello"
-			if typ == "divider" {
+			switch typ {
+			case "divider":
 				text = ""
+			case "image", "file", "video", "embed", "bookmark":
+				text = "https://example.com/thing"
+			case "equation":
+				text = "E=mc^2"
 			}
 			if err := AddBlock("fakeKey", "mixedPage", typ, text); err != nil {
 				t.Fatalf("AddBlock(%s): %v", typ, err)
@@ -338,7 +351,7 @@ func TestAddBlock_AllTypes(t *testing.T) {
 
 func TestAddBlock_RejectsUnknownType(t *testing.T) {
 	withMock(t)
-	err := AddBlock("fakeKey", "mixedPage", "image", "nope")
+	err := AddBlock("fakeKey", "mixedPage", "not_a_real_block_type", "nope")
 	if err == nil {
 		t.Fatal("expected error for unsupported block type, got nil")
 	}

--- a/utils/block_test.go
+++ b/utils/block_test.go
@@ -165,7 +165,7 @@ func TestIsValidBlockType(t *testing.T) {
 		}
 	}
 
-	invalidTypes := []string{"invalid", "unknown", "image", ""}
+	invalidTypes := []string{"invalid", "unknown", ""}
 	for _, bt := range invalidTypes {
 		if IsValidBlockType(bt) {
 			t.Errorf("Expected '%s' to be an invalid block type", bt)
@@ -176,8 +176,16 @@ func TestIsValidBlockType(t *testing.T) {
 func TestGetSupportedBlockTypeNames(t *testing.T) {
 	names := GetSupportedBlockTypeNames()
 
-	if len(names) != 12 {
-		t.Errorf("Expected 12 block types, got %d", len(names))
+	// The supported-types map is the source of truth; this guard catches
+	// accidental deletions while still letting #26 and later issues grow
+	// the set without churning this test.
+	if want := len(SupportedBlockTypes); len(names) != want {
+		t.Errorf("Expected %d block types, got %d", want, len(names))
+	}
+	// Floor: the foundation set is 12 types; regressions below that are
+	// a real bug.
+	if len(names) < 12 {
+		t.Errorf("Expected at least 12 block types, got %d", len(names))
 	}
 
 	// Check that list is sorted

--- a/utils/block_types_test.go
+++ b/utils/block_types_test.go
@@ -1,0 +1,742 @@
+// Tests for the extended block types added by issue #26: image, file,
+// video, embed, bookmark, equation, table, table_row, synced_block,
+// column_list, column. Lives in a dedicated file so it stays out of #27's
+// rich-text fidelity work.
+
+package utils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------- GetBlockContent coverage ----------
+
+func TestBlockTypes_GetBlockContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		block Block
+		want  string
+	}{
+		{
+			name: "image external",
+			block: Block{
+				Type:  "image",
+				Image: &MediaBlock{Type: "external", External: &ExternalFile{URL: "https://example.com/pic.png"}},
+			},
+			want: "https://example.com/pic.png",
+		},
+		{
+			name: "image file_upload",
+			block: Block{
+				Type:  "image",
+				Image: &MediaBlock{Type: "file_upload", FileUpload: &FileUploadRef{ID: "upload-1"}},
+			},
+			want: "[uploaded file upload-1]",
+		},
+		{
+			name:  "image nil payload",
+			block: Block{Type: "image"},
+			want:  "(empty)",
+		},
+		{
+			name: "file external",
+			block: Block{
+				Type: "file",
+				File: &MediaBlock{Type: "external", External: &ExternalFile{URL: "https://example.com/x.pdf"}},
+			},
+			want: "https://example.com/x.pdf",
+		},
+		{
+			name: "video external",
+			block: Block{
+				Type:  "video",
+				Video: &MediaBlock{Type: "external", External: &ExternalFile{URL: "https://example.com/v.mp4"}},
+			},
+			want: "https://example.com/v.mp4",
+		},
+		{
+			name: "embed",
+			block: Block{
+				Type:  "embed",
+				Embed: &EmbedBlock{URL: "https://twitter.com/x"},
+			},
+			want: "https://twitter.com/x",
+		},
+		{
+			name: "bookmark no caption",
+			block: Block{
+				Type:     "bookmark",
+				Bookmark: &BookmarkBlock{URL: "https://example.com"},
+			},
+			want: "https://example.com",
+		},
+		{
+			name: "bookmark with caption",
+			block: Block{
+				Type: "bookmark",
+				Bookmark: &BookmarkBlock{
+					URL:     "https://example.com",
+					Caption: []RichText{{PlainText: "the site"}},
+				},
+			},
+			want: "https://example.com — the site",
+		},
+		{
+			name: "equation",
+			block: Block{
+				Type:     "equation",
+				Equation: &EquationBlock{Expression: "E=mc^2"},
+			},
+			want: "$E=mc^2$",
+		},
+		{
+			name: "table with header",
+			block: Block{
+				Type:  "table",
+				Table: &TableBlock{TableWidth: 3, HasColumnHeader: true},
+			},
+			want: "table (3 cols, yes header)",
+		},
+		{
+			name: "table no header",
+			block: Block{
+				Type:  "table",
+				Table: &TableBlock{TableWidth: 2, HasColumnHeader: false},
+			},
+			want: "table (2 cols, no header)",
+		},
+		{
+			name: "table_row",
+			block: Block{
+				Type: "table_row",
+				TableRow: &TableRowBlock{
+					Cells: [][]RichText{
+						{{PlainText: "a"}},
+						{{PlainText: "b"}},
+						{{PlainText: "c"}},
+					},
+				},
+			},
+			want: "[ a | b | c ]",
+		},
+		{
+			name: "table_row empty cell",
+			block: Block{
+				Type: "table_row",
+				TableRow: &TableRowBlock{
+					Cells: [][]RichText{
+						{{PlainText: "a"}},
+						{},
+						{{PlainText: "c"}},
+					},
+				},
+			},
+			want: "[ a |  | c ]",
+		},
+		{
+			name: "synced_block original",
+			block: Block{
+				Type:        "synced_block",
+				SyncedBlock: &SyncedBlock{SyncedFrom: nil},
+			},
+			want: "(synced original)",
+		},
+		{
+			name: "synced_block reference",
+			block: Block{
+				Type: "synced_block",
+				SyncedBlock: &SyncedBlock{
+					SyncedFrom: &SyncedFromRef{BlockID: "orig-id"},
+				},
+			},
+			want: "(synced from orig-id)",
+		},
+		{
+			name:  "column_list",
+			block: Block{Type: "column_list", ColumnList: &ColumnList{}},
+			want:  "",
+		},
+		{
+			name:  "column",
+			block: Block{Type: "column", Column: &Column{}},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetBlockContent(tt.block)
+			if got != tt.want {
+				t.Errorf("GetBlockContent(%s) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------- GetBlockIcon coverage ----------
+
+func TestBlockTypes_GetBlockIcon(t *testing.T) {
+	tests := []struct {
+		typ  string
+		want string
+	}{
+		{"image", "🖼"},
+		{"file", "📎"},
+		{"video", "🎬"},
+		{"embed", "🔗"},
+		{"bookmark", "🔖"},
+		{"equation", "∑"},
+		{"table", "▦"},
+		{"table_row", "│"},
+		{"synced_block", "⟳"},
+		{"column_list", "⫴"},
+		{"column", "│"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typ, func(t *testing.T) {
+			got := GetBlockIcon(Block{Type: tt.typ})
+			if got != tt.want {
+				t.Errorf("GetBlockIcon(%s) = %q, want %q", tt.typ, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------- IsAddableBlockType ----------
+
+func TestBlockTypes_IsAddableBlockType(t *testing.T) {
+	addable := []string{
+		"paragraph", "heading_1", "heading_2", "heading_3",
+		"bulleted_list_item", "numbered_list_item", "to_do",
+		"toggle", "quote", "callout", "divider", "code",
+		"image", "file", "video", "embed", "bookmark", "equation",
+	}
+	notAddable := []string{"table", "table_row", "synced_block", "column_list", "column"}
+
+	for _, typ := range addable {
+		if !IsAddableBlockType(typ) {
+			t.Errorf("IsAddableBlockType(%q) = false, want true", typ)
+		}
+	}
+	for _, typ := range notAddable {
+		if IsAddableBlockType(typ) {
+			t.Errorf("IsAddableBlockType(%q) = true, want false", typ)
+		}
+	}
+	if IsAddableBlockType("not_a_type") {
+		t.Error("IsAddableBlockType(not_a_type) = true, want false")
+	}
+}
+
+// ---------- buildAddBlockPayload unit tests (no HTTP) ----------
+
+func TestBlockTypes_BuildPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		blockType string
+		text      string
+		cfg       blockConfig
+		wantErr   bool
+		verify    func(t *testing.T, payload map[string]interface{})
+	}{
+		{
+			name:      "image external via text",
+			blockType: "image",
+			text:      "https://example.com/p.png",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["image"].(map[string]interface{})
+				if inner["type"] != "external" {
+					t.Errorf("type = %v, want external", inner["type"])
+				}
+				ext := inner["external"].(map[string]interface{})
+				if ext["url"] != "https://example.com/p.png" {
+					t.Errorf("url = %v", ext["url"])
+				}
+			},
+		},
+		{
+			name:      "image external prefers --url over text",
+			blockType: "image",
+			text:      "fallback",
+			cfg:       blockConfig{URL: "https://example.com/real.png"},
+			verify: func(t *testing.T, p map[string]interface{}) {
+				ext := p["image"].(map[string]interface{})["external"].(map[string]interface{})
+				if ext["url"] != "https://example.com/real.png" {
+					t.Errorf("url = %v want --url value", ext["url"])
+				}
+			},
+		},
+		{
+			name:      "image file_upload",
+			blockType: "image",
+			text:      "",
+			cfg:       blockConfig{FileID: "up-1"},
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["image"].(map[string]interface{})
+				if inner["type"] != "file_upload" {
+					t.Errorf("type = %v, want file_upload", inner["type"])
+				}
+				fu := inner["file_upload"].(map[string]interface{})
+				if fu["id"] != "up-1" {
+					t.Errorf("id = %v", fu["id"])
+				}
+				if _, has := inner["external"]; has {
+					t.Error("external key must be absent for file_upload variant")
+				}
+			},
+		},
+		{
+			name:      "image with caption",
+			blockType: "image",
+			text:      "https://example.com/p.png",
+			cfg:       blockConfig{Caption: "pic"},
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["image"].(map[string]interface{})
+				caps := inner["caption"].([]map[string]interface{})
+				if len(caps) != 1 {
+					t.Fatalf("want 1 caption run, got %d", len(caps))
+				}
+				if caps[0]["text"].(map[string]interface{})["content"] != "pic" {
+					t.Error("caption text not propagated")
+				}
+			},
+		},
+		{
+			name:      "image missing url and file id errors",
+			blockType: "image",
+			text:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "file external",
+			blockType: "file",
+			text:      "https://example.com/x.pdf",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				if p["type"] != "file" {
+					t.Error("envelope type not file")
+				}
+			},
+		},
+		{
+			name:      "video external",
+			blockType: "video",
+			text:      "https://example.com/v.mp4",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				if p["type"] != "video" {
+					t.Error("envelope type not video")
+				}
+			},
+		},
+		{
+			name:      "embed",
+			blockType: "embed",
+			text:      "https://example.com",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["embed"].(map[string]interface{})
+				if inner["url"] != "https://example.com" {
+					t.Errorf("embed url = %v", inner["url"])
+				}
+			},
+		},
+		{
+			name:      "embed missing url errors",
+			blockType: "embed",
+			text:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "bookmark with caption",
+			blockType: "bookmark",
+			text:      "https://example.com",
+			cfg:       blockConfig{Caption: "home"},
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["bookmark"].(map[string]interface{})
+				if inner["url"] != "https://example.com" {
+					t.Errorf("bookmark url = %v", inner["url"])
+				}
+				caps := inner["caption"].([]map[string]interface{})
+				if len(caps) != 1 {
+					t.Fatalf("want 1 caption run, got %d", len(caps))
+				}
+			},
+		},
+		{
+			name:      "bookmark missing url errors",
+			blockType: "bookmark",
+			text:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "equation",
+			blockType: "equation",
+			text:      "a^2+b^2=c^2",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["equation"].(map[string]interface{})
+				if inner["expression"] != "a^2+b^2=c^2" {
+					t.Errorf("expression = %v", inner["expression"])
+				}
+			},
+		},
+		{
+			name:      "equation missing expression errors",
+			blockType: "equation",
+			text:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "paragraph retains rich-text shape",
+			blockType: "paragraph",
+			text:      "hi",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["paragraph"].(map[string]interface{})
+				rt := inner["rich_text"].([]map[string]interface{})
+				if rt[0]["text"].(map[string]interface{})["content"] != "hi" {
+					t.Error("rich_text content not propagated")
+				}
+			},
+		},
+		{
+			name:      "code with language option",
+			blockType: "code",
+			text:      "fmt.Println(1)",
+			cfg:       blockConfig{Language: "go"},
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["code"].(map[string]interface{})
+				if inner["language"] != "go" {
+					t.Errorf("language = %v want go", inner["language"])
+				}
+			},
+		},
+		{
+			name:      "code default language",
+			blockType: "code",
+			text:      "x",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				inner := p["code"].(map[string]interface{})
+				if inner["language"] != "plain text" {
+					t.Errorf("language = %v want plain text", inner["language"])
+				}
+			},
+		},
+		{
+			name:      "divider ignores text",
+			blockType: "divider",
+			text:      "ignored",
+			verify: func(t *testing.T, p map[string]interface{}) {
+				if _, ok := p["divider"].(map[string]interface{}); !ok {
+					t.Error("divider payload shape wrong")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildAddBlockPayload(tt.blockType, tt.text, tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got["object"] != "block" {
+				t.Errorf("envelope object = %v, want block", got["object"])
+			}
+			if got["type"] != tt.blockType {
+				t.Errorf("envelope type = %v, want %s", got["type"], tt.blockType)
+			}
+			if tt.verify != nil {
+				tt.verify(t, got)
+			}
+		})
+	}
+}
+
+// ---------- AddBlock end-to-end per type ----------
+
+// addBlockMock returns a server that accepts any PATCH to
+// /blocks/.../children and captures the JSON body, so tests can assert the
+// wire shape for each extended type.
+func addBlockMock(t *testing.T, captured *[]byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/children") {
+			body, _ := io.ReadAll(r.Body)
+			*captured = body
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		http.Error(w, `{"object":"error"}`, http.StatusNotFound)
+	}))
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	t.Cleanup(func() {
+		SetBaseURL(prev)
+		srv.Close()
+	})
+	return srv
+}
+
+// decodeFirstChild parses the captured AddBlock PATCH body and returns the
+// single child envelope — every AddBlock call sends exactly one.
+func decodeFirstChild(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var parsed struct {
+		Children []map[string]interface{} `json:"children"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if len(parsed.Children) != 1 {
+		t.Fatalf("want 1 child in payload, got %d", len(parsed.Children))
+	}
+	return parsed.Children[0]
+}
+
+func TestAddBlock_Image(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "image", "https://example.com/p.png"); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	if child["type"] != "image" {
+		t.Errorf("type = %v, want image", child["type"])
+	}
+	inner := child["image"].(map[string]interface{})
+	if inner["type"] != "external" {
+		t.Errorf("inner type = %v, want external", inner["type"])
+	}
+}
+
+func TestAddBlock_ImageFileUpload(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "image", "", WithFileUploadID("uploaded-id")); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	inner := child["image"].(map[string]interface{})
+	if inner["type"] != "file_upload" {
+		t.Fatalf("inner type = %v, want file_upload", inner["type"])
+	}
+	fu := inner["file_upload"].(map[string]interface{})
+	if fu["id"] != "uploaded-id" {
+		t.Errorf("file_upload id = %v", fu["id"])
+	}
+}
+
+func TestAddBlock_File(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "file", "https://example.com/x.pdf"); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	if child["type"] != "file" {
+		t.Errorf("type = %v", child["type"])
+	}
+}
+
+func TestAddBlock_Video(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "video", "https://example.com/v.mp4"); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	if child["type"] != "video" {
+		t.Errorf("type = %v", child["type"])
+	}
+}
+
+func TestAddBlock_Embed(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "embed", "https://twitter.com/x"); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	inner := child["embed"].(map[string]interface{})
+	if inner["url"] != "https://twitter.com/x" {
+		t.Errorf("url = %v", inner["url"])
+	}
+}
+
+func TestAddBlock_Bookmark(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "bookmark", "https://example.com", WithCaption("home")); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	inner := child["bookmark"].(map[string]interface{})
+	if inner["url"] != "https://example.com" {
+		t.Errorf("url = %v", inner["url"])
+	}
+	cap := inner["caption"].([]interface{})
+	if len(cap) != 1 {
+		t.Fatalf("want 1 caption run, got %d", len(cap))
+	}
+}
+
+func TestAddBlock_Equation(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	if err := AddBlock("k", "pg", "equation", "E=mc^2"); err != nil {
+		t.Fatalf("AddBlock: %v", err)
+	}
+	child := decodeFirstChild(t, body)
+	inner := child["equation"].(map[string]interface{})
+	if inner["expression"] != "E=mc^2" {
+		t.Errorf("expression = %v", inner["expression"])
+	}
+}
+
+func TestAddBlock_RejectsNonAddableType(t *testing.T) {
+	var body []byte
+	addBlockMock(t, &body)
+	for _, typ := range []string{"table", "table_row", "synced_block", "column_list", "column"} {
+		t.Run(typ, func(t *testing.T) {
+			err := AddBlock("k", "pg", typ, "x")
+			if err == nil {
+				t.Fatalf("AddBlock(%s) unexpectedly succeeded", typ)
+			}
+			if !strings.Contains(err.Error(), "not addable") {
+				t.Errorf("error %v does not mention not-addable", err)
+			}
+		})
+	}
+}
+
+// ---------- JSON round-trip for the new Block struct fields ----------
+
+func TestBlockTypes_JSONRoundTrip(t *testing.T) {
+	raw := `{
+		"object":"list","has_more":false,"results":[
+			{"object":"block","id":"i1","type":"image","image":{"type":"external","external":{"url":"https://example.com/p.png"},"caption":[{"type":"text","plain_text":"pic","text":{"content":"pic"}}]}},
+			{"object":"block","id":"f1","type":"file","file":{"type":"file_upload","file_upload":{"id":"fu-1"}}},
+			{"object":"block","id":"v1","type":"video","video":{"type":"external","external":{"url":"https://example.com/v.mp4"}}},
+			{"object":"block","id":"e1","type":"embed","embed":{"url":"https://example.com"}},
+			{"object":"block","id":"bk","type":"bookmark","bookmark":{"url":"https://example.com"}},
+			{"object":"block","id":"eq","type":"equation","equation":{"expression":"x^2"}},
+			{"object":"block","id":"tb","type":"table","table":{"table_width":2,"has_column_header":true,"has_row_header":false}},
+			{"object":"block","id":"tr","type":"table_row","table_row":{"cells":[[{"type":"text","plain_text":"a","text":{"content":"a"}}],[{"type":"text","plain_text":"b","text":{"content":"b"}}]]}},
+			{"object":"block","id":"sb","type":"synced_block","synced_block":{"synced_from":null}},
+			{"object":"block","id":"sb2","type":"synced_block","synced_block":{"synced_from":{"block_id":"orig-id"}}},
+			{"object":"block","id":"cl","type":"column_list","column_list":{}},
+			{"object":"block","id":"co","type":"column","column":{}}
+		]
+	}`
+
+	var list BlockList
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list.Results) != 12 {
+		t.Fatalf("want 12 blocks, got %d", len(list.Results))
+	}
+
+	checks := map[string]func(Block) bool{
+		"i1": func(b Block) bool { return b.Image != nil && b.Image.External.URL == "https://example.com/p.png" },
+		"f1": func(b Block) bool { return b.File != nil && b.File.FileUpload.ID == "fu-1" },
+		"v1": func(b Block) bool { return b.Video != nil && b.Video.External.URL == "https://example.com/v.mp4" },
+		"e1": func(b Block) bool { return b.Embed != nil && b.Embed.URL == "https://example.com" },
+		"bk": func(b Block) bool { return b.Bookmark != nil && b.Bookmark.URL == "https://example.com" },
+		"eq": func(b Block) bool { return b.Equation != nil && b.Equation.Expression == "x^2" },
+		"tb": func(b Block) bool { return b.Table != nil && b.Table.TableWidth == 2 && b.Table.HasColumnHeader },
+		"tr": func(b Block) bool { return b.TableRow != nil && len(b.TableRow.Cells) == 2 },
+		"sb": func(b Block) bool { return b.SyncedBlock != nil && b.SyncedBlock.SyncedFrom == nil },
+		"sb2": func(b Block) bool {
+			return b.SyncedBlock != nil && b.SyncedBlock.SyncedFrom != nil && b.SyncedBlock.SyncedFrom.BlockID == "orig-id"
+		},
+		"cl": func(b Block) bool { return b.ColumnList != nil },
+		"co": func(b Block) bool { return b.Column != nil },
+	}
+
+	byID := map[string]Block{}
+	for _, b := range list.Results {
+		byID[b.ID] = b
+	}
+	for id, check := range checks {
+		b, ok := byID[id]
+		if !ok {
+			t.Errorf("missing block id %s after decode", id)
+			continue
+		}
+		if !check(b) {
+			t.Errorf("block id %s did not decode with the expected payload", id)
+		}
+	}
+
+	// Re-marshal + decode ensures round-trip stability for the new types.
+	out, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	var list2 BlockList
+	if err := json.Unmarshal(out, &list2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if len(list2.Results) != 12 {
+		t.Errorf("round-trip: want 12 blocks, got %d", len(list2.Results))
+	}
+}
+
+// ---------- BlockOption helpers ----------
+
+// Gap-gate-facing names. These mirror the exported identifiers so the
+// repo's scripts/check-test-coverage.sh treats them as covered.
+
+func TestWithURL(t *testing.T) {
+	cfg := blockConfig{}
+	WithURL("https://x")(&cfg)
+	if cfg.URL != "https://x" {
+		t.Errorf("cfg.URL = %q, want https://x", cfg.URL)
+	}
+}
+
+func TestWithCaption(t *testing.T) {
+	cfg := blockConfig{}
+	WithCaption("hi")(&cfg)
+	if cfg.Caption != "hi" {
+		t.Errorf("cfg.Caption = %q, want hi", cfg.Caption)
+	}
+}
+
+func TestWithFileUploadID(t *testing.T) {
+	cfg := blockConfig{}
+	WithFileUploadID("up-1")(&cfg)
+	if cfg.FileID != "up-1" {
+		t.Errorf("cfg.FileID = %q, want up-1", cfg.FileID)
+	}
+}
+
+func TestWithLanguage(t *testing.T) {
+	cfg := blockConfig{}
+	WithLanguage("go")(&cfg)
+	if cfg.Language != "go" {
+		t.Errorf("cfg.Language = %q, want go", cfg.Language)
+	}
+}
+
+func TestIsAddableBlockType(t *testing.T) {
+	if !IsAddableBlockType("paragraph") {
+		t.Error("paragraph should be addable")
+	}
+	if !IsAddableBlockType("image") {
+		t.Error("image should be addable (issue #26)")
+	}
+	if IsAddableBlockType("table") {
+		t.Error("table should not be addable (needs children)")
+	}
+	if IsAddableBlockType("not_a_type") {
+		t.Error("unknown type should not be addable")
+	}
+}

--- a/utils/block_types_test.go
+++ b/utils/block_types_test.go
@@ -95,20 +95,36 @@ func TestBlockTypes_GetBlockContent(t *testing.T) {
 			want: "$E=mc^2$",
 		},
 		{
-			name: "table with header",
+			name: "table with column header only",
 			block: Block{
 				Type:  "table",
 				Table: &TableBlock{TableWidth: 3, HasColumnHeader: true},
 			},
-			want: "table (3 cols, yes header)",
+			want: "table (3 cols, yes col header, no row header)",
 		},
 		{
-			name: "table no header",
+			name: "table with no headers",
 			block: Block{
 				Type:  "table",
 				Table: &TableBlock{TableWidth: 2, HasColumnHeader: false},
 			},
-			want: "table (2 cols, no header)",
+			want: "table (2 cols, no col header, no row header)",
+		},
+		{
+			name: "table with both headers",
+			block: Block{
+				Type:  "table",
+				Table: &TableBlock{TableWidth: 4, HasColumnHeader: true, HasRowHeader: true},
+			},
+			want: "table (4 cols, yes col header, yes row header)",
+		},
+		{
+			name: "table with row header only",
+			block: Block{
+				Type:  "table",
+				Table: &TableBlock{TableWidth: 2, HasColumnHeader: false, HasRowHeader: true},
+			},
+			want: "table (2 cols, no col header, yes row header)",
 		},
 		{
 			name: "table_row",

--- a/utils/block_types_test.go
+++ b/utils/block_types_test.go
@@ -742,6 +742,11 @@ func TestWithLanguage(t *testing.T) {
 	}
 }
 
+// TestIsAddableBlockType is the gap-gate mirror for IsAddableBlockType. The
+// coverage checker looks for a Test<FuncName> that matches the exported
+// function exactly, so this minimal smoke test satisfies the gate even though
+// TestBlockTypes_IsAddableBlockType above covers the same surface in depth.
+// Do not merge the two — the singular-named test is the gap-gate hook.
 func TestIsAddableBlockType(t *testing.T) {
 	if !IsAddableBlockType("paragraph") {
 		t.Error("paragraph should be addable")

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -431,7 +431,7 @@ func buildMediaBlock(blockType, text string, cfg blockConfig) (map[string]interf
 	} else {
 		url := mediaURL(text, cfg)
 		if url == "" {
-			return nil, fmt.Errorf("%s block requires a URL or a file upload id", blockType)
+			return nil, fmt.Errorf("%s block requires a URL (positional arg or --url) or a --file-upload-id", blockType)
 		}
 		inner["type"] = "external"
 		inner["external"] = map[string]interface{}{"url": url}

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -360,8 +360,8 @@ func buildAddBlockPayload(blockType, text string, cfg blockConfig) (map[string]i
 			return nil, fmt.Errorf("embed block requires a URL")
 		}
 		inner := map[string]interface{}{"url": url}
-		if cap := captionRichText(cfg.Caption); cap != nil {
-			inner["caption"] = cap
+		if captionRT := captionRichText(cfg.Caption); captionRT != nil {
+			inner["caption"] = captionRT
 		}
 		return map[string]interface{}{
 			"object": "block",
@@ -375,8 +375,8 @@ func buildAddBlockPayload(blockType, text string, cfg blockConfig) (map[string]i
 			return nil, fmt.Errorf("bookmark block requires a URL")
 		}
 		inner := map[string]interface{}{"url": url}
-		if cap := captionRichText(cfg.Caption); cap != nil {
-			inner["caption"] = cap
+		if captionRT := captionRichText(cfg.Caption); captionRT != nil {
+			inner["caption"] = captionRT
 		}
 		return map[string]interface{}{
 			"object":   "block",
@@ -436,8 +436,8 @@ func buildMediaBlock(blockType, text string, cfg blockConfig) (map[string]interf
 		inner["type"] = "external"
 		inner["external"] = map[string]interface{}{"url": url}
 	}
-	if cap := captionRichText(cfg.Caption); cap != nil {
-		inner["caption"] = cap
+	if captionRT := captionRichText(cfg.Caption); captionRT != nil {
+		inner["caption"] = captionRT
 	}
 	return inner, nil
 }

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -254,38 +254,66 @@ func (b *BlockClient) FormatAllBlocks(ctx context.Context, pageID string, localT
 	return formatted, typeCounts, nil
 }
 
+// blockConfig holds the optional parameters used by AddBlock when building
+// block payloads. Fields only matter for the types that reference them —
+// e.g. Caption is ignored for paragraph/heading blocks.
+type blockConfig struct {
+	URL      string
+	Caption  string
+	FileID   string // Notion file_upload id; when set, media blocks use "file_upload" instead of "external".
+	Language string
+}
+
+// BlockOption mutates a blockConfig. Exposed as functional options so callers
+// can pass arbitrary combinations of URL, caption, file-upload id, and
+// language without growing AddBlock's positional parameter list.
+type BlockOption func(*blockConfig)
+
+// WithURL sets the external URL used by image/file/video/embed/bookmark
+// blocks. Overrides the positional text argument when non-empty.
+func WithURL(u string) BlockOption {
+	return func(c *blockConfig) { c.URL = u }
+}
+
+// WithCaption attaches a plain-text caption to media and bookmark blocks.
+func WithCaption(s string) BlockOption {
+	return func(c *blockConfig) { c.Caption = s }
+}
+
+// WithFileUploadID turns a media block into the "file_upload" variant,
+// referencing a previously-uploaded file by id (see utils.FileClient.Upload).
+// When set, any WithURL value is ignored.
+func WithFileUploadID(id string) BlockOption {
+	return func(c *blockConfig) { c.FileID = id }
+}
+
+// WithLanguage sets the language on a code block. Defaults to "plain text"
+// when not supplied.
+func WithLanguage(lang string) BlockOption {
+	return func(c *blockConfig) { c.Language = lang }
+}
+
 // AddBlock appends a block of the given type to the given page. Pass the
-// block's text for rich-text types; text is ignored for the divider block.
-func (b *BlockClient) AddBlock(ctx context.Context, pageID, blockType, text string) error {
+// block's text for rich-text types; text is the URL for media/embed/bookmark
+// blocks and the LaTeX expression for equation blocks. Optional behaviour
+// (file_upload id, captions, language) is supplied via BlockOption values.
+// Text is ignored for the divider block.
+func (b *BlockClient) AddBlock(ctx context.Context, pageID, blockType, text string, opts ...BlockOption) error {
 	if !IsValidBlockType(blockType) {
 		return fmt.Errorf("unsupported block type: %s", blockType)
 	}
+	if !IsAddableBlockType(blockType) {
+		return fmt.Errorf("block type %q is not addable via `blocks add`; use a JSON-payload path once --json-input lands", blockType)
+	}
 
-	var blockContent map[string]interface{}
-	if blockType == "divider" {
-		blockContent = map[string]interface{}{
-			"object":  "block",
-			"type":    "divider",
-			"divider": map[string]interface{}{},
-		}
-	} else {
-		richText := []map[string]interface{}{
-			{
-				"type": "text",
-				"text": map[string]interface{}{
-					"content": text,
-				},
-			},
-		}
-		innerContent := map[string]interface{}{"rich_text": richText}
-		if blockType == "code" {
-			innerContent["language"] = "plain text"
-		}
-		blockContent = map[string]interface{}{
-			"object":  "block",
-			"type":    blockType,
-			blockType: innerContent,
-		}
+	cfg := blockConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	blockContent, err := buildAddBlockPayload(blockType, text, cfg)
+	if err != nil {
+		return err
 	}
 
 	body := map[string]interface{}{
@@ -300,6 +328,143 @@ func (b *BlockClient) AddBlock(ctx context.Context, pageID, blockType, text stri
 		return err
 	}
 	return expectStatus(resp, http.StatusOK)
+}
+
+// buildAddBlockPayload returns the per-type JSON envelope for the Notion
+// `PATCH /blocks/{id}/children` endpoint. Split out of AddBlock so it can be
+// unit-tested without an HTTP round-trip and so each new type maps to a
+// single self-contained case block.
+func buildAddBlockPayload(blockType, text string, cfg blockConfig) (map[string]interface{}, error) {
+	switch blockType {
+	case "divider":
+		return map[string]interface{}{
+			"object":  "block",
+			"type":    "divider",
+			"divider": map[string]interface{}{},
+		}, nil
+
+	case "image", "file", "video":
+		inner, err := buildMediaBlock(blockType, text, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{
+			"object":  "block",
+			"type":    blockType,
+			blockType: inner,
+		}, nil
+
+	case "embed":
+		url := mediaURL(text, cfg)
+		if url == "" {
+			return nil, fmt.Errorf("embed block requires a URL")
+		}
+		inner := map[string]interface{}{"url": url}
+		if cap := captionRichText(cfg.Caption); cap != nil {
+			inner["caption"] = cap
+		}
+		return map[string]interface{}{
+			"object": "block",
+			"type":   "embed",
+			"embed":  inner,
+		}, nil
+
+	case "bookmark":
+		url := mediaURL(text, cfg)
+		if url == "" {
+			return nil, fmt.Errorf("bookmark block requires a URL")
+		}
+		inner := map[string]interface{}{"url": url}
+		if cap := captionRichText(cfg.Caption); cap != nil {
+			inner["caption"] = cap
+		}
+		return map[string]interface{}{
+			"object":   "block",
+			"type":     "bookmark",
+			"bookmark": inner,
+		}, nil
+
+	case "equation":
+		if text == "" {
+			return nil, fmt.Errorf("equation block requires an expression")
+		}
+		return map[string]interface{}{
+			"object":   "block",
+			"type":     "equation",
+			"equation": map[string]interface{}{"expression": text},
+		}, nil
+
+	default:
+		// Rich-text family: paragraph, heading_1..3, bulleted/numbered,
+		// to_do, toggle, quote, callout, code.
+		richText := []map[string]interface{}{
+			{
+				"type": "text",
+				"text": map[string]interface{}{"content": text},
+			},
+		}
+		innerContent := map[string]interface{}{"rich_text": richText}
+		if blockType == "code" {
+			lang := cfg.Language
+			if lang == "" {
+				lang = "plain text"
+			}
+			innerContent["language"] = lang
+		}
+		return map[string]interface{}{
+			"object":  "block",
+			"type":    blockType,
+			blockType: innerContent,
+		}, nil
+	}
+}
+
+// buildMediaBlock returns the inner envelope for an image/file/video block.
+// When the caller supplied a file-upload id, the block uses the "file_upload"
+// variant; otherwise it falls back to "external" with the URL taken from
+// WithURL (preferred) or the positional text argument.
+func buildMediaBlock(blockType, text string, cfg blockConfig) (map[string]interface{}, error) {
+	inner := map[string]interface{}{}
+	if cfg.FileID != "" {
+		inner["type"] = "file_upload"
+		inner["file_upload"] = map[string]interface{}{"id": cfg.FileID}
+	} else {
+		url := mediaURL(text, cfg)
+		if url == "" {
+			return nil, fmt.Errorf("%s block requires a URL or a file upload id", blockType)
+		}
+		inner["type"] = "external"
+		inner["external"] = map[string]interface{}{"url": url}
+	}
+	if cap := captionRichText(cfg.Caption); cap != nil {
+		inner["caption"] = cap
+	}
+	return inner, nil
+}
+
+// mediaURL picks the URL from WithURL when set, otherwise from the positional
+// text argument. Keeps `blocks add https://pic.png -t image` working while
+// still honouring `--url` on the cmd layer.
+func mediaURL(text string, cfg blockConfig) string {
+	if cfg.URL != "" {
+		return cfg.URL
+	}
+	return text
+}
+
+// captionRichText wraps a plain-text caption in the rich-text array shape the
+// Notion API expects on media/embed/bookmark blocks. An empty string yields
+// nil so the caption key stays absent from the payload.
+func captionRichText(s string) []map[string]interface{} {
+	if s == "" {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"type": "text",
+			"text": map[string]interface{}{"content": s},
+		},
+	}
 }
 
 // DeleteBlock removes the block at the given 1-based index across the full


### PR DESCRIPTION
## Summary

Closes #26. Adds support for the extended Notion block types split out of issue #11: `image`, `file`, `video`, `embed`, `bookmark`, `equation`, `table`, `table_row`, `synced_block`, `column_list`, `column`.

## What's in

- **Type model (`utils/block.go`)** — `MediaBlock` (shared by image/file/video), `EmbedBlock`, `BookmarkBlock`, `EquationBlock`, `TableBlock`, `TableRowBlock`, `SyncedBlock`, `ColumnList`, `Column`, plus matching pointer fields on `Block`.
- **Registry** — `SupportedBlockTypes` extended with icons/colors for all 11 new types. New `AddableBlockTypes` set + `IsAddableBlockType` helper tracks which types the CLI can create directly vs. which need children/references.
- **`GetBlockContent`** — per-type renderers: media → URL or `[uploaded file <id>]`, embed/bookmark → URL (+ caption), equation → `$expr$`, table → `table (<n> cols, <y/n> header)`, table_row → `[ a | b | c ]`, synced_block → `(synced original)` / `(synced from <id>)`, column/column_list → empty (layout-only).
- **`GetBlockIcon`** — icon per type via existing `SupportedBlockTypes` lookup.
- **`AddBlock`** — extended with a variadic `BlockOption` arg. Options: `WithURL`, `WithCaption`, `WithFileUploadID`, `WithLanguage`. Media blocks accept either an external URL (positional text or `--url`) or a file_upload id. Non-addable types (`table`, `synced_block`, `column_list`, `column`, `table_row`) are rejected with a clear error.
- **cmd layer** — new flags on `blocks add`: `--url`, `--caption`, `--file-upload-id`, `--language`. Help text updated. Non-addable types surface a human-readable error without hitting the API.

## What's CLI-addable

`paragraph`, `heading_1..3`, `bulleted_list_item`, `numbered_list_item`, `to_do`, `toggle`, `quote`, `callout`, `divider`, `code`, **`image`**, **`file`**, **`video`**, **`embed`**, **`bookmark`**, **`equation`**.

## What's NOT yet addable (listed/rendered only)

`table`, `table_row`, `synced_block`, `column_list`, `column`. These need children or a block-reference id; they'll become addable once JSON-payload input lands.

## Tests

- `utils/block_types_test.go` (new, 530 LOC) — table-driven `GetBlockContent`, `GetBlockIcon`, `IsAddableBlockType`; `buildAddBlockPayload` unit tests across every new type; `AddBlock` end-to-end with a PATCH-capturing mock to assert wire shape; JSON round-trip for the new `Block` struct fields; option-function tests named to satisfy the gap gate (`TestWithURL`, etc.).
- `cmd/blocks_test.go` — extended with `TestBlocksAdd_ExtendedFlags`, `TestBlocksAddDispatch_Image`, `TestBlocksAddDispatch_Equation`, `TestBlocksAddDispatch_BookmarkWithURLFlag`, `TestBlocksAdd_RejectsNonAddable`. Each dispatch test captures the PATCH body and asserts the correct Notion envelope.
- `utils/block_test.go` / `block_extra_test.go` — existing tests updated: the hardcoded \"12 types\" assertion now cross-checks against the map's live size with a ≥12 floor; `TestAddBlock_AllTypes` iterates only over addable types and uses per-type sample text (URL for media, LaTeX for equation, etc.); `TestAddBlock_RejectsUnknownType` now uses a genuinely unknown type (`image` was valid after this PR).

## Coverage

| | before | after |
|-|-|-|
| utils | 84.8% | 85.9% |
| cmd | 84.2% | 84.0% |
| total | 86.4% | **87.1%** |

Gap-gate unchanged: 2 pre-existing entries (`utils.NewFileRef`, `utils.Upload` from #10).

## \`make ci\` — tail

\`\`\`
ok  	notioncli/cmd	coverage: 84.0% of statements
ok  	notioncli/utils	coverage: 85.9% of statements
total:					(statements)			87.1%
Total coverage: 87.1% (gate: 70%)
Test coverage gaps — 2 exported function(s) have no matching Test*:
  utils.NewFileRef  (utils/files.go:38)
  utils.Upload  (utils/files.go:121)
\`\`\`

## Coordination with #27 (rich-text fidelity)

By design, this PR is strictly ADDITIVE on `utils/block.go`:
- **No changes** to `RichText`, `RichTextBlock`, `Annotation`, `Text`.
- **No changes** to existing `GetBlockContent` behaviour for already-supported types (only new `case` branches appended).
- New test file is `utils/block_types_test.go` — NOT `block_richtext_test.go` (reserved for #27).

The `utils/block.go` switch statements in `GetBlockContent` and the `buildAddBlockPayload` switch in `utils/blocks.go` add self-contained cases per new type; merging #27 should produce a trivial case-block concat.

## Test plan

- [ ] `make ci` green (verified locally: 87.1% total, gap gate 2 pre-existing).
- [ ] CI workflow dispatches clean.
- [ ] `notioncli blocks add "https://example.com/pic.png" -t image` adds an image block (covered by `TestBlocksAddDispatch_Image`).
- [ ] `notioncli blocks add "E=mc^2" -t equation` adds an equation block (covered by `TestBlocksAddDispatch_Equation`).
- [ ] `notioncli blocks add "home" -t bookmark --url https://example.com --caption "the site"` adds a bookmark (covered by `TestBlocksAddDispatch_BookmarkWithURLFlag`).
- [ ] `notioncli blocks add x -t table` errors without hitting the API (covered by `TestBlocksAdd_RejectsNonAddable`).