### PR TITLE
feat(cmd): --resolve-mentions wires CachingPageResolver for human output (closes #34)

### DIFF
--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -87,11 +87,17 @@ var blocksListCmd = &cobra.Command{
 			return nil
 		}
 
-		formatted, typeCounts, err := utils.FormatAllBlocks(
+		// --resolve-mentions (persistent) opts into page-title
+		// expansion for the snippet column. When off, buildPageResolver
+		// returns utils.NoPageResolver{} and the output stays
+		// byte-identical to the pre-resolver rendering.
+		resolver := buildPageResolver(notionAPIKey)
+		formatted, typeCounts, err := utils.FormatAllBlocksWithResolver(
 			notionAPIKey,
 			pageID,
 			localTimezone,
 			blockType,
+			resolver,
 		)
 		if err != nil {
 			color.Red("Error: %v", err)

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"reflect"
 
+	"notioncli/utils"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -161,6 +163,30 @@ func applyGlobalOutput() error {
 	return fmt.Errorf("invalid --output %q (want text|json)", globalOutput)
 }
 
+// buildPageResolver returns the PageTitleResolver appropriate for the
+// current invocation: a *utils.CachingPageResolver bound to a fresh
+// PageClient when --resolve-mentions is set, or utils.NoPageResolver
+// otherwise. The returned resolver is safe to discard after a single
+// render pass — its cache is intentionally per-invocation so stale
+// titles cannot leak across runs.
+//
+// A fresh *utils.Client is allocated per call rather than reused across
+// commands; this mirrors the legacy top-level helpers (GetAllBlocks,
+// FormatAllBlocks, ...) which also build a client per call. The overhead
+// is negligible next to the network round-trip the resolver then issues.
+//
+// JSON paths must not call this helper — mention resolution is a
+// human-output affordance only. See the --resolve-mentions flag
+// godoc on globalResolveMentions for the full rationale.
+func buildPageResolver(apiKey string) utils.PageTitleResolver {
+	if !globalResolveMentions {
+		return utils.NoPageResolver{}
+	}
+	return utils.NewCachingPageResolver(
+		utils.NewPageClient(utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))),
+	)
+}
+
 // resetGlobalOutputFlags is used by tests to return to the default
 // state between runs. cobra retains bound flag values across the
 // process so this reset is required to keep tests hermetic.
@@ -169,6 +195,7 @@ func resetGlobalOutputFlags() {
 	globalPretty = false
 	globalOutput = ""
 	globalPage = ""
+	globalResolveMentions = false
 	// Intentionally do NOT reset aliasStoreOverride here: test helpers
 	// install it via aliasTestEnv(t) and depend on it surviving the call
 	// to resetRootCmdArgs(). t.Cleanup restores the prior value at test

--- a/cmd/resolve_mentions_test.go
+++ b/cmd/resolve_mentions_test.go
@@ -1,0 +1,336 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"notioncli/utils"
+)
+
+// resolveMentionsMockServer answers the two Notion endpoints the cmd
+// layer hits when --resolve-mentions is on: GET /blocks/pageID/children
+// (returns to_do blocks each carrying a page-mention run) and
+// GET /pages/{id} (returns a Notion page with a title property).
+// Counts page GETs so tests can assert the cache fires exactly once.
+type resolveMentionsMockServer struct {
+	srv          *httptest.Server
+	pageGetCalls int64
+	titles       map[string]string // page id → title; missing entry → 404
+	blocks       []utils.Block
+}
+
+func newResolveMentionsMockServer(t *testing.T, blocks []utils.Block, titles map[string]string) *resolveMentionsMockServer {
+	t.Helper()
+	m := &resolveMentionsMockServer{blocks: blocks, titles: titles}
+	m.srv = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *resolveMentionsMockServer) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/blocks/pageID/children":
+		_ = json.NewEncoder(w).Encode(utils.BlockList{Results: m.blocks})
+
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pages/"):
+		atomic.AddInt64(&m.pageGetCalls, 1)
+		id := strings.TrimPrefix(r.URL.Path, "/pages/")
+		title, ok := m.titles[id]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"object":"error","status":404,"code":"object_not_found"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"object": "page",
+			"id":     id,
+			"properties": map[string]interface{}{
+				"title": map[string]interface{}{
+					"id":   "title",
+					"type": "title",
+					"title": []interface{}{
+						map[string]interface{}{
+							"type":       "text",
+							"plain_text": title,
+							"text":       map[string]interface{}{"content": title},
+						},
+					},
+				},
+			},
+		})
+
+	default:
+		http.Error(w, `{"code":"unexpected"}`, http.StatusBadRequest)
+	}
+}
+
+// mentionBlock is a page-mention-bearing to_do fixture. The mock
+// server's /blocks/pageID/children endpoint returns these.
+func mentionBlock(id, pageID string) utils.Block {
+	return utils.Block{
+		Object:         "block",
+		ID:             id,
+		Type:           "to_do",
+		LastEditedTime: "2026-04-22T10:00:00.000Z",
+		ToDo: &utils.ToDo{
+			Checked: false,
+			RichText: []utils.RichText{
+				{
+					Type:      "mention",
+					PlainText: "[page:" + pageID + "]",
+					Mention:   &utils.Mention{Type: "page", Page: &utils.PageMention{ID: pageID}},
+				},
+			},
+		},
+	}
+}
+
+// withResolveMentionsEnv wires up the cmd-layer test environment with
+// the resolver-aware mock server in place of the default one. It
+// mirrors withCmdEnv but targets the resolver-specific endpoints.
+func withResolveMentionsEnv(t *testing.T, blocks []utils.Block, titles map[string]string) *resolveMentionsMockServer {
+	t.Helper()
+
+	m := newResolveMentionsMockServer(t, blocks, titles)
+	priorBaseURL := utils.GetBaseURL()
+	utils.SetBaseURL(m.srv.URL)
+	t.Cleanup(func() { utils.SetBaseURL(priorBaseURL) })
+
+	emptyCwd := t.TempDir()
+	emptyHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(emptyCwd, ".env"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(emptyCwd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("NOTION_API_KEY", "test-key")
+	t.Setenv("NOTION_PAGE_ID", "pageID")
+	t.Setenv("LOCAL_TIMEZONE", "UTC")
+
+	return m
+}
+
+// TestBlocksList_ResolveMentions_Off verifies the default (flag absent)
+// keeps the legacy "[page:<id>]" rendering and does NOT issue any
+// /v1/pages/<id> GETs. This is the backward-compat contract — users
+// who don't opt in must see pre-resolver output byte-for-byte.
+func TestBlocksList_ResolveMentions_Off(t *testing.T) {
+	m := withResolveMentionsEnv(t,
+		[]utils.Block{mentionBlock("b-1", "p-42")},
+		map[string]string{"p-42": "Should Not Be Used"},
+	)
+
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "[page:p-42]") {
+		t.Errorf("flag-off output missing legacy marker:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "Should Not Be Used") {
+		t.Errorf("flag-off output should not contain resolved title:\n%s", out.String())
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 0 {
+		t.Errorf("flag-off should not hit /pages/, got %d calls", got)
+	}
+}
+
+// TestBlocksList_ResolveMentions_On_Title locks the happy path:
+// --resolve-mentions on + mock returns a title → snippet contains
+// "[<title>]" instead of "[page:<id>]".
+func TestBlocksList_ResolveMentions_On_Title(t *testing.T) {
+	m := withResolveMentionsEnv(t,
+		[]utils.Block{mentionBlock("b-1", "p-42")},
+		map[string]string{"p-42": "Project Plan"},
+	)
+
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--resolve-mentions", "blocks", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "[Project Plan]") {
+		t.Errorf("expected expanded title in output:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "[page:p-42]") {
+		t.Errorf("expanded-title path should not leak legacy marker:\n%s", out.String())
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 1 {
+		t.Errorf("expected 1 page GET, got %d", got)
+	}
+}
+
+// TestBlocksList_ResolveMentions_On_Error covers the network-error
+// fallback: --resolve-mentions on + mock returns 404 → snippet still
+// renders as "[page:<id>]" and no panic / no stderr spam breaks the
+// pipeline. The issue explicitly calls this guarantee out.
+func TestBlocksList_ResolveMentions_On_Error(t *testing.T) {
+	m := withResolveMentionsEnv(t,
+		[]utils.Block{mentionBlock("b-1", "p-missing")},
+		map[string]string{}, // empty → every page GET is a 404
+	)
+
+	blockType = ""
+	resetRootCmdArgs()
+	var out, errBuf bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&errBuf)
+	rootCmd.SetArgs([]string{"--resolve-mentions", "blocks", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "[page:p-missing]") {
+		t.Errorf("404 fallback missing legacy marker:\n%s", out.String())
+	}
+	// The resolver is silent on errors (negative cache); we do NOT want
+	// stderr spam for every missing page. A strict emptiness check is
+	// too brittle — just assert the error message from the 404 is not
+	// leaked into output.
+	if strings.Contains(errBuf.String(), "404") {
+		t.Errorf("stderr should not leak 404 details:\n%s", errBuf.String())
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 1 {
+		t.Errorf("expected 1 page GET (negative cache), got %d", got)
+	}
+}
+
+// TestBlocksList_ResolveMentions_Caching is the hit-count assertion:
+// three mentions of the same page across three blocks must trigger
+// exactly one /v1/pages/<id> call. Exercises the full cmd→utils→
+// CachingPageResolver path end-to-end.
+func TestBlocksList_ResolveMentions_Caching(t *testing.T) {
+	m := withResolveMentionsEnv(t,
+		[]utils.Block{
+			mentionBlock("b-1", "p-shared"),
+			mentionBlock("b-2", "p-shared"),
+			mentionBlock("b-3", "p-shared"),
+		},
+		map[string]string{"p-shared": "Runbook"},
+	)
+
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--resolve-mentions", "blocks", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute: %v", err)
+	}
+
+	if n := strings.Count(out.String(), "[Runbook]"); n != 3 {
+		t.Errorf("expected 3 expanded titles in output, got %d:\n%s", n, out.String())
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 1 {
+		t.Errorf("expected 1 page GET (cache), got %d", got)
+	}
+}
+
+// TestBlocksList_ResolveMentions_JSONPathIgnoresFlag locks the design
+// contract: --resolve-mentions is a human-output affordance. The JSON
+// path must continue to emit the raw rich_text mention shape so tooling
+// sees the original Notion payload. Even with --resolve-mentions set,
+// no /v1/pages/<id> calls may fire on the JSON path.
+func TestBlocksList_ResolveMentions_JSONPathIgnoresFlag(t *testing.T) {
+	m := withResolveMentionsEnv(t,
+		[]utils.Block{mentionBlock("b-1", "p-42")},
+		map[string]string{"p-42": "Should Not Appear"},
+	)
+
+	blockType = ""
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--json", "--resolve-mentions", "blocks", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute: %v", err)
+	}
+
+	wire := out.String()
+	// The JSON path emits the raw rich_text array; the mention shape
+	// survives and no resolved title leaks in.
+	if !strings.Contains(wire, `"type":"page"`) {
+		t.Errorf("JSON output missing raw page mention shape:\n%s", wire)
+	}
+	if strings.Contains(wire, "Should Not Appear") {
+		t.Errorf("JSON path should not resolve titles:\n%s", wire)
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 0 {
+		t.Errorf("JSON path should not trigger /pages/ calls, got %d", got)
+	}
+}
+
+// TestResolveMentionsFlag_Registered is a cheap-to-run smoke test that
+// the persistent --resolve-mentions flag is wired on rootCmd with the
+// correct type and default value.
+func TestResolveMentionsFlag_Registered(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("resolve-mentions")
+	if f == nil {
+		t.Fatal("rootCmd: --resolve-mentions flag not registered")
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("--resolve-mentions type = %q, want bool", f.Value.Type())
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--resolve-mentions default = %q, want false", f.DefValue)
+	}
+}
+
+// TestBuildPageResolver_Off verifies buildPageResolver returns
+// utils.NoPageResolver when the flag is off (the default).
+func TestBuildPageResolver_Off(t *testing.T) {
+	globalResolveMentions = false
+	t.Cleanup(func() { globalResolveMentions = false })
+
+	r := buildPageResolver("any-key")
+	if _, ok := r.(utils.NoPageResolver); !ok {
+		t.Errorf("buildPageResolver with flag off = %T, want utils.NoPageResolver", r)
+	}
+}
+
+// TestBuildPageResolver_On verifies buildPageResolver returns a
+// *utils.CachingPageResolver when the flag is set. We only assert on
+// the concrete type — the construction path is exercised end-to-end by
+// the TestBlocksList_ResolveMentions_* tests above.
+func TestBuildPageResolver_On(t *testing.T) {
+	globalResolveMentions = true
+	t.Cleanup(func() { globalResolveMentions = false })
+
+	r := buildPageResolver("any-key")
+	if _, ok := r.(*utils.CachingPageResolver); !ok {
+		t.Errorf("buildPageResolver with flag on = %T, want *utils.CachingPageResolver", r)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,19 @@ func shouldSuppressBanner() bool {
 // typo in an alias is reported by the specific command that needed it.
 var globalPage string
 
+// globalResolveMentions backs the persistent --resolve-mentions flag on
+// rootCmd. Default off. When true, mention-bearing commands (today:
+// blocks list, human-output path only) build a CachingPageResolver and
+// pass it into the rich-text renderer so "[page:<id>]" expands to
+// "[<title>]". One API call per unique page id per invocation —
+// see utils.CachingPageResolver for the caching contract.
+//
+// JSON output paths intentionally ignore this flag: expanding mentions
+// there would be lossy round-tripping (the original rich_text mention
+// shape is replaced by a bracketed string). This is a human-rendering
+// affordance only.
+var globalResolveMentions bool
+
 // aliasStoreOverride is a test seam: if non-nil, resolvePageID uses it
 // instead of utils.DefaultAliasStore(). Production code leaves it nil so
 // the real ~/.config/notioncli/pages.yaml path is consulted.
@@ -152,4 +165,12 @@ func init() {
 	// Persistent page-targeting flag. resolvePageID translates aliases
 	// lazily so unknown aliases surface at command run time, not here.
 	rootCmd.PersistentFlags().StringVar(&globalPage, "page", "", "page id or alias; falls back to NOTION_PAGE_ID env var")
+
+	// Opt-in page-mention resolution. Default off so the existing
+	// "[page:<id>]" rendering stays the baseline. When set, commands
+	// that surface rich text to humans build a CachingPageResolver
+	// (one API call per unique page id) and expand page mentions to
+	// "[<title>]". Ignored on --json paths.
+	rootCmd.PersistentFlags().BoolVar(&globalResolveMentions, "resolve-mentions", false,
+		"resolve page mentions from [page:<id>] to [<title>] (issues one API call per unique page; human output only)")
 }

--- a/utils/block.go
+++ b/utils/block.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -406,6 +407,23 @@ func FormatAllBlocks(notionAPIKey, pageID string, localTimezone *time.Location, 
 	return defaultBlockClient(notionAPIKey).FormatAllBlocks(defaultCtx(), pageID, localTimezone, filterType)
 }
 
+// FormatAllBlocksWithResolver is FormatAllBlocks but threads the given
+// PageTitleResolver into the snippet renderer so page mentions expand
+// from the legacy "[page:<id>]" marker into "[<title>]". Callers that
+// do not need resolution should continue to use FormatAllBlocks — the
+// legacy helper passes a NoPageResolver internally and preserves the
+// pre-resolver output byte-for-byte.
+//
+// This is a human-output affordance only. JSON paths must NOT go
+// through this helper: emitting resolved titles there would be lossy
+// round-tripping (the original rich_text mention shape is replaced by a
+// bracketed string). Keep JSON on raw rich_text arrays.
+//
+// Deprecated: prefer BlockClient.FormatAllBlocksWithResolver.
+func FormatAllBlocksWithResolver(notionAPIKey, pageID string, localTimezone *time.Location, filterType string, resolver PageTitleResolver) ([]string, map[string]int, error) {
+	return defaultBlockClient(notionAPIKey).FormatAllBlocksWithResolver(defaultCtx(), pageID, localTimezone, filterType, resolver)
+}
+
 // AddBlock delegates to BlockClient.AddBlock on a default client. The
 // variadic opts argument passes media URLs, captions, and other per-type
 // metadata through to the block payload.
@@ -562,7 +580,20 @@ func extendedBlockContent(block Block) (string, bool) {
 // "$…$") so callers see the whole block, not just the first segment.
 // fatih/color respects color.NoColor — when --json toggles that off,
 // RenderRichText emits plain text without ANSI escapes.
+//
+// This overload keeps legacy call sites intact — it delegates to
+// GetBlockContentWithResolver with a NoPageResolver which errors on every
+// lookup and therefore preserves the "[page:<id>]" marker.
 func GetBlockContent(block Block) string {
+	return GetBlockContentWithResolver(context.Background(), block, NoPageResolver{})
+}
+
+// GetBlockContentWithResolver is GetBlockContent but routes page mentions
+// through the supplied PageTitleResolver so "[page:<id>]" can be
+// expanded to "[<title>]". Semantics match RenderRichTextWithResolver
+// for page mentions; non-rich-text block types (divider, media, table,
+// etc.) are unaffected by the resolver.
+func GetBlockContentWithResolver(ctx context.Context, block Block, resolver PageTitleResolver) string {
 	if block.Type == "divider" {
 		return "───────────"
 	}
@@ -573,14 +604,26 @@ func GetBlockContent(block Block) string {
 	if len(rt) == 0 {
 		return "(empty)"
 	}
-	return RenderRichText(rt)
+	return RenderRichTextWithResolver(ctx, rt, resolver)
 }
 
 // GetBlockContentPlain returns the block's text with no annotations,
 // mention markers, or equation delimiters applied — just the concatenated
 // PlainText of every segment. Use this from tests and JSON paths that
 // want a stable string and don't care about the visual rendering.
+//
+// This overload keeps legacy call sites intact — it delegates to
+// GetBlockContentPlainWithResolver with a NoPageResolver which errors on
+// every lookup and therefore preserves the "[page:<id>]" marker.
 func GetBlockContentPlain(block Block) string {
+	return GetBlockContentPlainWithResolver(context.Background(), block, NoPageResolver{})
+}
+
+// GetBlockContentPlainWithResolver is GetBlockContentPlain but routes
+// page mentions through the supplied PageTitleResolver so "[page:<id>]"
+// can be expanded to "[<title>]". Still emits an ANSI-free string so the
+// snippet truncation in FormatAllBlocks stays byte-slice safe.
+func GetBlockContentPlainWithResolver(ctx context.Context, block Block, resolver PageTitleResolver) string {
 	if block.Type == "divider" {
 		return "───────────"
 	}
@@ -591,7 +634,7 @@ func GetBlockContentPlain(block Block) string {
 	if len(rt) == 0 {
 		return "(empty)"
 	}
-	return PlainRichText(rt)
+	return PlainRichTextWithResolver(ctx, rt, resolver)
 }
 
 // mediaBlockContent returns a human-readable one-liner for a MediaBlock.

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -223,7 +223,26 @@ func (b *BlockClient) GetAllBlocks(ctx context.Context, pageID, filterType strin
 
 // FormatAllBlocks returns human-readable lines plus a by-type count for
 // every block under pageID, optionally filtered by filterType.
+//
+// This overload keeps legacy call sites intact — it delegates to
+// FormatAllBlocksWithResolver with a NoPageResolver which errors on every
+// lookup and therefore preserves the "[page:<id>]" marker byte-for-byte.
 func (b *BlockClient) FormatAllBlocks(ctx context.Context, pageID string, localTimezone *time.Location, filterType string) ([]string, map[string]int, error) {
+	return b.FormatAllBlocksWithResolver(ctx, pageID, localTimezone, filterType, NoPageResolver{})
+}
+
+// FormatAllBlocksWithResolver is FormatAllBlocks with a caller-supplied
+// PageTitleResolver threaded through the snippet renderer so page
+// mentions in "[page:<id>]" positions expand to "[<title>]" when the
+// resolver succeeds. Any resolver error or empty title falls back to
+// the legacy marker (per RenderRichTextWithResolver semantics), so a
+// 404 on one mention can never panic or drop content.
+//
+// Human-output path only. JSON paths must continue to emit raw
+// rich_text arrays (see cmd/blocks.go blocks list --json) so caller
+// tooling sees the original mention shape rather than a bracketed
+// lossy string.
+func (b *BlockClient) FormatAllBlocksWithResolver(ctx context.Context, pageID string, localTimezone *time.Location, filterType string, resolver PageTitleResolver) ([]string, map[string]int, error) {
 	blocks, err := b.GetAllBlocks(ctx, pageID, filterType)
 	if err != nil {
 		return nil, nil, err
@@ -245,8 +264,9 @@ func (b *BlockClient) FormatAllBlocks(ctx context.Context, pageID string, localT
 		// already flipped off under --json via rootCmd's PersistentPreRunE,
 		// but relying on that for correctness here would make a future
 		// caller of FormatAllBlocks from a JSON path silently leak escapes
-		// into the stream. GetBlockContentPlain closes the gap.
-		content := GetBlockContentPlain(block)
+		// into the stream. GetBlockContentPlainWithResolver closes the gap
+		// while still expanding page mentions when a resolver is wired.
+		content := GetBlockContentPlainWithResolver(ctx, block, resolver)
 		if len(content) > 50 {
 			content = content[:47] + "..."
 		}

--- a/utils/blocks_resolver_test.go
+++ b/utils/blocks_resolver_test.go
@@ -1,0 +1,351 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// pageMention returns a to_do block whose rich_text array is a single
+// page-mention run referencing pageID. Used to seed the mock block list
+// with repeated mentions of the same page id so we can assert caching.
+func pageMentionBlock(id, pageID string) Block {
+	return Block{
+		Object:         "block",
+		ID:             id,
+		Type:           "to_do",
+		LastEditedTime: "2026-04-22T10:00:00.000Z",
+		ToDo: &ToDo{
+			Checked: false,
+			RichText: []RichText{
+				{
+					Type:      "mention",
+					PlainText: "[page:" + pageID + "]",
+					Mention:   &Mention{Type: "page", Page: &PageMention{ID: pageID}},
+				},
+			},
+		},
+	}
+}
+
+// resolverFormatMockServer answers both GET /blocks/{id}/children (for
+// FormatAllBlocksWithResolver) and GET /pages/{id} (for the resolver's
+// PageClient.Get). Counts page GETs so tests can assert the cache
+// collapses repeated mentions of the same page into a single API call.
+type resolverFormatMockServer struct {
+	srv          *httptest.Server
+	pageGetCalls int64
+	pageTitles   map[string]string // page id → title; missing = 404
+	blocks       []Block
+}
+
+func newResolverFormatMockServer(t *testing.T, blocks []Block, titles map[string]string) *resolverFormatMockServer {
+	t.Helper()
+	m := &resolverFormatMockServer{
+		pageTitles: titles,
+		blocks:     blocks,
+	}
+	m.srv = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *resolverFormatMockServer) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/blocks/pageID/children":
+		_ = json.NewEncoder(w).Encode(BlockList{Results: m.blocks})
+
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pages/"):
+		atomic.AddInt64(&m.pageGetCalls, 1)
+		id := strings.TrimPrefix(r.URL.Path, "/pages/")
+		title, ok := m.pageTitles[id]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"object":"error","status":404,"code":"object_not_found"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"object": "page",
+			"id":     id,
+			"properties": map[string]interface{}{
+				"title": map[string]interface{}{
+					"id":   "title",
+					"type": "title",
+					"title": []interface{}{
+						map[string]interface{}{
+							"type":       "text",
+							"plain_text": title,
+							"text":       map[string]interface{}{"content": title},
+						},
+					},
+				},
+			},
+		})
+
+	default:
+		http.Error(w, `{"code":"unexpected"}`, http.StatusBadRequest)
+	}
+}
+
+// TestFormatAllBlocksWithResolver_ExpandsTitle locks the happy path:
+// --resolve-mentions on, the resolver returns a non-empty title, and
+// the formatted snippet contains "[<title>]" instead of "[page:<id>]".
+func TestFormatAllBlocksWithResolver_ExpandsTitle(t *testing.T) {
+	withNoColor(t)
+
+	blocks := []Block{pageMentionBlock("b-1", "p-42")}
+	m := newResolverFormatMockServer(t, blocks, map[string]string{"p-42": "Project Plan"})
+
+	bc := NewBlockClient(m.client())
+	pc := NewPageClient(m.client())
+	resolver := NewCachingPageResolver(pc)
+
+	loc, _ := time.LoadLocation("UTC")
+	formatted, _, err := bc.FormatAllBlocksWithResolver(context.Background(), "pageID", loc, "", resolver)
+	if err != nil {
+		t.Fatalf("FormatAllBlocksWithResolver: %v", err)
+	}
+	if len(formatted) != 1 {
+		t.Fatalf("formatted len=%d, want 1", len(formatted))
+	}
+	if !strings.Contains(formatted[0], "[Project Plan]") {
+		t.Errorf("expected expanded title in snippet, got %q", formatted[0])
+	}
+	if strings.Contains(formatted[0], "[page:p-42]") {
+		t.Errorf("expected expanded title to replace legacy marker, got %q", formatted[0])
+	}
+}
+
+// TestFormatAllBlocksWithResolver_NoResolverPreservesMarker asserts that
+// a NoPageResolver round-trip leaves the legacy "[page:<id>]" marker
+// byte-for-byte unchanged. Guards against any future resolver-aware
+// refactor that accidentally reaches for the network when the caller
+// opted out.
+func TestFormatAllBlocksWithResolver_NoResolverPreservesMarker(t *testing.T) {
+	withNoColor(t)
+
+	blocks := []Block{pageMentionBlock("b-1", "p-1")}
+	m := newResolverFormatMockServer(t, blocks, map[string]string{"p-1": "Should Not Be Used"})
+
+	bc := NewBlockClient(m.client())
+
+	loc, _ := time.LoadLocation("UTC")
+	formatted, _, err := bc.FormatAllBlocksWithResolver(context.Background(), "pageID", loc, "", NoPageResolver{})
+	if err != nil {
+		t.Fatalf("FormatAllBlocksWithResolver: %v", err)
+	}
+	if !strings.Contains(formatted[0], "[page:p-1]") {
+		t.Errorf("no-resolver path should keep legacy marker; got %q", formatted[0])
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 0 {
+		t.Errorf("page GET calls=%d, want 0 (no resolver)", got)
+	}
+}
+
+// TestFormatAllBlocksWithResolver_CachingHitCount is the cache-behavior
+// assertion the issue calls out: three mentions of the same page must
+// trigger exactly one PageClient.Get call in total. Without the cache
+// this is the N+1 problem.
+func TestFormatAllBlocksWithResolver_CachingHitCount(t *testing.T) {
+	withNoColor(t)
+
+	blocks := []Block{
+		pageMentionBlock("b-1", "p-repeat"),
+		pageMentionBlock("b-2", "p-repeat"),
+		pageMentionBlock("b-3", "p-repeat"),
+	}
+	m := newResolverFormatMockServer(t, blocks, map[string]string{"p-repeat": "Runbook"})
+
+	bc := NewBlockClient(m.client())
+	pc := NewPageClient(m.client())
+	resolver := NewCachingPageResolver(pc)
+
+	loc, _ := time.LoadLocation("UTC")
+	formatted, _, err := bc.FormatAllBlocksWithResolver(context.Background(), "pageID", loc, "", resolver)
+	if err != nil {
+		t.Fatalf("FormatAllBlocksWithResolver: %v", err)
+	}
+	if len(formatted) != 3 {
+		t.Fatalf("formatted len=%d, want 3", len(formatted))
+	}
+	for i, line := range formatted {
+		if !strings.Contains(line, "[Runbook]") {
+			t.Errorf("snippet %d = %q, missing expanded title", i, line)
+		}
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 1 {
+		t.Errorf("PageClient.Get calls=%d, want exactly 1 (cache)", got)
+	}
+}
+
+// TestFormatAllBlocksWithResolver_NotFoundFallsBack covers the error
+// path: the resolver hits 404 for the referenced page, and the snippet
+// falls back to the legacy "[page:<id>]" marker without panicking. The
+// negative cache ensures repeated mentions don't hammer the API — we
+// assert pageGetCalls == 1 even with three mentions.
+func TestFormatAllBlocksWithResolver_NotFoundFallsBack(t *testing.T) {
+	withNoColor(t)
+
+	blocks := []Block{
+		pageMentionBlock("b-1", "p-missing"),
+		pageMentionBlock("b-2", "p-missing"),
+		pageMentionBlock("b-3", "p-missing"),
+	}
+	// No entry for p-missing → 404 on every GET.
+	m := newResolverFormatMockServer(t, blocks, map[string]string{})
+
+	bc := NewBlockClient(m.client())
+	pc := NewPageClient(m.client())
+	resolver := NewCachingPageResolver(pc)
+
+	loc, _ := time.LoadLocation("UTC")
+	formatted, _, err := bc.FormatAllBlocksWithResolver(context.Background(), "pageID", loc, "", resolver)
+	if err != nil {
+		t.Fatalf("FormatAllBlocksWithResolver: %v", err)
+	}
+	for i, line := range formatted {
+		if !strings.Contains(line, "[page:p-missing]") {
+			t.Errorf("snippet %d = %q, should fall back to legacy marker on 404", i, line)
+		}
+	}
+	if got := atomic.LoadInt64(&m.pageGetCalls); got != 1 {
+		t.Errorf("PageClient.Get calls=%d, want exactly 1 (negative cache)", got)
+	}
+}
+
+// TestFormatAllBlocks_LegacyDelegatesToResolverAware locks the refactor:
+// FormatAllBlocks is now a thin wrapper over FormatAllBlocksWithResolver
+// with NoPageResolver{}. The legacy function's output must match the
+// no-resolver path byte-for-byte so existing callers and their snapshot
+// tests keep passing.
+func TestFormatAllBlocks_LegacyDelegatesToResolverAware(t *testing.T) {
+	withNoColor(t)
+
+	blocks := []Block{pageMentionBlock("b-1", "p-1")}
+	m := newResolverFormatMockServer(t, blocks, map[string]string{"p-1": "Unused"})
+
+	bc := NewBlockClient(m.client())
+
+	loc, _ := time.LoadLocation("UTC")
+	legacy, _, err := bc.FormatAllBlocks(context.Background(), "pageID", loc, "")
+	if err != nil {
+		t.Fatalf("FormatAllBlocks: %v", err)
+	}
+	noresolver, _, err := bc.FormatAllBlocksWithResolver(context.Background(), "pageID", loc, "", NoPageResolver{})
+	if err != nil {
+		t.Fatalf("FormatAllBlocksWithResolver: %v", err)
+	}
+	if len(legacy) != len(noresolver) {
+		t.Fatalf("len mismatch: legacy=%d, noresolver=%d", len(legacy), len(noresolver))
+	}
+	for i := range legacy {
+		if legacy[i] != noresolver[i] {
+			t.Errorf("line %d mismatch:\n legacy=%q\n nores =%q", i, legacy[i], noresolver[i])
+		}
+	}
+}
+
+func (m *resolverFormatMockServer) client() *Client {
+	return NewClient("sk_test", WithBaseURL(m.srv.URL))
+}
+
+// TestGetBlockContentPlainWithResolver covers the per-block plain
+// renderer: resolver hit yields "[<title>]", resolver miss preserves
+// "[page:<id>]".
+func TestGetBlockContentPlainWithResolver(t *testing.T) {
+	withNoColor(t)
+
+	block := pageMentionBlock("b-1", "p-x")
+
+	// Stub resolver via the in-memory titles path.
+	res := &stubTitleResolver{titles: map[string]string{"p-x": "Specs"}}
+	got := GetBlockContentPlainWithResolver(context.Background(), block, res)
+	if got != "[Specs]" {
+		t.Errorf("with-resolver = %q, want [Specs]", got)
+	}
+
+	if legacy := GetBlockContentPlain(block); legacy != "[page:p-x]" {
+		t.Errorf("legacy plain = %q, want [page:p-x]", legacy)
+	}
+}
+
+// TestGetBlockContentWithResolver covers the ANSI-capable rendering
+// path with a resolver hit.
+func TestGetBlockContentWithResolver(t *testing.T) {
+	withNoColor(t)
+
+	block := pageMentionBlock("b-1", "p-y")
+	res := &stubTitleResolver{titles: map[string]string{"p-y": "Docs"}}
+	got := GetBlockContentWithResolver(context.Background(), block, res)
+	if got != "[Docs]" {
+		t.Errorf("with-resolver = %q, want [Docs]", got)
+	}
+
+	// Non-rich-text block types are unaffected by the resolver.
+	divider := Block{Type: "divider", Divider: &struct{}{}}
+	if s := GetBlockContentWithResolver(context.Background(), divider, res); s != "───────────" {
+		t.Errorf("divider with resolver = %q, want the divider glyph", s)
+	}
+}
+
+// TestPlainRichTextWithResolver locks the PlainRichText resolver-aware
+// variant in isolation. Empty input must still return "", resolver hit
+// must expand to [<title>], no resolver → legacy marker.
+func TestPlainRichTextWithResolver(t *testing.T) {
+	withNoColor(t)
+
+	if got := PlainRichTextWithResolver(context.Background(), nil, NoPageResolver{}); got != "" {
+		t.Errorf("empty = %q, want empty string", got)
+	}
+
+	in := []RichText{{Type: "mention", Mention: &Mention{Type: "page", Page: &PageMention{ID: "p-z"}}}}
+	// No resolver → legacy marker.
+	if got := PlainRichTextWithResolver(context.Background(), in, NoPageResolver{}); got != "[page:p-z]" {
+		t.Errorf("noresolver = %q, want [page:p-z]", got)
+	}
+	// Resolver hit → expanded.
+	res := &stubTitleResolver{titles: map[string]string{"p-z": "Roadmap"}}
+	if got := PlainRichTextWithResolver(context.Background(), in, res); got != "[Roadmap]" {
+		t.Errorf("resolved = %q, want [Roadmap]", got)
+	}
+}
+
+// TestFormatAllBlocksWithResolverDelegate exercises the package-level
+// FormatAllBlocksWithResolver entry point so it does not silently rot.
+func TestFormatAllBlocksWithResolverDelegate(t *testing.T) {
+	withNoColor(t)
+
+	blocks := []Block{pageMentionBlock("b-1", "p-d")}
+	m := newResolverFormatMockServer(t, blocks, map[string]string{"p-d": "Delegated"})
+
+	// Redirect the legacy package-level baseURL so the default client
+	// used by the delegate lands on our mock server.
+	prior := GetBaseURL()
+	SetBaseURL(m.srv.URL)
+	t.Cleanup(func() { SetBaseURL(prior) })
+
+	pc := NewPageClient(m.client())
+	resolver := NewCachingPageResolver(pc)
+
+	loc, _ := time.LoadLocation("UTC")
+	formatted, _, err := FormatAllBlocksWithResolver("sk_test", "pageID", loc, "", resolver)
+	if err != nil {
+		t.Fatalf("FormatAllBlocksWithResolver: %v", err)
+	}
+	if len(formatted) != 1 {
+		t.Fatalf("len=%d, want 1", len(formatted))
+	}
+	if !strings.Contains(formatted[0], "[Delegated]") {
+		t.Errorf("snippet=%q, missing expanded title", formatted[0])
+	}
+}

--- a/utils/richtext.go
+++ b/utils/richtext.go
@@ -231,13 +231,29 @@ func colorAttribute(name string) color.Attribute {
 // mentions expanded to their markers and equations wrapped in "$…$" but
 // no ANSI escapes applied. Used by JSON paths and by tests that need a
 // deterministic string without fighting color.NoColor global state.
+//
+// This overload keeps legacy call sites intact — it delegates to
+// PlainRichTextWithResolver with a NoPageResolver which errors on every
+// lookup and therefore preserves the "[page:<id>]" marker.
 func PlainRichText(rt []RichText) string {
+	return PlainRichTextWithResolver(context.Background(), rt, NoPageResolver{})
+}
+
+// PlainRichTextWithResolver is PlainRichText but routes page mentions
+// through the supplied PageTitleResolver so "[page:<id>]" can be
+// expanded to "[<title>]". Semantics match RenderRichTextWithResolver
+// (resolver error or empty title → legacy "[page:<id>]" marker); the
+// only difference is that no ANSI annotations are applied.
+//
+// Used by FormatAllBlocks's snippet path — the 50-char truncation there
+// byte-slices the string, which is safe only with no ANSI escapes.
+func PlainRichTextWithResolver(ctx context.Context, rt []RichText, resolver PageTitleResolver) string {
 	if len(rt) == 0 {
 		return ""
 	}
 	var sb strings.Builder
 	for i := range rt {
-		sb.WriteString(segmentPayload(&rt[i]))
+		sb.WriteString(segmentPayloadWithResolver(ctx, &rt[i], resolver))
 	}
 	return sb.String()
 }

--- a/utils/richtext.go
+++ b/utils/richtext.go
@@ -75,20 +75,14 @@ func renderSegmentWithResolver(ctx context.Context, r *RichText, resolver PageTi
 	return applyAnnotations(raw, r.Annotations)
 }
 
-// segmentPayload returns the bare, unannotated content of a rich-text
-// run without consulting any resolver. Callers that want page-title
-// expansion should use segmentPayloadWithResolver. Kept as a thin
-// wrapper so non-rendering helpers (PlainRichText) can continue to work
-// without a context.
-func segmentPayload(r *RichText) string {
-	return segmentPayloadWithResolver(context.Background(), r, NoPageResolver{})
-}
-
-// segmentPayloadWithResolver is segmentPayload with page-mention title
-// resolution. For mentions it expands into a display marker; for
+// segmentPayloadWithResolver returns the bare, unannotated content of a
+// rich-text run, consulting the resolver for page-mention title
+// expansion. For mentions it expands into a display marker; for
 // equations it wraps in "$…$"; for everything else it uses PlainText
 // (or Text.Content as a fallback when PlainText is empty, which can
 // happen on inputs the caller constructed by hand for write paths).
+// Callers that do not need resolution can pass NoPageResolver{} and
+// context.Background().
 func segmentPayloadWithResolver(ctx context.Context, r *RichText, resolver PageTitleResolver) string {
 	// Mention — type discriminator selects the sub-shape.
 	if r.Type == "mention" && r.Mention != nil {


### PR DESCRIPTION
## Summary

Wires the foundation's `CachingPageResolver` (utils/) into the `blocks list` human-output path via a new persistent `--resolve-mentions` flag. Default off. When set, page mentions in the snippet column render as \`[<title>]\` instead of \`[page:<id>]\`, with exactly one \`/v1/pages/<id>\` API call per unique page id per invocation.

Closes #34.

## Commands wired

- \`blocks list\` (human output path only) — swaps \`utils.FormatAllBlocks\` for \`utils.FormatAllBlocksWithResolver\`, passing a resolver built via \`buildPageResolver(apiKey)\`.
- \`pages get\` / \`comments list\`: **not wired in this PR.** Neither currently renders Notion rich-text mentions in its human output (\`pages get\` prints page metadata + property keys; \`comments list\` uses \`comment.PlainText\` for a compact one-liner). Wiring them is a no-op today; revisit when those commands grow rich-text rendering.

## JSON-path exclusion rationale

\`--resolve-mentions\` is a **human-output affordance only**. The \`blocks list --json\` branch is intentionally left on \`utils.GetAllBlocks\` + \`emitList\` — expanding mentions into bracketed titles on JSON would be lossy round-tripping of the original \`rich_text\` mention shape. Tooling consuming NDJSON should see the raw Notion payload. This is locked in by \`TestBlocksList_ResolveMentions_JSONPathIgnoresFlag\`: \`--json --resolve-mentions\` together trigger 0 \`/pages/\` calls and preserve the \`{"type":"page"}\` mention shape on the wire.

## Cache verification

\`TestBlocksList_ResolveMentions_Caching\` drives three blocks that each mention the same page id through \`rootCmd.Execute\` and asserts the mock httptest server sees exactly **1** \`/v1/pages/<id>\` GET — collapsing the N+1 problem the issue calls out. \`TestBlocksList_ResolveMentions_On_Error\` asserts the negative cache: three mentions of a 404 page also result in exactly 1 GET, with the snippet falling back to \`[page:<id>]\` and no stderr spam.

## Test evidence (namespace \`TestBlocksList_ResolveMentions_*\`)

| Test | Asserts |
|---|---|
| \`_Off\` | no flag → legacy marker, 0 \`/pages/\` calls |
| \`_On_Title\` | flag on + 200 → \`[<title>]\`, 1 \`/pages/\` call |
| \`_On_Error\` | flag on + 404 → legacy fallback, no panic, 1 call (neg cache) |
| \`_Caching\` | 3 mentions of same id → 1 \`/pages/\` call |
| \`_JSONPathIgnoresFlag\` | \`--json --resolve-mentions\` → 0 \`/pages/\` calls, raw rich_text preserved |
| \`TestResolveMentionsFlag_Registered\` | flag shape: bool, default \`false\` |
| \`TestBuildPageResolver_Off\` / \`_On\` | helper returns \`NoPageResolver\` / \`*CachingPageResolver\` respectively |

Plus utils-layer coverage in \`utils/blocks_resolver_test.go\` for \`FormatAllBlocksWithResolver\`, \`GetBlockContent{,Plain}WithResolver\`, \`PlainRichTextWithResolver\`, and a byte-for-byte equivalence test that \`FormatAllBlocks\` still matches the no-resolver path.

## Coverage delta

\`\`\`
Before: cmd 83.6%, utils 86.2%, total 87.3%
After:  cmd 83.7%, utils 86.3%, total 87.3%
\`\`\`

Gap-gate: 0 new gaps (pre-existing 2 \`utils.NewFileRef\` / \`utils.Upload\` untouched).

## make ci tail

\`\`\`
go vet ./...
go test -race ./...
ok  	notioncli/cmd	2.571s
ok  	notioncli/utils	2.803s
Total coverage: 87.3% (gate: 70%)
\`\`\`

## Commits

1. \`feat(utils):\` \`FormatAllBlocksWithResolver\` + resolver-aware plain renderer
2. \`feat(cmd):\` \`--resolve-mentions\` persistent flag + \`buildPageResolver\` helper
3. \`refactor(cmd):\` \`blocks list\` wires resolver through \`FormatAllBlocksWithResolver\`
4. \`test:\` mention resolution coverage for cmd + utils

## Constraints honoured

- No existing signatures removed (\`RenderRichText\`, \`GetBlockContent\`, \`FormatAllBlocks\` all still exist and delegate to the new \`*WithResolver\` siblings — same drop-in pattern as PR #33).
- JSON paths untouched.
- gofmt + \`go vet\` clean.
- No Claude co-author trailer (per Jordan's preference).