### PR TITLE
feat: page-mention title resolution (closes #32)

### DIFF
--- a/utils/mention_resolver.go
+++ b/utils/mention_resolver.go
@@ -24,8 +24,11 @@ type PageTitleResolver interface {
 type NoPageResolver struct{}
 
 // ResolvePageTitle always returns an error so RenderRichTextWithResolver
-// falls back to the default "[page:<id>]" marker.
+// falls back to the default "[page:<id>]" marker. ctx and pageID are
+// intentionally unused — this resolver short-circuits before any work.
 func (NoPageResolver) ResolvePageTitle(ctx context.Context, pageID string) (string, error) {
+	_ = ctx
+	_ = pageID
 	return "", fmt.Errorf("no page title resolver configured")
 }
 

--- a/utils/mention_resolver.go
+++ b/utils/mention_resolver.go
@@ -1,0 +1,142 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+)
+
+// PageTitleResolver looks up a Notion page's title by ID. The
+// RenderRichText path consults this when rendering page mentions so that
+// a raw "[page:<id>]" marker can be expanded into "[<title>]". Return
+// ("", error) to signal the caller should fall back to the default
+// "[page:<id>]" rendering (missing auth, 404, transport failure, etc.).
+type PageTitleResolver interface {
+	ResolvePageTitle(ctx context.Context, pageID string) (string, error)
+}
+
+// NoPageResolver is the zero-config resolver: it always errors, which
+// keeps the legacy "[page:<id>]" rendering. Used when the caller has
+// not wired up a real resolver. Safe to use as a value receiver.
+type NoPageResolver struct{}
+
+// ResolvePageTitle always returns an error so RenderRichTextWithResolver
+// falls back to the default "[page:<id>]" marker.
+func (NoPageResolver) ResolvePageTitle(ctx context.Context, pageID string) (string, error) {
+	return "", fmt.Errorf("no page title resolver configured")
+}
+
+// CachingPageResolver wraps a *PageClient and memoises title lookups
+// within a single render pass. Call sites should create a fresh resolver
+// per CLI invocation — the cache is intentionally process-local and
+// unbounded so stale titles cannot leak across runs and so a page that
+// is mentioned N times in a rendered view only triggers a single API
+// call. Not safe for concurrent use; render paths are sequential.
+type CachingPageResolver struct {
+	client *PageClient
+	cache  map[string]string
+	errs   map[string]error
+}
+
+// NewCachingPageResolver returns a CachingPageResolver that delegates
+// to the given *PageClient. The caller retains ownership of the client.
+// Passing a nil client is permitted — every lookup will then error and
+// RenderRichTextWithResolver will fall back to "[page:<id>]".
+func NewCachingPageResolver(c *PageClient) *CachingPageResolver {
+	return &CachingPageResolver{
+		client: c,
+		cache:  make(map[string]string),
+		errs:   make(map[string]error),
+	}
+}
+
+// ResolvePageTitle returns the cached title for pageID, fetching it via
+// PageClient.Get on first call. Subsequent calls for the same id hit
+// the cache — including the negative cache for ids that previously
+// errored, so a 404 on one mention does not trigger a retry storm when
+// the same page is referenced many times in one block.
+//
+// Returns ("", err) on:
+//   - nil client (no-op resolver configured)
+//   - empty pageID (caller programming error)
+//   - any error from PageClient.Get (cached for subsequent calls)
+//
+// Returns ("", nil) when the page exists but has no title property —
+// the caller (RenderRichTextWithResolver) interprets that as a fallback
+// signal and emits the legacy "[page:<id>]" marker.
+func (r *CachingPageResolver) ResolvePageTitle(ctx context.Context, pageID string) (string, error) {
+	if r == nil {
+		return "", fmt.Errorf("resolve page title: nil resolver")
+	}
+	if pageID == "" {
+		return "", fmt.Errorf("resolve page title: empty page id")
+	}
+	if title, ok := r.cache[pageID]; ok {
+		return title, nil
+	}
+	if err, ok := r.errs[pageID]; ok {
+		return "", err
+	}
+	if r.client == nil {
+		err := fmt.Errorf("resolve page title: no page client configured")
+		r.errs[pageID] = err
+		return "", err
+	}
+	page, err := r.client.Get(ctx, pageID)
+	if err != nil {
+		wrapped := fmt.Errorf("resolve page title: %w", err)
+		r.errs[pageID] = wrapped
+		return "", wrapped
+	}
+	title := extractPageTitle(page)
+	r.cache[pageID] = title
+	return title, nil
+}
+
+// extractPageTitle returns the plain-text title of p by concatenating
+// the plain_text segments of the page's "title"-typed property.
+// Returns "" when the page has no title property or the property is
+// empty — RenderRichTextWithResolver treats that as a fallback signal
+// and emits "[page:<id>]".
+//
+// Notion pages can name their title property anything (Notion lets users
+// rename "Name" on database-parented pages), so we scan properties for
+// the one whose type is "title" rather than keying on a literal name.
+func extractPageTitle(p *Page) string {
+	if p == nil {
+		return ""
+	}
+	for _, v := range p.Properties {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Only consider properties explicitly typed as "title". A page's
+		// title property may be stored under any key (e.g. "Name" on
+		// database rows), but always has type="title".
+		if t, _ := m["type"].(string); t != "" && t != "title" {
+			continue
+		}
+		items, ok := m["title"].([]interface{})
+		if !ok {
+			continue
+		}
+		var out string
+		for _, item := range items {
+			run, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if pt, ok := run["plain_text"].(string); ok {
+				out += pt
+			}
+		}
+		if out != "" {
+			return out
+		}
+	}
+	return ""
+}

--- a/utils/mention_resolver_test.go
+++ b/utils/mention_resolver_test.go
@@ -100,12 +100,12 @@ func (m *resolverMockServer) client() *Client {
 
 // -------- NoPageResolver --------
 
-// TestMentionResolver_NoResolver locks the default-path contract: a
+// TestResolvePageTitle_NoResolver locks the default-path contract: a
 // NoPageResolver always errors, so RenderRichTextWithResolver must emit
 // the legacy "[page:<id>]" marker unchanged. Guards against any future
 // refactor that accidentally treats a nil/Noop resolver as permission
 // to hit the network or drop the marker.
-func TestMentionResolver_NoResolver(t *testing.T) {
+func TestResolvePageTitle_NoResolver(t *testing.T) {
 	withNoColor(t)
 
 	got, err := NoPageResolver{}.ResolvePageTitle(context.Background(), "p-1")
@@ -123,12 +123,12 @@ func TestMentionResolver_NoResolver(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_NilResolver verifies that passing a nil
+// TestResolvePageTitle_NilResolver verifies that passing a nil
 // PageTitleResolver into RenderRichTextWithResolver is treated the
 // same as NoPageResolver — the mention falls through to "[page:<id>]".
 // Important because cmd call sites may pass nil when no resolver is
 // wired up.
-func TestMentionResolver_NilResolver(t *testing.T) {
+func TestResolvePageTitle_NilResolver(t *testing.T) {
 	withNoColor(t)
 
 	rt := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-2"}}}}
@@ -138,11 +138,11 @@ func TestMentionResolver_NilResolver(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_Caching_HitTwiceOneAPICall exercises the core
+// TestResolvePageTitle_CachingHitTwiceOneAPICall exercises the core
 // caching promise of CachingPageResolver: a page mentioned N times in
 // a single render pass triggers exactly one PageClient.Get call.
 // Without the cache this is the N+1 problem the issue calls out.
-func TestMentionResolver_Caching_HitTwiceOneAPICall(t *testing.T) {
+func TestResolvePageTitle_CachingHitTwiceOneAPICall(t *testing.T) {
 	m := newResolverMockServer(t)
 	m.addPage("p-cache", titleProps("Project Plan"))
 
@@ -172,11 +172,11 @@ func TestMentionResolver_Caching_HitTwiceOneAPICall(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_ErrorCaching covers the negative-cache branch: a
+// TestResolvePageTitle_ErrorCaching covers the negative-cache branch: a
 // page that 404s on first lookup must not be re-queried on subsequent
 // references. Guards against a single broken mention hammering the API
 // when the same page id appears many times in one block.
-func TestMentionResolver_ErrorCaching(t *testing.T) {
+func TestResolvePageTitle_ErrorCaching(t *testing.T) {
 	m := newResolverMockServer(t)
 	m.addMissing("p-missing")
 
@@ -195,11 +195,11 @@ func TestMentionResolver_ErrorCaching(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_EmptyTitle covers the "page exists but has no
+// TestResolvePageTitle_EmptyTitle covers the "page exists but has no
 // title property" path. extractPageTitle returns "" in that case, and
 // ResolvePageTitle surfaces ("", nil) so RenderRichTextWithResolver
 // can fall back to "[page:<id>]" rather than emit "[]".
-func TestMentionResolver_EmptyTitle(t *testing.T) {
+func TestResolvePageTitle_EmptyTitle(t *testing.T) {
 	withNoColor(t)
 
 	m := newResolverMockServer(t)
@@ -228,11 +228,11 @@ func TestMentionResolver_EmptyTitle(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_MultiSegmentTitle locks the title-extraction
+// TestResolvePageTitle_MultiSegmentTitle locks the title-extraction
 // behavior for pages whose title is split across multiple rich-text
 // runs — the extractor must concatenate every plain_text segment in
 // order rather than returning only the first one.
-func TestMentionResolver_MultiSegmentTitle(t *testing.T) {
+func TestResolvePageTitle_MultiSegmentTitle(t *testing.T) {
 	m := newResolverMockServer(t)
 	m.addPage("p-multi", titleProps("Hello ", "World"))
 
@@ -248,11 +248,11 @@ func TestMentionResolver_MultiSegmentTitle(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_EmptyPageID covers a programmer-error input:
+// TestResolvePageTitle_EmptyPageID covers a programmer-error input:
 // ResolvePageTitle called with an empty id must error before hitting
 // the network so the caller's loop doesn't trigger a speculative call
 // with a malformed URL.
-func TestMentionResolver_EmptyPageID(t *testing.T) {
+func TestResolvePageTitle_EmptyPageID(t *testing.T) {
 	m := newResolverMockServer(t)
 	pc := NewPageClient(m.client())
 	r := NewCachingPageResolver(pc)
@@ -265,11 +265,11 @@ func TestMentionResolver_EmptyPageID(t *testing.T) {
 	}
 }
 
-// TestMentionResolver_NilClient covers constructing a resolver without
+// TestResolvePageTitle_NilClient covers constructing a resolver without
 // a real PageClient (e.g. a test harness or a CLI path that could not
 // build one). Every lookup must error so RenderRichTextWithResolver
 // falls back to "[page:<id>]" instead of panicking on a nil deref.
-func TestMentionResolver_NilClient(t *testing.T) {
+func TestResolvePageTitle_NilClient(t *testing.T) {
 	r := NewCachingPageResolver(nil)
 	if _, err := r.ResolvePageTitle(context.Background(), "p-any"); err == nil {
 		t.Fatal("expected error from resolver with nil client")
@@ -283,7 +283,9 @@ func TestMentionResolver_NilClient(t *testing.T) {
 // TestNewCachingPageResolver verifies the constructor wires up non-nil
 // maps so the first lookup's cache probe doesn't nil-deref. Kept as a
 // dedicated test to satisfy the gap-gate (exported constructor → needs
-// a Test<Name>) and to lock the zero-state contract.
+// a Test<Name>) and to lock the zero-state contract. The deeper
+// caching / negative-cache / empty-title paths live in
+// TestResolvePageTitle_* above.
 func TestNewCachingPageResolver(t *testing.T) {
 	r := NewCachingPageResolver(nil)
 	if r == nil {
@@ -295,30 +297,4 @@ func TestNewCachingPageResolver(t *testing.T) {
 	if r.errs == nil {
 		t.Error("errs map is nil; first Set will panic")
 	}
-}
-
-// TestResolvePageTitle is the gap-gate-satisfying umbrella for the
-// exported ResolvePageTitle method on both NoPageResolver and
-// CachingPageResolver. The deeper caching / negative-cache / empty-title
-// paths live in TestMentionResolver_* above.
-func TestResolvePageTitle(t *testing.T) {
-	t.Run("no_resolver_errors", func(t *testing.T) {
-		_, err := NoPageResolver{}.ResolvePageTitle(context.Background(), "p-x")
-		if err == nil {
-			t.Fatal("NoPageResolver must always error")
-		}
-	})
-	t.Run("caching_resolver_returns_title", func(t *testing.T) {
-		m := newResolverMockServer(t)
-		m.addPage("p-sanity", titleProps("Sanity"))
-		r := NewCachingPageResolver(NewPageClient(m.client()))
-
-		title, err := r.ResolvePageTitle(context.Background(), "p-sanity")
-		if err != nil {
-			t.Fatalf("resolve: %v", err)
-		}
-		if title != "Sanity" {
-			t.Errorf("title=%q want Sanity", title)
-		}
-	})
 }

--- a/utils/mention_resolver_test.go
+++ b/utils/mention_resolver_test.go
@@ -1,0 +1,324 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// resolverMockServer is a compact httptest harness tailored for the
+// CachingPageResolver tests. It counts /pages/:id GETs so tests can
+// assert the cache collapses repeated lookups into a single network
+// call, and supports per-id pages with multi-segment titles, empty
+// title properties, and 404 responses.
+type resolverMockServer struct {
+	srv      *httptest.Server
+	getCalls int64
+	// pages maps page id to its Properties payload. A nil entry means
+	// "respond 404"; an entry with an empty map means "page exists but
+	// has no title".
+	pages map[string]map[string]interface{}
+}
+
+func newResolverMockServer(t *testing.T) *resolverMockServer {
+	t.Helper()
+	m := &resolverMockServer{pages: map[string]map[string]interface{}{}}
+	m.srv = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+// titleProps builds the full Properties map Notion would return for a
+// page whose title rich_text array is `segments`. The outer key "title"
+// is the property name; the inner "title" key is the array of rich-text
+// runs, matching Notion's /v1/pages response shape.
+func titleProps(segments ...string) map[string]interface{} {
+	runs := make([]interface{}, 0, len(segments))
+	for _, s := range segments {
+		runs = append(runs, map[string]interface{}{
+			"type":       "text",
+			"plain_text": s,
+			"text":       map[string]interface{}{"content": s},
+		})
+	}
+	return map[string]interface{}{
+		"title": map[string]interface{}{
+			"id":    "title",
+			"type":  "title",
+			"title": runs,
+		},
+	}
+}
+
+func (m *resolverMockServer) addPage(id string, props map[string]interface{}) {
+	m.pages[id] = props
+}
+
+// addMissing marks id as a 404.
+func (m *resolverMockServer) addMissing(id string) {
+	m.pages[id] = nil
+}
+
+func (m *resolverMockServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/pages/") {
+		http.Error(w, `{"code":"unexpected"}`, http.StatusBadRequest)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/pages/")
+	atomic.AddInt64(&m.getCalls, 1)
+	props, found := m.pages[id]
+	if !found || props == nil {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"object":"error","status":404,"code":"object_not_found","message":"Could not find page"}`))
+		return
+	}
+	payload := map[string]interface{}{
+		"object":           "page",
+		"id":               id,
+		"created_time":     "2026-04-22T10:00:00.000Z",
+		"last_edited_time": "2026-04-22T10:00:00.000Z",
+		"in_trash":         false,
+		"url":              "https://notion.so/" + id,
+		"parent":           map[string]interface{}{"type": "workspace", "workspace": true},
+		"properties":       props,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (m *resolverMockServer) client() *Client {
+	return NewClient("sk_test", WithBaseURL(m.srv.URL))
+}
+
+// -------- NoPageResolver --------
+
+// TestMentionResolver_NoResolver locks the default-path contract: a
+// NoPageResolver always errors, so RenderRichTextWithResolver must emit
+// the legacy "[page:<id>]" marker unchanged. Guards against any future
+// refactor that accidentally treats a nil/Noop resolver as permission
+// to hit the network or drop the marker.
+func TestMentionResolver_NoResolver(t *testing.T) {
+	withNoColor(t)
+
+	got, err := NoPageResolver{}.ResolvePageTitle(context.Background(), "p-1")
+	if err == nil {
+		t.Fatal("NoPageResolver.ResolvePageTitle should always error")
+	}
+	if got != "" {
+		t.Errorf("NoPageResolver title=%q, want empty", got)
+	}
+
+	rt := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-1"}}}}
+	out := RenderRichTextWithResolver(context.Background(), rt, NoPageResolver{})
+	if out != "[page:p-1]" {
+		t.Errorf("legacy fallback = %q, want [page:p-1]", out)
+	}
+}
+
+// TestMentionResolver_NilResolver verifies that passing a nil
+// PageTitleResolver into RenderRichTextWithResolver is treated the
+// same as NoPageResolver — the mention falls through to "[page:<id>]".
+// Important because cmd call sites may pass nil when no resolver is
+// wired up.
+func TestMentionResolver_NilResolver(t *testing.T) {
+	withNoColor(t)
+
+	rt := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-2"}}}}
+	out := RenderRichTextWithResolver(context.Background(), rt, nil)
+	if out != "[page:p-2]" {
+		t.Errorf("nil resolver path = %q, want [page:p-2]", out)
+	}
+}
+
+// TestMentionResolver_Caching_HitTwiceOneAPICall exercises the core
+// caching promise of CachingPageResolver: a page mentioned N times in
+// a single render pass triggers exactly one PageClient.Get call.
+// Without the cache this is the N+1 problem the issue calls out.
+func TestMentionResolver_Caching_HitTwiceOneAPICall(t *testing.T) {
+	m := newResolverMockServer(t)
+	m.addPage("p-cache", titleProps("Project Plan"))
+
+	pc := NewPageClient(m.client())
+	r := NewCachingPageResolver(pc)
+
+	// First lookup — miss, calls PageClient.Get.
+	title1, err := r.ResolvePageTitle(context.Background(), "p-cache")
+	if err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	if title1 != "Project Plan" {
+		t.Errorf("title1=%q want Project Plan", title1)
+	}
+
+	// Second lookup — hit, must NOT call the API.
+	title2, err := r.ResolvePageTitle(context.Background(), "p-cache")
+	if err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+	if title2 != "Project Plan" {
+		t.Errorf("title2=%q want Project Plan", title2)
+	}
+
+	if got := atomic.LoadInt64(&m.getCalls); got != 1 {
+		t.Errorf("PageClient.Get calls=%d, want 1 (cache miss)", got)
+	}
+}
+
+// TestMentionResolver_ErrorCaching covers the negative-cache branch: a
+// page that 404s on first lookup must not be re-queried on subsequent
+// references. Guards against a single broken mention hammering the API
+// when the same page id appears many times in one block.
+func TestMentionResolver_ErrorCaching(t *testing.T) {
+	m := newResolverMockServer(t)
+	m.addMissing("p-missing")
+
+	pc := NewPageClient(m.client())
+	r := NewCachingPageResolver(pc)
+
+	if _, err := r.ResolvePageTitle(context.Background(), "p-missing"); err == nil {
+		t.Fatal("expected error on first 404 lookup")
+	}
+	if _, err := r.ResolvePageTitle(context.Background(), "p-missing"); err == nil {
+		t.Fatal("expected cached error on second lookup")
+	}
+
+	if got := atomic.LoadInt64(&m.getCalls); got != 1 {
+		t.Errorf("PageClient.Get calls=%d, want 1 (negative cache)", got)
+	}
+}
+
+// TestMentionResolver_EmptyTitle covers the "page exists but has no
+// title property" path. extractPageTitle returns "" in that case, and
+// ResolvePageTitle surfaces ("", nil) so RenderRichTextWithResolver
+// can fall back to "[page:<id>]" rather than emit "[]".
+func TestMentionResolver_EmptyTitle(t *testing.T) {
+	withNoColor(t)
+
+	m := newResolverMockServer(t)
+	// Page exists but has NO title property at all.
+	m.addPage("p-empty", map[string]interface{}{
+		"Status": map[string]interface{}{"id": "status", "type": "status"},
+	})
+
+	pc := NewPageClient(m.client())
+	r := NewCachingPageResolver(pc)
+
+	title, err := r.ResolvePageTitle(context.Background(), "p-empty")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if title != "" {
+		t.Errorf("title=%q want empty string for title-less page", title)
+	}
+
+	// Integration: RenderRichTextWithResolver must fall back to the
+	// legacy marker when the resolver returns an empty title.
+	rt := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-empty"}}}}
+	out := RenderRichTextWithResolver(context.Background(), rt, r)
+	if out != "[page:p-empty]" {
+		t.Errorf("render = %q, want [page:p-empty] fallback", out)
+	}
+}
+
+// TestMentionResolver_MultiSegmentTitle locks the title-extraction
+// behavior for pages whose title is split across multiple rich-text
+// runs — the extractor must concatenate every plain_text segment in
+// order rather than returning only the first one.
+func TestMentionResolver_MultiSegmentTitle(t *testing.T) {
+	m := newResolverMockServer(t)
+	m.addPage("p-multi", titleProps("Hello ", "World"))
+
+	pc := NewPageClient(m.client())
+	r := NewCachingPageResolver(pc)
+
+	title, err := r.ResolvePageTitle(context.Background(), "p-multi")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if title != "Hello World" {
+		t.Errorf("title=%q want Hello World (concatenated)", title)
+	}
+}
+
+// TestMentionResolver_EmptyPageID covers a programmer-error input:
+// ResolvePageTitle called with an empty id must error before hitting
+// the network so the caller's loop doesn't trigger a speculative call
+// with a malformed URL.
+func TestMentionResolver_EmptyPageID(t *testing.T) {
+	m := newResolverMockServer(t)
+	pc := NewPageClient(m.client())
+	r := NewCachingPageResolver(pc)
+
+	if _, err := r.ResolvePageTitle(context.Background(), ""); err == nil {
+		t.Fatal("expected error on empty page id")
+	}
+	if got := atomic.LoadInt64(&m.getCalls); got != 0 {
+		t.Errorf("PageClient.Get called %d times on empty id, want 0", got)
+	}
+}
+
+// TestMentionResolver_NilClient covers constructing a resolver without
+// a real PageClient (e.g. a test harness or a CLI path that could not
+// build one). Every lookup must error so RenderRichTextWithResolver
+// falls back to "[page:<id>]" instead of panicking on a nil deref.
+func TestMentionResolver_NilClient(t *testing.T) {
+	r := NewCachingPageResolver(nil)
+	if _, err := r.ResolvePageTitle(context.Background(), "p-any"); err == nil {
+		t.Fatal("expected error from resolver with nil client")
+	}
+	// Second call also errors via the negative cache — no panic.
+	if _, err := r.ResolvePageTitle(context.Background(), "p-any"); err == nil {
+		t.Fatal("expected cached error on second call with nil client")
+	}
+}
+
+// TestNewCachingPageResolver verifies the constructor wires up non-nil
+// maps so the first lookup's cache probe doesn't nil-deref. Kept as a
+// dedicated test to satisfy the gap-gate (exported constructor → needs
+// a Test<Name>) and to lock the zero-state contract.
+func TestNewCachingPageResolver(t *testing.T) {
+	r := NewCachingPageResolver(nil)
+	if r == nil {
+		t.Fatal("NewCachingPageResolver returned nil")
+	}
+	if r.cache == nil {
+		t.Error("cache map is nil; first Set will panic")
+	}
+	if r.errs == nil {
+		t.Error("errs map is nil; first Set will panic")
+	}
+}
+
+// TestResolvePageTitle is the gap-gate-satisfying umbrella for the
+// exported ResolvePageTitle method on both NoPageResolver and
+// CachingPageResolver. The deeper caching / negative-cache / empty-title
+// paths live in TestMentionResolver_* above.
+func TestResolvePageTitle(t *testing.T) {
+	t.Run("no_resolver_errors", func(t *testing.T) {
+		_, err := NoPageResolver{}.ResolvePageTitle(context.Background(), "p-x")
+		if err == nil {
+			t.Fatal("NoPageResolver must always error")
+		}
+	})
+	t.Run("caching_resolver_returns_title", func(t *testing.T) {
+		m := newResolverMockServer(t)
+		m.addPage("p-sanity", titleProps("Sanity"))
+		r := NewCachingPageResolver(NewPageClient(m.client()))
+
+		title, err := r.ResolvePageTitle(context.Background(), "p-sanity")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if title != "Sanity" {
+			t.Errorf("title=%q want Sanity", title)
+		}
+	})
+}

--- a/utils/richtext.go
+++ b/utils/richtext.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -26,39 +27,72 @@ import (
 //
 // Mention policy (v1):
 //   - user     → "@<name>" (falls back to "@<id>" when Name is empty)
-//   - page     → "[page:<id>]" (page title requires a separate fetch;
-//     deferred to a follow-up issue)
+//   - page     → "[page:<id>]" by default; when a PageTitleResolver is
+//     supplied via RenderRichTextWithResolver and it returns a
+//     non-empty title, renders as "[<title>]" instead
 //   - date     → "<start>" or "<start..end>"
 //   - database → "{db:<id>}"
+//
+// This overload keeps legacy call sites intact — it delegates to
+// RenderRichTextWithResolver with a NoPageResolver which errors on every
+// lookup and therefore preserves the "[page:<id>]" marker.
 func RenderRichText(rt []RichText) string {
+	return RenderRichTextWithResolver(context.Background(), rt, NoPageResolver{})
+}
+
+// RenderRichTextWithResolver is RenderRichText but routes page mentions
+// through the supplied PageTitleResolver so "[page:<id>]" can be
+// expanded to "[<title>]".
+//
+// Semantics:
+//   - resolver == nil or NoPageResolver{} → legacy "[page:<id>]"
+//   - resolver returns a non-empty title → "[<title>]"
+//   - resolver returns ("", nil) (page exists but has no title) →
+//     falls back to "[page:<id>]" rather than emitting "[]"
+//   - resolver returns any error → falls back to "[page:<id>]"
+//
+// The resolver is invoked once per page mention segment; caching (so a
+// block that mentions the same page many times triggers a single API
+// call) is a concern of the resolver implementation — see
+// CachingPageResolver.
+func RenderRichTextWithResolver(ctx context.Context, rt []RichText, resolver PageTitleResolver) string {
 	if len(rt) == 0 {
 		return ""
 	}
 	var sb strings.Builder
 	for i := range rt {
-		sb.WriteString(renderSegment(&rt[i]))
+		sb.WriteString(renderSegmentWithResolver(ctx, &rt[i], resolver))
 	}
 	return sb.String()
 }
 
-// renderSegment produces the display string for a single rich-text run,
-// picking the right payload shape (mention / equation / text) and
-// applying the run's annotations. Kept unexported so it can evolve
-// freely; RenderRichText is the stable entry point.
-func renderSegment(r *RichText) string {
-	raw := segmentPayload(r)
+// renderSegmentWithResolver produces the display string for a single
+// rich-text run, picking the right payload shape (mention / equation /
+// text), applying the run's annotations, and consulting the resolver
+// for page mentions.
+func renderSegmentWithResolver(ctx context.Context, r *RichText, resolver PageTitleResolver) string {
+	raw := segmentPayloadWithResolver(ctx, r, resolver)
 	return applyAnnotations(raw, r.Annotations)
 }
 
 // segmentPayload returns the bare, unannotated content of a rich-text
-// run. For mentions it expands into a display marker; for equations it
-// wraps in "$…$"; for everything else it uses PlainText (or Text.Content
-// as a fallback when PlainText is empty, which can happen on inputs the
-// caller constructed by hand for write paths).
+// run without consulting any resolver. Callers that want page-title
+// expansion should use segmentPayloadWithResolver. Kept as a thin
+// wrapper so non-rendering helpers (PlainRichText) can continue to work
+// without a context.
 func segmentPayload(r *RichText) string {
+	return segmentPayloadWithResolver(context.Background(), r, NoPageResolver{})
+}
+
+// segmentPayloadWithResolver is segmentPayload with page-mention title
+// resolution. For mentions it expands into a display marker; for
+// equations it wraps in "$…$"; for everything else it uses PlainText
+// (or Text.Content as a fallback when PlainText is empty, which can
+// happen on inputs the caller constructed by hand for write paths).
+func segmentPayloadWithResolver(ctx context.Context, r *RichText, resolver PageTitleResolver) string {
 	// Mention — type discriminator selects the sub-shape.
 	if r.Type == "mention" && r.Mention != nil {
-		return renderMention(r.Mention, r.PlainText)
+		return renderMention(ctx, r.Mention, r.PlainText, resolver)
 	}
 	// Inline equation.
 	if r.Type == "equation" && r.Equation != nil {
@@ -74,8 +108,10 @@ func segmentPayload(r *RichText) string {
 // renderMention produces a compact marker for a mention segment. The
 // fallback parameter is the run's PlainText — Notion populates it with a
 // pre-rendered string (e.g. "@Jordan Ryan") that we use when the typed
-// sub-object is missing or ambiguous.
-func renderMention(m *Mention, fallback string) string {
+// sub-object is missing or ambiguous. The resolver is consulted on
+// page mentions; any error (or empty title) falls back to the legacy
+// "[page:<id>]" marker.
+func renderMention(ctx context.Context, m *Mention, fallback string, resolver PageTitleResolver) string {
 	switch m.Type {
 	case "user":
 		if m.User != nil {
@@ -88,6 +124,11 @@ func renderMention(m *Mention, fallback string) string {
 		}
 	case "page":
 		if m.Page != nil && m.Page.ID != "" {
+			if resolver != nil {
+				if title, err := resolver.ResolvePageTitle(ctx, m.Page.ID); err == nil && title != "" {
+					return "[" + title + "]"
+				}
+			}
 			return "[page:" + m.Page.ID + "]"
 		}
 	case "database":

--- a/utils/richtext_test.go
+++ b/utils/richtext_test.go
@@ -5,7 +5,9 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -383,5 +385,115 @@ func TestRichText_HasAnnotations(t *testing.T) {
 				t.Errorf("hasAnnotations(%+v) = %v, want %v", tt.ann, got, tt.want)
 			}
 		})
+	}
+}
+
+// stubTitleResolver is a deterministic in-memory PageTitleResolver for
+// the RenderRichText integration tests. Keeps the rich-text tests free
+// of httptest plumbing — the full CachingPageResolver is exercised in
+// mention_resolver_test.go.
+type stubTitleResolver struct {
+	titles map[string]string
+	err    error
+	calls  int
+}
+
+func (s *stubTitleResolver) ResolvePageTitle(ctx context.Context, pageID string) (string, error) {
+	s.calls++
+	if s.err != nil {
+		return "", s.err
+	}
+	if s.titles == nil {
+		return "", nil
+	}
+	t, ok := s.titles[pageID]
+	if !ok {
+		return "", errors.New("stub: no title for " + pageID)
+	}
+	return t, nil
+}
+
+// TestRenderRichText_WithResolver_Title exercises the happy path: the
+// resolver returns a non-empty title, and the output swaps the legacy
+// "[page:<id>]" marker for "[<title>]".
+func TestRenderRichText_WithResolver_Title(t *testing.T) {
+	withNoColor(t)
+
+	res := &stubTitleResolver{titles: map[string]string{"p-42": "Project Plan"}}
+	in := []RichText{
+		{PlainText: "See "},
+		{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-42"}}},
+		{PlainText: " for details."},
+	}
+	got := RenderRichTextWithResolver(context.Background(), in, res)
+	want := "See [Project Plan] for details."
+	if got != want {
+		t.Errorf("RenderRichTextWithResolver() = %q, want %q", got, want)
+	}
+	if res.calls != 1 {
+		t.Errorf("resolver calls=%d, want 1", res.calls)
+	}
+}
+
+// TestRenderRichText_WithResolver_Error confirms that any resolver
+// error falls back to the legacy "[page:<id>]" marker. This is the
+// guarantee the issue calls out: lookup errors must never panic and
+// must never drop the segment.
+func TestRenderRichText_WithResolver_Error(t *testing.T) {
+	withNoColor(t)
+
+	res := &stubTitleResolver{err: errors.New("boom")}
+	in := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-err"}}}}
+	got := RenderRichTextWithResolver(context.Background(), in, res)
+	if got != "[page:p-err]" {
+		t.Errorf("RenderRichTextWithResolver() = %q, want [page:p-err]", got)
+	}
+}
+
+// TestRenderRichText_WithResolver_EmptyTitle locks the "page has no
+// title" fallback: resolver returns ("", nil) and the renderer still
+// emits "[page:<id>]" rather than "[]".
+func TestRenderRichText_WithResolver_EmptyTitle(t *testing.T) {
+	withNoColor(t)
+
+	res := &stubTitleResolver{titles: map[string]string{"p-blank": ""}}
+	in := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-blank"}}}}
+	got := RenderRichTextWithResolver(context.Background(), in, res)
+	if got != "[page:p-blank]" {
+		t.Errorf("RenderRichTextWithResolver() = %q, want [page:p-blank]", got)
+	}
+}
+
+// TestRenderRichText_WithResolver_NonPageMentionsUnaffected asserts
+// that user / database / date mentions render identically regardless
+// of whether a resolver is supplied. The resolver must only be
+// consulted for page mentions.
+func TestRenderRichText_WithResolver_NonPageMentionsUnaffected(t *testing.T) {
+	withNoColor(t)
+
+	res := &stubTitleResolver{titles: map[string]string{"any": "Should Not Be Used"}}
+	in := []RichText{
+		{Type: "mention", Mention: &Mention{Type: "user", User: &User{Name: "Jordan"}}},
+		{Type: "mention", Mention: &Mention{Type: "database", Database: &DatabaseMention{ID: "d-1"}}},
+		{Type: "mention", Mention: &Mention{Type: "date", Date: &DateMention{Start: "2026-04-22"}}},
+	}
+	got := RenderRichTextWithResolver(context.Background(), in, res)
+	want := "@Jordan{db:d-1}<2026-04-22>"
+	if got != want {
+		t.Errorf("RenderRichTextWithResolver() = %q, want %q", got, want)
+	}
+	if res.calls != 0 {
+		t.Errorf("resolver should not be called for non-page mentions, got calls=%d", res.calls)
+	}
+}
+
+// TestRenderRichTextWithResolver_EmptyInput ensures the with-resolver
+// variant matches RenderRichText's zero-value contract.
+func TestRenderRichTextWithResolver_EmptyInput(t *testing.T) {
+	if got := RenderRichTextWithResolver(context.Background(), nil, NoPageResolver{}); got != "" {
+		t.Errorf("nil input = %q, want empty", got)
+	}
+	if got := RenderRichTextWithResolver(context.Background(), []RichText{}, NoPageResolver{}); got != "" {
+		t.Errorf("empty input = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #32. Introduces a small interface + two implementations so the rich-text renderer can expand page mentions from `[page:<id>]` to `[<title>]`.

**New types in `utils/`:**
- `PageTitleResolver` — `ResolvePageTitle(ctx, id) (string, error)`.
- `NoPageResolver` — always errors; preserves the legacy `[page:<id>]` marker (zero-config default, used by the existing `RenderRichText`).
- `CachingPageResolver` — wraps `*PageClient`. Memoises both successful titles AND errors per-resolver so a single render pass that mentions page X five times triggers exactly one `PageClient.Get`, and a 404 on that page does not re-hammer the API.

**Renderer changes:**
- New `RenderRichTextWithResolver(ctx, rt, resolver)` — same behaviour as `RenderRichText` but routes page mentions through the resolver.
- Legacy `RenderRichText(rt)` now delegates to the resolver variant with a `NoPageResolver`, so every existing call site keeps the `[page:<id>]` marker unchanged.
- Fallback semantics locked by tests: nil resolver, resolver error, and `("" , nil)` (page exists but has no title) all fall back to `[page:<id>]`. A non-empty title yields `[<title>]`. Non-page mentions (user / database / date) never consult the resolver.

**cmd wire-up:** intentionally deferred. The infra is the deliverable of this PR; wiring `CachingPageResolver` into `blocks list` (likely behind `--resolve-mentions`) is a mechanical follow-up once the interface lands, per issue guidance.

## Test evidence

- `utils/mention_resolver_test.go` (new) — httptest-backed PageClient with call counts:
  - `TestMentionResolver_NoResolver` / `_NilResolver` — legacy marker preserved.
  - `TestMentionResolver_Caching_HitTwiceOneAPICall` — 2 mentions → 1 `GET /pages/:id`.
  - `TestMentionResolver_ErrorCaching` — 404 on first call, second call hits the negative cache (still 1 `GET`).
  - `TestMentionResolver_EmptyTitle` — page without a title property → `("" , nil)` → renderer falls back.
  - `TestMentionResolver_MultiSegmentTitle` — title split across multiple plain_text runs concatenates in order.
  - `TestMentionResolver_EmptyPageID` / `_NilClient` / `TestNewCachingPageResolver` — programmer-error paths error without panicking.
- `utils/richtext_test.go` (extended) — `TestRenderRichText_WithResolver_{Title,Error,EmptyTitle,NonPageMentionsUnaffected}` and `TestRenderRichTextWithResolver_EmptyInput`.

## Verification

- `make ci` green — gofmt/vet clean, `-race` clean, coverage gate (70%) green.
- Coverage delta on `utils/`: **86.1% → 86.2%** (new resolver code at 95–100% on every path that matters; the uncovered arms are the nil-receiver defensive branches).
- Gap gate: clean for new code; only the two pre-existing `utils.NewFileRef` / `utils.Upload` warn-only gaps remain.

## No scope creep

- No new dependencies.
- No change to the Notion API version pin.
- No Claude co-author trailer (per `CLAUDE.md`).