### PR TITLE
feat: fetch URL/id dispatcher + version subcommand + release plumbing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,187 @@
+name: Release
+
+# Hand-rolled cross-platform release pipeline. Triggers on any annotated
+# semver tag (v*.*.*) and produces:
+#
+#   - a GitHub Release with darwin amd64+arm64 and linux amd64+arm64
+#     archives, each containing a notioncli binary linked with
+#     -X main.version=<tag>;
+#   - per-archive sha256 checksums (.sha256 sidecars) so downstream
+#     consumers can verify downloads;
+#   - the source-tarball sha256 in the release body so the
+#     homebrew-notioncli tap formula can copy it verbatim.
+#
+# GoReleaser is the eventual swap — see issue #36. This workflow is the
+# minimum viable cut so we can ship v0.1.0 without taking on the
+# GoReleaser config surface area today.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.0). Required for manual dispatch."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+          cache: true
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+          VERSION: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          archive="notioncli_${VERSION}_${GOOS}_${GOARCH}"
+          mkdir -p "dist/${archive}"
+          go build -trimpath \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o "dist/${archive}/notioncli" .
+          cp LICENSE "dist/${archive}/LICENSE"
+          cp README.md "dist/${archive}/README.md"
+          tar -C dist -czf "dist/${archive}.tar.gz" "${archive}"
+          ( cd dist && sha256sum "${archive}.tar.gz" > "${archive}.tar.gz.sha256" )
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: notioncli-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/notioncli_*.tar.gz
+            dist/notioncli_*.tar.gz.sha256
+          retention-days: 7
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: notioncli-*
+          merge-multiple: true
+
+      - name: Compute source tarball sha256
+        id: src_sha
+        env:
+          VERSION: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # The source archive GitHub auto-publishes for every tag is the
+          # same artifact homebrew downloads. Pull it down, hash it, and
+          # surface the digest both as a step output and in the release
+          # body so the tap formula's `sha256` line is a copy-paste away.
+          url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${VERSION}.tar.gz"
+          curl -fsSL -o source.tar.gz "$url"
+          sha=$(sha256sum source.tar.gz | awk '{print $1}')
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "Source tarball sha256: ${sha}"
+
+      - name: Write release notes
+        id: notes
+        env:
+          VERSION: ${{ steps.tag.outputs.tag }}
+          SRC_SHA: ${{ steps.src_sha.outputs.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## notioncli ${VERSION}"
+            echo
+            echo "### Install"
+            echo
+            echo '```'
+            echo "brew install jordan8037310/notioncli/notioncli"
+            echo '```'
+            echo
+            echo "Or grab a binary archive from the assets below and put"
+            echo "\`notioncli\` somewhere on your \$PATH."
+            echo
+            echo "### Homebrew formula values"
+            echo
+            echo "Source tarball:"
+            echo
+            echo '```'
+            echo "url    https://github.com/${REPO}/archive/refs/tags/${VERSION}.tar.gz"
+            echo "sha256 ${SRC_SHA}"
+            echo '```'
+            echo
+            echo "Per-asset sha256 sidecars are published alongside each archive."
+          } > release-notes.md
+          echo "path=release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Idempotency: if the release already exists (re-run after a
+          # transient failure), upload assets onto the existing one
+          # instead of erroring out.
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists; uploading assets."
+            gh release upload "$VERSION" dist/notioncli_*.tar.gz dist/notioncli_*.tar.gz.sha256 \
+              --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "notioncli $VERSION" \
+              --notes-file release-notes.md \
+              dist/notioncli_*.tar.gz dist/notioncli_*.tar.gz.sha256
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,23 @@ jobs:
           pattern: notioncli-*
           merge-multiple: true
 
+      - name: Verify tag exists on origin
+        env:
+          VERSION: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # workflow_dispatch lets a maintainer re-run the release for a
+          # given tag, but the source-tarball curl below depends on the
+          # tag actually being published on origin so GitHub serves the
+          # auto-generated archive. Fail fast with a clear instruction
+          # instead of the opaque "curl 404" the next step would emit
+          # otherwise (PR #50 second-pass review).
+          git fetch origin "refs/tags/${VERSION}:refs/tags/${VERSION}" 2>/dev/null || true
+          if ! git rev-parse --verify "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} not found on origin. Push the tag first (\`git tag -a ${VERSION} -m ${VERSION} && git push origin ${VERSION}\`) before re-running this workflow."
+            exit 1
+          fi
+
       - name: Compute source tarball sha256
         id: src_sha
         env:
@@ -126,8 +143,20 @@ jobs:
           # same artifact homebrew downloads. Pull it down, hash it, and
           # surface the digest both as a step output and in the release
           # body so the tap formula's `sha256` line is a copy-paste away.
+          # Brief retry — GitHub takes a few seconds to publish the
+          # auto-tarball after a fresh tag push.
           url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${VERSION}.tar.gz"
-          curl -fsSL -o source.tar.gz "$url"
+          for i in 1 2 3 4 5; do
+            if curl -fsSL -o source.tar.gz "$url"; then
+              break
+            fi
+            echo "Source tarball not yet published (attempt $i); retrying in 5s..."
+            sleep 5
+          done
+          if [ ! -s source.tar.gz ]; then
+            echo "::error::Source tarball at ${url} did not become available after 25s."
+            exit 1
+          fi
           sha=$(sha256sum source.tar.gz | awk '{print $1}')
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
           echo "Source tarball sha256: ${sha}"

--- a/README.md
+++ b/README.md
@@ -6,16 +6,38 @@
 
 Notion CLI Go is a command-line interface tool written in Go to manage tasks in Notion.so. This tool is a new iteration based on the original [Python project](https://github.com/kris-hansen/notion-cli), now built in Go for improved performance and portability. This project is a work in progress, some of the features mentioned below are aspirational and not yet implemented.
 
-## Installation
+## Install
 
-To install the project, you'll need to clone the repository and build the Go application. Here are the basic instructions:
+The fastest path is the homebrew tap (macOS + linuxbrew):
 
 ```bash
-git clone https://github.com/kris-hansen/notion-cli-go
-cd notion-cli-go
-go build
-go install .
+brew install jordan8037310/notioncli/notioncli
 ```
+
+> The tap repo (`jordan8037310/homebrew-notioncli`) is published separately. If `brew tap` reports the tap is missing, fall back to one of the manual options below until the tap is live.
+
+**Manual via `go install`** (any platform with Go 1.21+):
+
+```bash
+go install github.com/jordan8037310/notion-cli-go@latest
+# binary lands in $(go env GOPATH)/bin as `notion-cli-go`; rename or symlink to `notioncli` if you like
+```
+
+**From source** (clone + build):
+
+```bash
+git clone https://github.com/jordan8037310/notion-cli-go
+cd notion-cli-go
+go build -o notioncli .
+```
+
+Confirm the install with:
+
+```bash
+notioncli version
+```
+
+Tagged releases are published at <https://github.com/jordan8037310/notion-cli-go/releases> with prebuilt darwin/linux binaries (amd64 + arm64) and per-asset sha256 sidecars.
 
 ## Configuration
 

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -178,6 +178,14 @@ Examples:
 		return cobra.MinimumNArgs(1)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Suppress cobra's default "Error: ..." + usage block on non-nil
+		// return so the colored color.Red lines below are the only error
+		// the user sees. Without this, cobra would double-print every
+		// error (once via color.Red, once via cobra's own handler) and
+		// dump the help block under each failure.
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+
 		// Validate block type
 		if blockType == "" {
 			blockType = "paragraph"
@@ -190,7 +198,7 @@ Examples:
 				return jsonErrorOr(cmd, err)
 			}
 			color.Red("Error: %v", err)
-			return nil
+			return err
 		}
 
 		if !utils.IsAddableBlockType(blockType) {
@@ -199,7 +207,7 @@ Examples:
 				return jsonErrorOr(cmd, err)
 			}
 			color.Red("Error: %v", err)
-			return nil
+			return err
 		}
 
 		notionAPIKey, _ := utils.SetAPIConfig()
@@ -219,7 +227,7 @@ Examples:
 					return jsonErrorOr(cmd, wrapped)
 				}
 				color.Red("Error: %v", wrapped)
-				return nil
+				return wrapped
 			}
 			rt, err := utils.ParseRichTextJSON(raw)
 			if err != nil {
@@ -228,7 +236,7 @@ Examples:
 					return jsonErrorOr(cmd, wrapped)
 				}
 				color.Red("Error: %v", wrapped)
-				return nil
+				return wrapped
 			}
 			if err := utils.AddRichTextBlock(notionAPIKey, pageID, blockType, rt); err != nil {
 				wrapped := fmt.Errorf("blocks add: %w", err)
@@ -236,7 +244,7 @@ Examples:
 					return jsonErrorOr(cmd, wrapped)
 				}
 				color.Red("Error adding block: %v", err)
-				return nil
+				return wrapped
 			}
 			if globalJSON {
 				return emitOK(cmd.OutOrStdout(), map[string]interface{}{
@@ -254,11 +262,12 @@ Examples:
 		opts := blocksAddOptions()
 
 		if err := utils.AddBlock(notionAPIKey, pageID, blockType, text, opts...); err != nil {
+			wrapped := fmt.Errorf("blocks add: %w", err)
 			if globalJSON {
-				return jsonErrorOr(cmd, fmt.Errorf("blocks add: %w", err))
+				return jsonErrorOr(cmd, wrapped)
 			}
 			color.Red("Error adding block: %v", err)
-			return nil
+			return wrapped
 		}
 
 		if globalJSON {

--- a/cmd/blocks_test.go
+++ b/cmd/blocks_test.go
@@ -371,7 +371,9 @@ func TestBlocksAddDispatch_BookmarkWithURLFlag(t *testing.T) {
 }
 
 // TestBlocksAdd_RejectsNonAddable asserts that `blocks add … -t table`
-// surfaces a human-readable error and does NOT issue a PATCH.
+// surfaces a human-readable error, propagates it to cobra so the process
+// exits non-zero, and does NOT issue a PATCH. Regression guard for
+// PR #50 second-pass review [P1] — text-mode failures used to return nil.
 func TestBlocksAdd_RejectsNonAddable(t *testing.T) {
 	srv := withCmdEnv(t)
 
@@ -390,11 +392,71 @@ func TestBlocksAdd_RejectsNonAddable(t *testing.T) {
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"blocks", "add", "ignored", "-t", "table"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("rootCmd.Execute returned err: %v (expected swallowed)", err)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("rootCmd.Execute returned nil; expected non-nil so the process exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "cannot be created via") {
+		t.Errorf("err = %v; want substring 'cannot be created via'", err)
 	}
 	if atomic.LoadInt64(&patched) != 0 {
 		t.Error("blocks add -t table should not PATCH the API")
+	}
+}
+
+// TestBlocksAdd_RejectsUnsupportedType asserts an unknown block type
+// errors out before any HTTP traffic and the error is propagated to
+// cobra (non-nil RunE return).
+func TestBlocksAdd_RejectsUnsupportedType(t *testing.T) {
+	srv := withCmdEnv(t)
+	var patched int64
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			atomic.AddInt64(&patched, 1)
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetBlocksAddFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "ignored", "-t", "not-a-real-type"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on unsupported block type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported block type") {
+		t.Errorf("err = %v; want substring 'unsupported block type'", err)
+	}
+	if atomic.LoadInt64(&patched) != 0 {
+		t.Error("blocks add with unsupported type should not PATCH the API")
+	}
+}
+
+// TestBlocksAdd_RichTextJSONUnreadableFile confirms a missing
+// --rich-text-json file produces a non-nil error from cobra so callers
+// don't silently treat the failure as success.
+func TestBlocksAdd_RichTextJSONUnreadableFile(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetBlocksAddFlags()
+	resetRootCmdArgs()
+
+	missing := "/nonexistent/path/should-not-exist.json"
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "add", "--rich-text-json", missing, "-t", "paragraph"})
+	t.Cleanup(func() { blocksAddRichTextJSON = "" })
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on unreadable --rich-text-json file, got nil")
+	}
+	if !strings.Contains(err.Error(), "read --rich-text-json") {
+		t.Errorf("err = %v; want substring 'read --rich-text-json'", err)
 	}
 }
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,202 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"notioncli/utils"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// fetchCmd is the unified URL/id dispatcher. It mirrors the Notion MCP
+// server's notion-fetch tool: hand it any Notion URL or id and it figures
+// out whether the resource is a page or a database, then prints the object
+// (or its JSON form when --json is set) along with a follow-up hint.
+//
+// Probe order is page → database. Block-level fallback is intentionally
+// out of scope per issue #38: block ids returned from `blocks list` are
+// already addressable via that command, and probing /v1/blocks here would
+// double the round-trip cost on every cold cache miss.
+//
+// --resolve-mentions is honoured by being accepted on the command line
+// (the persistent flag wires it for free); it is mostly a no-op because
+// fetch returns raw API objects rather than rendered rich text. Callers
+// who want mention resolution should use `blocks list --resolve-mentions`.
+var fetchCmd = &cobra.Command{
+	Use:   "fetch <url-or-id>",
+	Short: "Fetch a Notion page or database by URL or id, auto-detecting type",
+	Long: `Fetch any Notion resource by URL or bare id without having to know
+its type up front.
+
+Accepted inputs:
+  https://www.notion.so/Workspace/Page-Title-<id>
+  https://notion.so/<id>
+  notion.so/<id>
+  <32-hex bare id>
+  <dashed uuid>
+
+The command probes /v1/pages first; on 404 it falls back to /v1/databases.
+When neither hits, it returns a clear "no resource found" error.
+
+Examples:
+  notioncli fetch https://www.notion.so/Workspace/Project-abc123def456...
+  notioncli fetch abc123def4567890abc123def4567890
+  notioncli fetch <id> --json | jq .`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := utils.ParseNotionID(args[0])
+		if err != nil {
+			return jsonErrorOr(cmd, fmt.Errorf("fetch: %w", err))
+		}
+
+		apiKey, _ := utils.SetAPIConfig()
+		if apiKey == "" {
+			return jsonErrorOr(cmd, fmt.Errorf("fetch: %w", utils.ErrMissingAPIKey))
+		}
+		client := utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))
+
+		ctx := context.Background()
+
+		// Probe pages first. Notion does not expose a way to know the
+		// resource type from the id alone, so we GET /pages/{id} and on
+		// 404 fall through to /databases/{id}. Other errors (auth,
+		// transport) bubble up immediately because there is no point
+		// double-probing them.
+		page, pageErr := utils.NewPageClient(client).Get(ctx, id)
+		if pageErr == nil {
+			return emitPage(cmd, page)
+		}
+		if !isNotFound(pageErr) {
+			return jsonErrorOr(cmd, fmt.Errorf("fetch: probe page: %w", pageErr))
+		}
+
+		db, dbErr := utils.NewDatabaseClient(client).Get(ctx, id)
+		if dbErr == nil {
+			return emitDatabase(cmd, db)
+		}
+		if !isNotFound(dbErr) {
+			return jsonErrorOr(cmd, fmt.Errorf("fetch: probe database: %w", dbErr))
+		}
+
+		return jsonErrorOr(cmd, fmt.Errorf("fetch: no page or database found at id %s", id))
+	},
+}
+
+// emitPage formats a page result for the current output mode. JSON paths
+// emit the raw object so the round-trip is loss-free; human paths print a
+// minimal type/id/title summary plus a follow-up command hint.
+func emitPage(cmd *cobra.Command, page *utils.Page) error {
+	if globalJSON {
+		return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), page))
+	}
+	w := cmd.OutOrStdout()
+	title := pagePlainTitle(page)
+	if title == "" {
+		title = "(untitled)"
+	}
+	fmt.Fprintf(w, "%s %s\n", color.GreenString("page"), page.ID)
+	fmt.Fprintf(w, "  title: %s\n", title)
+	if page.URL != "" {
+		fmt.Fprintf(w, "  url:   %s\n", page.URL)
+	}
+	fmt.Fprintf(w, "  hint:  notioncli blocks list --page %s\n", page.ID)
+	return nil
+}
+
+// emitDatabase formats a database result for the current output mode.
+func emitDatabase(cmd *cobra.Command, db *utils.Database) error {
+	if globalJSON {
+		return jsonErrorOr(cmd, emitJSON(cmd.OutOrStdout(), db))
+	}
+	w := cmd.OutOrStdout()
+	title := databasePlainTitle(db)
+	if title == "" {
+		title = "(untitled)"
+	}
+	fmt.Fprintf(w, "%s %s\n", color.GreenString("database"), db.ID)
+	fmt.Fprintf(w, "  title: %s\n", title)
+	if db.URL != "" {
+		fmt.Fprintf(w, "  url:   %s\n", db.URL)
+	}
+	fmt.Fprintf(w, "  hint:  notioncli databases query %s\n", db.ID)
+	return nil
+}
+
+// pagePlainTitle digs the plain-text title out of a page's loose Properties
+// map. Returns "" when no title property is found so callers can fall back
+// to a placeholder. Mirrors utils.extractTitle but lives in cmd to keep
+// the utils package free of presentation-layer helpers.
+func pagePlainTitle(page *utils.Page) string {
+	if page == nil {
+		return ""
+	}
+	for _, v := range page.Properties {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		items, ok := m["title"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range items {
+			run, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if pt, ok := run["plain_text"].(string); ok && pt != "" {
+				return pt
+			}
+		}
+	}
+	return ""
+}
+
+// databasePlainTitle returns the concatenated plain-text title of a
+// Database. Notion serialises database titles as a rich_text array; we
+// stitch the runs together and trim whitespace.
+func databasePlainTitle(db *utils.Database) string {
+	if db == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, rt := range db.Title {
+		if rt.PlainText != "" {
+			sb.WriteString(rt.PlainText)
+		} else if rt.Text.Content != "" {
+			sb.WriteString(rt.Text.Content)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// isNotFound reports whether err looks like a 404 from the Notion API.
+// utils.decodeInto wraps non-2xx responses as "unexpected status N: ..."
+// rather than exposing typed status codes, so this check is a string
+// scan. When the error structure grows a typed shape, swap this for an
+// errors.As / errors.Is call.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Walk the wrapped chain so we still recognise 404s after callers
+	// add their own fmt.Errorf("...: %w", err) layers.
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if strings.Contains(e.Error(), "unexpected status 404") {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCmd)
+}

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -1,0 +1,355 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"notioncli/utils"
+)
+
+// fetchID is a canonical 32-hex Notion id used across the fetch tests.
+// Its dashed form is what the cmd dispatch path actually sends to the
+// mock server because ParseNotionID normalises every input.
+const (
+	fetchHexID    = "abc123def4567890abc123def4567890"
+	fetchDashedID = "abc123de-f456-7890-abc1-23def4567890"
+)
+
+// fetchMock is an httptest server that lets each test configure how the
+// /pages and /databases endpoints respond. The default is 404 on both so
+// individual tests opt into success by setting the corresponding handler
+// flag.
+type fetchMock struct {
+	srv      *httptest.Server
+	mu       sync.Mutex
+	calls    map[string]int
+	pageOK   bool
+	dbOK     bool
+	pageErr  int // optional non-404 error code on /pages
+	dbErr    int // optional non-404 error code on /databases
+}
+
+func newFetchMock(t *testing.T) *fetchMock {
+	t.Helper()
+	m := &fetchMock{calls: map[string]int{}}
+	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.calls[r.Method+" "+r.URL.Path]++
+		pageOK, dbOK := m.pageOK, m.dbOK
+		pageErr, dbErr := m.pageErr, m.dbErr
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/pages/"):
+			id := strings.TrimPrefix(r.URL.Path, "/pages/")
+			if pageErr != 0 {
+				http.Error(w, `{"object":"error","code":"server_error"}`, pageErr)
+				return
+			}
+			if !pageOK {
+				http.Error(w, `{"object":"error","code":"object_not_found"}`, http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"object":           "page",
+				"id":               id,
+				"created_time":     "2026-04-22T10:00:00.000Z",
+				"last_edited_time": "2026-04-22T10:00:00.000Z",
+				"url":              "https://notion.so/" + id,
+				"parent":           map[string]interface{}{"type": "page_id", "page_id": "p"},
+				"properties": map[string]interface{}{
+					"Name": map[string]interface{}{
+						"title": []interface{}{
+							map[string]interface{}{
+								"type":       "text",
+								"plain_text": "Sample Page",
+							},
+						},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/databases/"):
+			id := strings.TrimPrefix(r.URL.Path, "/databases/")
+			if dbErr != 0 {
+				http.Error(w, `{"object":"error","code":"server_error"}`, dbErr)
+				return
+			}
+			if !dbOK {
+				http.Error(w, `{"object":"error","code":"object_not_found"}`, http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"object":           "database",
+				"id":               id,
+				"created_time":     "2026-04-22T10:00:00.000Z",
+				"last_edited_time": "2026-04-22T10:00:00.000Z",
+				"url":              "https://notion.so/" + id,
+				"title": []map[string]interface{}{
+					{"plain_text": "Sample DB", "text": map[string]interface{}{"content": "Sample DB"}},
+				},
+				"parent":     map[string]interface{}{"type": "page_id", "page_id": "p"},
+				"properties": map[string]interface{}{},
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *fetchMock) count(key string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls[key]
+}
+
+// withFetchEnv mirrors withCmdEnv but swaps in the fetch-aware mock so
+// /pages and /databases respond exactly the way the dispatcher expects.
+func withFetchEnv(t *testing.T) *fetchMock {
+	t.Helper()
+	_ = withCmdEnv(t)
+	m := newFetchMock(t)
+	prior := utils.GetBaseURL()
+	utils.SetBaseURL(m.srv.URL)
+	t.Cleanup(func() { utils.SetBaseURL(prior) })
+	return m
+}
+
+// TestFetch_CmdRegistered confirms the fetch command is wired onto rootCmd.
+func TestFetch_CmdRegistered(t *testing.T) {
+	cmd := findTopLevelCmd(t, "fetch")
+	if cmd.Use == "" {
+		t.Error("fetch: Use is empty")
+	}
+	// Single positional arg.
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Error("fetch: expected error on zero args")
+	}
+	if err := cmd.Args(cmd, []string{"id"}); err != nil {
+		t.Errorf("fetch: expected no error on one arg, got %v", err)
+	}
+	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
+		t.Error("fetch: expected error on two args")
+	}
+}
+
+// TestFetch_PersistentFlagsAvailable confirms --json and --resolve-mentions
+// are reachable from fetch via the persistent flags on rootCmd. Fetch
+// itself adds no flags but must honour these.
+func TestFetch_PersistentFlagsAvailable(t *testing.T) {
+	cmd := findTopLevelCmd(t, "fetch")
+	if cmd.InheritedFlags().Lookup("json") == nil {
+		t.Error("fetch: persistent --json flag not visible")
+	}
+	if cmd.InheritedFlags().Lookup("resolve-mentions") == nil {
+		t.Error("fetch: persistent --resolve-mentions flag not visible")
+	}
+}
+
+// TestFetch_PageResolves runs the happy page path: /pages/{id} returns 200
+// and the dispatcher prints the page summary without ever falling through
+// to /databases.
+func TestFetch_PageResolves(t *testing.T) {
+	m := withFetchEnv(t)
+	m.pageOK = true
+	resetRootCmdArgs()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"fetch", fetchHexID})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := m.count("GET /pages/" + fetchDashedID); got != 1 {
+		t.Errorf("fetch did not GET /pages/%s exactly once (count=%d, calls=%v)", fetchDashedID, got, m.calls)
+	}
+	if got := m.count("GET /databases/" + fetchDashedID); got != 0 {
+		t.Errorf("fetch should not have probed /databases when page hits (count=%d)", got)
+	}
+	if !strings.Contains(out.String(), "page") || !strings.Contains(out.String(), fetchDashedID) {
+		t.Errorf("fetch human output missing page/id markers: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "blocks list") {
+		t.Errorf("fetch human output missing follow-up hint: %q", out.String())
+	}
+}
+
+// TestFetch_DatabaseResolvesAfterPage404 confirms the dispatcher falls
+// through to /databases when /pages returns 404, and emits the database
+// follow-up hint.
+func TestFetch_DatabaseResolvesAfterPage404(t *testing.T) {
+	m := withFetchEnv(t)
+	m.dbOK = true
+	resetRootCmdArgs()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"fetch", fetchHexID})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := m.count("GET /pages/" + fetchDashedID); got != 1 {
+		t.Errorf("fetch should have probed /pages first (count=%d)", got)
+	}
+	if got := m.count("GET /databases/" + fetchDashedID); got != 1 {
+		t.Errorf("fetch did not fall through to /databases (count=%d, calls=%v)", got, m.calls)
+	}
+	if !strings.Contains(out.String(), "database") || !strings.Contains(out.String(), "databases query") {
+		t.Errorf("fetch human output missing database hint: %q", out.String())
+	}
+}
+
+// TestFetch_AllNotFound confirms a clear "no resource found" error when
+// both probes return 404.
+func TestFetch_AllNotFound(t *testing.T) {
+	_ = withFetchEnv(t)
+	resetRootCmdArgs()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	rootCmd.SetArgs([]string{"fetch", fetchHexID})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both /pages and /databases 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "no page or database") {
+		t.Errorf("expected 'no page or database' error, got %v", err)
+	}
+}
+
+// TestFetch_BadInput confirms ParseNotionID errors propagate cleanly
+// without issuing any HTTP probes.
+func TestFetch_BadInput(t *testing.T) {
+	m := withFetchEnv(t)
+	resetRootCmdArgs()
+
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	rootCmd.SetArgs([]string{"fetch", "not-a-real-id"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error on malformed input, got nil")
+	}
+	if got := m.count("GET /pages/"); got != 0 {
+		t.Errorf("expected no /pages probes on malformed input, got %d", got)
+	}
+}
+
+// TestFetch_JSONOutput confirms --json emits the raw page object and
+// suppresses the human follow-up hint.
+func TestFetch_JSONOutput(t *testing.T) {
+	m := withFetchEnv(t)
+	m.pageOK = true
+	resetRootCmdArgs()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"fetch", "--json", fetchHexID})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if got["object"] != "page" {
+		t.Errorf("expected object=page, got %v", got["object"])
+	}
+	if strings.Contains(out.String(), "hint:") {
+		t.Errorf("--json mode should not emit human hint line: %q", out.String())
+	}
+}
+
+// TestFetch_PageProbeNon404Surfaces confirms a non-404 page error short-
+// circuits the dispatcher (no fall-through, error returned to caller).
+func TestFetch_PageProbeNon404Surfaces(t *testing.T) {
+	m := withFetchEnv(t)
+	m.pageErr = http.StatusInternalServerError
+	resetRootCmdArgs()
+
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	rootCmd.SetArgs([]string{"fetch", fetchHexID})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error on 500 from /pages, got nil")
+	}
+	if got := m.count("GET /databases/" + fetchDashedID); got != 0 {
+		t.Errorf("non-404 page error should not fall through to /databases (count=%d)", got)
+	}
+}
+
+// TestFetch_IsNotFound exercises the helper directly so the wrap-aware
+// branch is covered. The dispatcher relies on the wrapped form because
+// every Get layers its own fmt.Errorf around the underlying decode error.
+func TestFetch_IsNotFound(t *testing.T) {
+	if isNotFound(nil) {
+		t.Error("isNotFound(nil) must be false")
+	}
+	plain := fmt.Errorf("unexpected status 404: object_not_found")
+	if !isNotFound(plain) {
+		t.Error("isNotFound: plain 404 error not detected")
+	}
+	wrapped := fmt.Errorf("get page: %w", plain)
+	if !isNotFound(wrapped) {
+		t.Error("isNotFound: wrapped 404 error not detected")
+	}
+	other := fmt.Errorf("unexpected status 500: server_error")
+	if isNotFound(other) {
+		t.Error("isNotFound: 500 must not be classified as 404")
+	}
+}
+
+// TestFetch_PagePlainTitle covers the title extractor branches.
+func TestFetch_PagePlainTitle(t *testing.T) {
+	if got := pagePlainTitle(nil); got != "" {
+		t.Errorf("pagePlainTitle(nil) = %q, want empty", got)
+	}
+	page := &utils.Page{Properties: map[string]interface{}{
+		"Name": map[string]interface{}{
+			"title": []interface{}{
+				map[string]interface{}{"plain_text": "Hello"},
+			},
+		},
+	}}
+	if got := pagePlainTitle(page); got != "Hello" {
+		t.Errorf("pagePlainTitle = %q, want Hello", got)
+	}
+	bare := &utils.Page{Properties: map[string]interface{}{}}
+	if got := pagePlainTitle(bare); got != "" {
+		t.Errorf("pagePlainTitle(empty) = %q, want empty", got)
+	}
+}
+
+// TestFetch_DatabasePlainTitle covers the database title joiner.
+func TestFetch_DatabasePlainTitle(t *testing.T) {
+	if got := databasePlainTitle(nil); got != "" {
+		t.Errorf("databasePlainTitle(nil) = %q, want empty", got)
+	}
+	db := &utils.Database{Title: []utils.RichText{
+		{PlainText: "Foo "},
+		{PlainText: "Bar"},
+	}}
+	if got := databasePlainTitle(db); got != "Foo Bar" {
+		t.Errorf("databasePlainTitle = %q, want 'Foo Bar'", got)
+	}
+}

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -30,13 +30,13 @@ const (
 // individual tests opt into success by setting the corresponding handler
 // flag.
 type fetchMock struct {
-	srv      *httptest.Server
-	mu       sync.Mutex
-	calls    map[string]int
-	pageOK   bool
-	dbOK     bool
-	pageErr  int // optional non-404 error code on /pages
-	dbErr    int // optional non-404 error code on /databases
+	srv     *httptest.Server
+	mu      sync.Mutex
+	calls   map[string]int
+	pageOK  bool
+	dbOK    bool
+	pageErr int // optional non-404 error code on /pages
+	dbErr   int // optional non-404 error code on /databases
 }
 
 func newFetchMock(t *testing.T) *fetchMock {

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -77,14 +77,15 @@ returns the file id and name only.`,
 		if err != nil {
 			return jsonErrorOr(cmd, err)
 		}
-		ref, err := fc.Upload(context.Background(), args[0])
+		// Pass --name through to UploadAs so Notion stores the file
+		// under the caller's label (used in the create-request filename
+		// and the multipart "file" part name). When --name is empty,
+		// UploadAs falls back to the source path's basename.
+		ref, err := fc.UploadAs(context.Background(), args[0], blocksAddFileName)
 		if err != nil {
 			return jsonErrorOr(cmd, fmt.Errorf("add-file: %w", err))
 		}
-		name := blocksAddFileName
-		if name == "" {
-			name = ref.Name
-		}
+		name := ref.Name
 		if globalJSON {
 			// Emit an action envelope so the caller's --name is visible
 			// in the JSON stream. ref itself is nested so consumers can

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,13 +22,12 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return jsonErrorOr(cmd, fmt.Errorf("list: %w", err))
 		}
-		localTimezone, err := utils.GetLocalTimeZone()
-		if err != nil {
-			return jsonErrorOr(cmd, fmt.Errorf("list: resolve local time zone: %w", err))
-		}
-		// In --json mode we want the raw Notion block objects so consumers
-		// can jq on them; the formatted lines are for humans only. This
-		// mirrors the blocks list split (typed objects pass-through).
+
+		// JSON path emits raw Notion block objects, so timestamps are
+		// never humanised — resolving LOCAL_TIMEZONE on this branch
+		// would just fail loudly on machines that ship without one set.
+		// The human path below is the only consumer of localTimezone,
+		// so the lookup moves to right before GetToDoBlocks.
 		if globalJSON {
 			// GetAllBlocks with "to_do" mirrors the human list by only
 			// returning to-do blocks. emitList picks NDJSON or a pretty
@@ -40,6 +39,10 @@ var listCmd = &cobra.Command{
 			return jsonErrorOr(cmd, emitList(cmd.OutOrStdout(), blocks))
 		}
 
+		localTimezone, err := utils.GetLocalTimeZone()
+		if err != nil {
+			return fmt.Errorf("list: resolve local time zone: %w", err)
+		}
 		brightWhite := color.New(color.FgHiWhite).SprintFunc()
 		blocks, err := utils.GetToDoBlocks(notionAPIKey, pageID, localTimezone)
 		if err != nil {

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -334,6 +334,36 @@ func TestList_JSON(t *testing.T) {
 	}
 }
 
+// TestList_JSON_NoLocalTimezone confirms `list --json` does not fail
+// on machines that ship without LOCAL_TIMEZONE set. JSON mode emits raw
+// block objects with un-humanised timestamps, so the timezone lookup
+// belongs strictly on the human path. Regression guard for PR #50
+// second-pass review [P2].
+func TestList_JSON_NoLocalTimezone(t *testing.T) {
+	_ = withCmdEnv(t)
+	// withCmdEnv pins LOCAL_TIMEZONE=UTC for human-mode determinism;
+	// override it here so the assertion is meaningful — the bug only
+	// reproduces when the env var is absent.
+	t.Setenv("LOCAL_TIMEZONE", "")
+	if err := os.Unsetenv("LOCAL_TIMEZONE"); err != nil {
+		t.Fatalf("unset LOCAL_TIMEZONE: %v", err)
+	}
+
+	resetGlobalOutputFlags()
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"list", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("list --json failed without LOCAL_TIMEZONE: %v", err)
+	}
+	objs := assertNDJSON(t, out.String())
+	if len(objs) == 0 {
+		t.Fatalf("want at least 1 todo block, got 0: %q", out.String())
+	}
+}
+
 // TestAdd_JSON runs `add "task" --json` and asserts the ok envelope.
 func TestAdd_JSON(t *testing.T) {
 	_ = withCmdEnv(t)

--- a/cmd/pages.go
+++ b/cmd/pages.go
@@ -22,6 +22,7 @@ import (
 // blocks.go's pattern and lets cobra bind them via init().
 var (
 	pagesCreateParent    string
+	pagesCreateParentDB  string
 	pagesCreateTitle     string
 	pagesUpdateTitle     string
 	pagesUpdateProps     []string
@@ -38,7 +39,8 @@ archive/unarchive, move between parents, and duplicate.
 
 Examples:
   notioncli pages get <page-id>
-  notioncli pages create --parent <page-or-db-id> --title "New page"
+  notioncli pages create --parent <page-id> --title "New page"
+  notioncli pages create --parent-database <db-id> --title "New row"
   notioncli pages update <id> --title "Renamed"
   notioncli pages archive <id>
   notioncli pages unarchive <id>
@@ -57,6 +59,24 @@ func newPageClient() (*utils.PageClient, error) {
 	}
 	c := utils.NewClient(apiKey, utils.WithBaseURL(utils.GetBaseURL()))
 	return utils.NewPageClient(c), nil
+}
+
+// buildCreateParent resolves the (--parent, --parent-database) flag pair into
+// a utils.PageParent suitable for CreatePageRequest. Exactly one of the two
+// must be set; both empty or both populated is a usage error. The returned
+// parent has only the matching id field set so the JSON encoder emits the
+// `page_id` or `database_id` discriminator Notion expects, never both.
+func buildCreateParent(pageID, databaseID string) (utils.PageParent, error) {
+	switch {
+	case pageID == "" && databaseID == "":
+		return utils.PageParent{}, fmt.Errorf("create page: --parent or --parent-database is required")
+	case pageID != "" && databaseID != "":
+		return utils.PageParent{}, fmt.Errorf("create page: --parent and --parent-database are mutually exclusive")
+	case databaseID != "":
+		return utils.PageParent{DatabaseID: databaseID}, nil
+	default:
+		return utils.PageParent{PageID: pageID}, nil
+	}
 }
 
 // parseProperty splits "key=value" from the --property flag. Values are sent
@@ -107,19 +127,27 @@ var pagesGetCmd = &cobra.Command{
 }
 
 // pagesCreateCmd creates a new page under the provided parent.
+//
+// Notion distinguishes page parents (parent.page_id) from database parents
+// (parent.database_id) at the wire level, so the CLI surfaces them as two
+// mutually-exclusive flags: --parent for a page parent, --parent-database
+// for a database row. Earlier versions accepted any id under --parent and
+// always serialised it as page_id, which 400'd against database parents
+// with "parent is expected to be database" — see PR #50 review.
 var pagesCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create a new page under --parent",
+	Short: "Create a new page under --parent (page) or --parent-database",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if pagesCreateParent == "" {
-			return jsonErrorOr(cmd, fmt.Errorf("create page: --parent is required"))
+		parent, err := buildCreateParent(pagesCreateParent, pagesCreateParentDB)
+		if err != nil {
+			return jsonErrorOr(cmd, err)
 		}
 		pc, err := newPageClient()
 		if err != nil {
 			return jsonErrorOr(cmd, err)
 		}
 		page, err := pc.Create(context.Background(), utils.CreatePageRequest{
-			Parent: utils.PageParent{PageID: pagesCreateParent},
+			Parent: parent,
 			Title:  pagesCreateTitle,
 		})
 		if err != nil {
@@ -327,7 +355,8 @@ func init() {
 	pagesCmd.AddCommand(pagesMoveCmd)
 	pagesCmd.AddCommand(pagesDuplicateCmd)
 
-	pagesCreateCmd.Flags().StringVar(&pagesCreateParent, "parent", "", "Parent page or database ID (required)")
+	pagesCreateCmd.Flags().StringVar(&pagesCreateParent, "parent", "", "Parent page ID (mutually exclusive with --parent-database)")
+	pagesCreateCmd.Flags().StringVar(&pagesCreateParentDB, "parent-database", "", "Parent database ID for database-parented pages (mutually exclusive with --parent)")
 	pagesCreateCmd.Flags().StringVar(&pagesCreateTitle, "title", "", "Title for the new page")
 
 	pagesUpdateCmd.Flags().StringVar(&pagesUpdateTitle, "title", "", "New title for the page")

--- a/cmd/pages_test.go
+++ b/cmd/pages_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -153,19 +154,32 @@ func TestPagesParseProperty(t *testing.T) {
 }
 
 // pagesDispatchServer swaps the cmd-layer mock with a pages-aware handler.
-// It returns a counter map keyed by method+path and a close func.
+// It returns a counter map keyed by method+path, the most recent request
+// body for each (method+path), and a close func. Body capture lets tests
+// assert wire shapes — e.g. the parent discriminator on POST /pages —
+// without standing up a separate fixture.
 type pagesDispatchServer struct {
-	srv   *httptest.Server
-	mu    sync.Mutex
-	calls map[string]int64
+	srv    *httptest.Server
+	mu     sync.Mutex
+	calls  map[string]int64
+	bodies map[string][]byte
 }
 
 func newPagesDispatchServer(t *testing.T) *pagesDispatchServer {
 	t.Helper()
-	d := &pagesDispatchServer{calls: map[string]int64{}}
+	d := &pagesDispatchServer{calls: map[string]int64{}, bodies: map[string][]byte{}}
 	d.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		var body []byte
+		if r.Body != nil {
+			body, _ = io.ReadAll(r.Body)
+			_ = r.Body.Close()
+		}
 		d.mu.Lock()
-		d.calls[r.Method+" "+r.URL.Path]++
+		d.calls[key]++
+		if len(body) > 0 {
+			d.bodies[key] = body
+		}
 		d.mu.Unlock()
 		switch {
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pages/"):
@@ -210,6 +224,15 @@ func (d *pagesDispatchServer) count(key string) int64 {
 	return d.calls[key]
 }
 
+// body returns the most recent request body captured for the given
+// method+path key. Returns nil when nothing was recorded; tests should
+// fail loudly on a nil body for endpoints they expect to have hit.
+func (d *pagesDispatchServer) body(key string) []byte {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.bodies[key]
+}
+
 // withPagesEnv swaps in the pages dispatch server and sets env the way the
 // blocks tests do.
 func withPagesEnv(t *testing.T) *pagesDispatchServer {
@@ -228,6 +251,7 @@ func withPagesEnv(t *testing.T) *pagesDispatchServer {
 // persists bound flag values across executions.
 func resetPagesFlags() {
 	pagesCreateParent = ""
+	pagesCreateParentDB = ""
 	pagesCreateTitle = ""
 	pagesUpdateTitle = ""
 	pagesUpdateProps = nil
@@ -253,7 +277,8 @@ func TestPagesGetDispatch(t *testing.T) {
 	}
 }
 
-// TestPagesCreateDispatch runs `pages create --parent p --title t`.
+// TestPagesCreateDispatch runs `pages create --parent p --title t` and
+// asserts the body serialises a page-id parent (not a database id).
 func TestPagesCreateDispatch(t *testing.T) {
 	d := withPagesEnv(t)
 	resetPagesFlags()
@@ -265,6 +290,68 @@ func TestPagesCreateDispatch(t *testing.T) {
 	}
 	if got := d.count("POST /pages"); got != 1 {
 		t.Errorf("POST /pages count=%d want 1 (calls=%v)", got, d.calls)
+	}
+	body := d.body("POST /pages")
+	if body == nil {
+		t.Fatal("POST /pages: no body captured")
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	parent, _ := got["parent"].(map[string]interface{})
+	if parent["page_id"] != "parentID" {
+		t.Errorf("parent.page_id=%v want parentID (parent=%v)", parent["page_id"], parent)
+	}
+	if _, hasDB := parent["database_id"]; hasDB {
+		t.Errorf("parent must not include database_id when --parent set: %v", parent)
+	}
+}
+
+// TestPagesCreateDatabaseParent confirms --parent-database emits the
+// database_id discriminator the API requires for database-parented
+// pages. Regression test for PR #50 review [P1].
+func TestPagesCreateDatabaseParent(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SetArgs([]string{"pages", "create", "--parent-database", "dbID", "--title", "Row"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	body := d.body("POST /pages")
+	if body == nil {
+		t.Fatal("POST /pages: no body captured")
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	parent, _ := got["parent"].(map[string]interface{})
+	if parent["database_id"] != "dbID" {
+		t.Errorf("parent.database_id=%v want dbID (parent=%v)", parent["database_id"], parent)
+	}
+	if _, hasPage := parent["page_id"]; hasPage {
+		t.Errorf("parent must not include page_id when --parent-database set: %v", parent)
+	}
+}
+
+// TestPagesCreateBothParentFlagsErrors confirms the CLI rejects the
+// ambiguous case where both flags are populated, before any HTTP call.
+func TestPagesCreateBothParentFlagsErrors(t *testing.T) {
+	d := withPagesEnv(t)
+	resetPagesFlags()
+	resetRootCmdArgs()
+
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	rootCmd.SetArgs([]string{"pages", "create", "--parent", "p", "--parent-database", "db"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when both --parent and --parent-database set, got nil")
+	}
+	if got := d.count("POST /pages"); got != 0 {
+		t.Errorf("expected no POST /pages on conflicting flags, got %d", got)
 	}
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,56 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionString is the release identifier surfaced by the `version`
+// subcommand. main.go injects the value via SetVersion at process start.
+// The "dev" sentinel keeps unflagged `go build` and `go install` honest:
+// developers running an unreleased binary see "dev" rather than a stale
+// hard-coded tag. Release builds override main.version at link time, and
+// main calls SetVersion(version) before cobra dispatch — see main.go.
+var versionString = "dev"
+
+// SetVersion lets main inject the link-time-resolved version string into
+// the cmd package without exposing the underlying var. Calling it after
+// rootCmd.Execute() has no effect on already-running invocations, so
+// main.go MUST call this before Execute().
+func SetVersion(v string) {
+	if v != "" {
+		versionString = v
+	}
+}
+
+// versionCmd prints the build version. JSON mode emits a single-key object
+// so scripted consumers can `notioncli version --json | jq -r .version`
+// without parsing free-form text.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the notioncli build version",
+	Long: `Print the notioncli build version.
+
+Release builds embed the git tag (e.g. v0.1.0) via -ldflags. Source
+builds report "dev". Use --json for a machine-readable form.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		w := cmd.OutOrStdout()
+		if globalJSON {
+			enc := json.NewEncoder(w)
+			return enc.Encode(map[string]string{"version": versionString})
+		}
+		fmt.Fprintln(w, versionString)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,22 @@ import (
 	"notioncli/cmd"
 )
 
+// version is the notioncli release identifier surfaced by the `version`
+// subcommand. The default "dev" sentinel keeps `go install` and unflagged
+// `go build` invocations honest — both produce a binary that reports its
+// build provenance without needing release plumbing.
+//
+// Release builds override this at link time:
+//
+//	go build -ldflags "-X main.version=v0.1.0" .
+//
+// The release workflow (.github/workflows/release.yml) injects the tag
+// name (e.g. v0.1.0) so users running `notioncli version` on a tagged
+// binary see the exact tag that produced it. The homebrew formula in the
+// companion tap repo passes the same ldflag via std_go_args.
+var version = "dev"
+
 func main() {
+	cmd.SetVersion(version)
 	cmd.Execute()
 }

--- a/utils/block.go
+++ b/utils/block.go
@@ -105,6 +105,37 @@ func IsAddableBlockType(blockType string) bool {
 	return AddableBlockTypes[blockType]
 }
 
+// richTextBearingBlockTypes lists the addable block types whose body
+// schema includes a `rich_text` array. AddRichTextBlock builds a payload
+// of the form `<type>: {"rich_text": [...]}`, so only these types yield
+// a valid Notion block. Types like image/file/video/embed/bookmark take
+// a `<media>: {"url": "..."}` shape instead, and equation takes
+// `equation: {"expression": "..."}` — passing rich text to those
+// produces a 400 from Notion.
+var richTextBearingBlockTypes = map[string]bool{
+	"paragraph":          true,
+	"heading_1":          true,
+	"heading_2":          true,
+	"heading_3":          true,
+	"bulleted_list_item": true,
+	"numbered_list_item": true,
+	"to_do":              true,
+	"toggle":             true,
+	"quote":              true,
+	"callout":            true,
+	"code":               true,
+}
+
+// BlockTypeAcceptsRichText reports whether a block type's Notion schema
+// includes a `rich_text` array, and is therefore a valid target for
+// AddRichTextBlock / `blocks add --rich-text-json`. Returns false for
+// divider (no body), media blocks (image/file/video/embed/bookmark —
+// these take a url-bearing object instead), and equation (which takes
+// an `expression` string rather than rich text).
+func BlockTypeAcceptsRichText(blockType string) bool {
+	return richTextBearingBlockTypes[blockType]
+}
+
 // GetSupportedBlockTypeNames returns a sorted list of supported block type names.
 func GetSupportedBlockTypeNames() []string {
 	names := make([]string, 0, len(SupportedBlockTypes))

--- a/utils/block_richtext_test.go
+++ b/utils/block_richtext_test.go
@@ -289,7 +289,13 @@ func TestAddRichTextBlock_Errors(t *testing.T) {
 		wantSub   string
 	}{
 		{"unsupported type", "bogus", []RichText{{Text: Text{Content: "x"}}}, "unsupported block type"},
-		{"divider rejected", "divider", []RichText{{Text: Text{Content: "x"}}}, "divider blocks do not accept"},
+		{"divider rejected", "divider", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
+		{"image rejected", "image", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
+		{"file rejected", "file", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
+		{"video rejected", "video", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
+		{"embed rejected", "embed", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
+		{"bookmark rejected", "bookmark", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
+		{"equation rejected", "equation", []RichText{{Text: Text{Content: "x"}}}, "does not accept rich text"},
 		{"empty rt", "paragraph", nil, "at least one segment"},
 	}
 	for _, tt := range tests {

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -509,8 +509,8 @@ func (b *BlockClient) AddRichTextBlock(ctx context.Context, pageID, blockType st
 	if !IsValidBlockType(blockType) {
 		return fmt.Errorf("unsupported block type: %s", blockType)
 	}
-	if blockType == "divider" {
-		return fmt.Errorf("divider blocks do not accept rich text; use AddBlock")
+	if !BlockTypeAcceptsRichText(blockType) {
+		return fmt.Errorf("block type %q does not accept rich text; rich-text-json is only valid for paragraph, heading_1/2/3, bulleted_list_item, numbered_list_item, to_do, toggle, quote, callout, and code", blockType)
 	}
 	if len(rt) == 0 {
 		return fmt.Errorf("rich text must have at least one segment")

--- a/utils/files.go
+++ b/utils/files.go
@@ -111,14 +111,26 @@ func validateUploadPath(path string) error {
 	return nil
 }
 
-// Upload runs the two-step Notion file-upload flow:
+// Upload runs the Notion file-upload flow using the source file's basename
+// as the displayed filename. Equivalent to UploadAs(ctx, path, "").
+func (f *FileClient) Upload(ctx context.Context, path string) (*FileRef, error) {
+	return f.UploadAs(ctx, path, "")
+}
+
+// UploadAs runs the two-step Notion file-upload flow with an optional
+// override for the displayed filename:
 //  1. POST /v1/file_uploads (mode=single_part, filename) → FileUploadResponse
 //  2. POST FileUploadResponse.UploadURL with multipart/form-data containing
 //     the file bytes under the "file" field
 //
+// When displayName is empty the source path's basename is used. When
+// non-empty, displayName is sent as both the create-request `filename`
+// and the multipart "file" part name, so the file lands in Notion under
+// the caller-supplied label rather than the local filesystem name.
+//
 // Returns a FileRef suitable for use as a block/page icon/cover reference.
 // Caller cancellation is honored on both requests.
-func (f *FileClient) Upload(ctx context.Context, path string) (*FileRef, error) {
+func (f *FileClient) UploadAs(ctx context.Context, path, displayName string) (*FileRef, error) {
 	if err := f.checkAuth(); err != nil {
 		return nil, fmt.Errorf("upload file: %w", err)
 	}
@@ -132,6 +144,9 @@ func (f *FileClient) Upload(ctx context.Context, path string) (*FileRef, error) 
 	}
 
 	filename := filepath.Base(path)
+	if displayName != "" {
+		filename = displayName
+	}
 
 	// Step 1: request an upload slot.
 	createReq := FileUploadRequest{

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -192,6 +192,66 @@ func TestFiles_Upload_HappyPath(t *testing.T) {
 	}
 }
 
+// TestFiles_UploadAs_DisplayNameOverride verifies that a non-empty
+// displayName flows through both steps of the upload: it lands in the
+// /v1/file_uploads create-request body, the multipart "file" part name
+// on the pre-signed POST, and the returned FileRef.Name. Regression
+// guard for PR #50 review [P2] — `--name` must not be cosmetic.
+func TestFiles_UploadAs_DisplayNameOverride(t *testing.T) {
+	api := &fakeNotionFileAPI{}
+	srv := httptest.NewServer(api.handler(t))
+	defer srv.Close()
+
+	// Source file lives on disk under one name, but the caller wants
+	// Notion to display a different one. Asserting both ends rules out
+	// regressions where only the create-side or only the multipart-side
+	// gets the override.
+	path := filepath.Join(t.TempDir(), "tmp-source.bin")
+	if err := os.WriteFile(path, []byte("payload-bytes"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	const displayName = "Q1-Plan.pdf"
+
+	client := NewFileClient(NewClient("k", WithBaseURL(srv.URL)))
+	ref, err := client.UploadAs(context.Background(), path, displayName)
+	if err != nil {
+		t.Fatalf("UploadAs: %v", err)
+	}
+	if ref == nil || ref.Name != displayName {
+		t.Errorf("UploadAs ref.Name = %v, want %q", ref, displayName)
+	}
+	if api.uploadedNm != displayName {
+		t.Errorf("UploadAs: create-request filename = %q, want %q", api.uploadedNm, displayName)
+	}
+}
+
+// TestFiles_UploadAs_EmptyOverrideUsesBasename confirms the empty
+// displayName path is equivalent to Upload(): the source basename
+// reaches Notion. This locks in the back-compat contract that
+// Upload(ctx, path) == UploadAs(ctx, path, "").
+func TestFiles_UploadAs_EmptyOverrideUsesBasename(t *testing.T) {
+	api := &fakeNotionFileAPI{}
+	srv := httptest.NewServer(api.handler(t))
+	defer srv.Close()
+
+	path := filepath.Join(t.TempDir(), "screenshot.png")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := NewFileClient(NewClient("k", WithBaseURL(srv.URL)))
+	ref, err := client.UploadAs(context.Background(), path, "")
+	if err != nil {
+		t.Fatalf("UploadAs: %v", err)
+	}
+	if ref.Name != "screenshot.png" {
+		t.Errorf("UploadAs ref.Name = %q, want screenshot.png", ref.Name)
+	}
+	if api.uploadedNm != "screenshot.png" {
+		t.Errorf("UploadAs: create-request filename = %q, want screenshot.png", api.uploadedNm)
+	}
+}
+
 // TestFiles_Upload_Step1Error surfaces a non-2xx from step 1 without
 // calling step 2.
 func TestFiles_Upload_Step1Error(t *testing.T) {

--- a/utils/parse_id.go
+++ b/utils/parse_id.go
@@ -1,0 +1,77 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// notionIDInString matches the 32-hex-with-optional-dashes Notion id shape
+// when it appears anywhere inside a larger string (e.g. embedded in a URL
+// path or slug). Anchored matching is handled by uuidPattern in aliases.go;
+// this variant is unanchored on purpose so the URL-extraction path in
+// ParseNotionID can pick the trailing id out of slugs like
+// "Page-Title-abc123def4567890abc123def4567890".
+var notionIDInString = regexp.MustCompile(`[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}`)
+
+// ParseNotionID accepts the inputs the fetch dispatcher (and any future
+// URL-or-id callers) need to handle and returns the canonical dashed UUID
+// form Notion's API expects.
+//
+// Accepted forms:
+//
+//	abc123def4567890abc123def4567890        // bare 32-hex
+//	abc123de-f456-7890-abc1-23def4567890    // dashed UUID
+//	https://www.notion.so/Workspace/Page-Title-<id>
+//	https://notion.so/<id>
+//	notion.so/<id>
+//	notion.so/<id>?v=<view-id>              // view fragment ignored
+//
+// Returns the dashed 8-4-4-4-12 form. Any input that does not contain a
+// 32-hex (with or without dashes) sequence returns an error citing the
+// original input so callers can produce a clean user-facing message.
+//
+// When a URL contains multiple 32-hex sequences (e.g. a page url with a
+// `?v=<view-id>` query suffix), the FIRST id in the path is returned —
+// that is the page/database id, not the secondary view id. Query strings
+// and fragments are stripped before scanning.
+func ParseNotionID(input string) (string, error) {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return "", fmt.Errorf("parse notion id: empty input")
+	}
+
+	// Bare-id fast path: input is already the 32-hex or dashed UUID with
+	// nothing surrounding it. Normalise to dashed form and return.
+	if uuidPattern.MatchString(s) {
+		return canonicalizeNotionID(s), nil
+	}
+
+	// URL/slug path: scan for the first id-shaped substring inside the
+	// path. Strip ?query and #fragment first so query parameters
+	// (notably the ?v=<view-id> Notion appends to database URLs) cannot
+	// shadow the page id we actually want.
+	path := s
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+	if match := notionIDInString.FindString(path); match != "" {
+		return canonicalizeNotionID(match), nil
+	}
+
+	return "", fmt.Errorf("parse notion id: %q does not contain a Notion id (want 32-hex, dashed uuid, or notion.so URL)", input)
+}
+
+// canonicalizeNotionID strips dashes from a matched id and re-inserts them
+// at the canonical 8-4-4-4-12 boundaries so every consumer of the result
+// can rely on a single shape regardless of which input form was passed in.
+// The caller MUST have already validated the input via uuidPattern or
+// notionIDInString — this function does not re-validate.
+func canonicalizeNotionID(raw string) string {
+	hex := strings.ReplaceAll(raw, "-", "")
+	return hex[0:8] + "-" + hex[8:12] + "-" + hex[12:16] + "-" + hex[16:20] + "-" + hex[20:32]
+}

--- a/utils/parse_id_test.go
+++ b/utils/parse_id_test.go
@@ -1,0 +1,72 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseNotionID_Forms covers every input shape the fetch dispatcher
+// promises to accept plus the negative paths. The expected output is
+// always the canonical dashed form so callers can build paths like
+// /v1/pages/<id> without re-normalising.
+func TestParseNotionID_Forms(t *testing.T) {
+	const (
+		hex    = "abc123def4567890abc123def4567890"
+		dashed = "abc123de-f456-7890-abc1-23def4567890"
+	)
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare hex", hex, dashed},
+		{"already dashed", dashed, dashed},
+		{"https www", "https://www.notion.so/Workspace/Page-Title-" + hex, dashed},
+		{"https no www", "https://notion.so/" + hex, dashed},
+		{"protocol-less", "notion.so/" + hex, dashed},
+		{"with query", "https://www.notion.so/" + hex + "?v=" + hex, dashed},
+		{"with fragment", "https://www.notion.so/Workspace/Page-Title-" + hex + "#section", dashed},
+		{"surrounding whitespace", "  " + hex + "\n", dashed},
+		{"uppercase preserved", strings.ToUpper(hex), strings.ToUpper(hex)[0:8] + "-" + strings.ToUpper(hex)[8:12] + "-" + strings.ToUpper(hex)[12:16] + "-" + strings.ToUpper(hex)[16:20] + "-" + strings.ToUpper(hex)[20:32]},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseNotionID(tc.input)
+			if err != nil {
+				t.Fatalf("ParseNotionID(%q) returned error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseNotionID(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseNotionID_Errors confirms malformed inputs surface a descriptive
+// error instead of returning a partial id or panicking.
+func TestParseNotionID_Errors(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"too short", "abc123"},
+		{"non-hex content", "not-a-real-id"},
+		{"url with no id", "https://www.notion.so/Some-Page-Title"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseNotionID(tc.input); err == nil {
+				t.Errorf("ParseNotionID(%q) expected error, got nil", tc.input)
+			}
+		})
+	}
+}

--- a/utils/users.go
+++ b/utils/users.go
@@ -64,10 +64,25 @@ func NewUserClient(c *Client) *UserClient {
 	return &UserClient{c: c}
 }
 
+// checkAuth mirrors PageClient.checkAuth so missing-credential errors
+// surface as ErrMissingAPIKey rather than panicking on a nil client or
+// falling through to an opaque 401 from Notion. Library callers that
+// pass a nil *Client (e.g. NewUserClient(nil) in a test seam) get a
+// typed error instead of a runtime panic.
+func (u *UserClient) checkAuth() error {
+	if u == nil || u.c == nil || u.c.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	return nil
+}
+
 // ListPage fetches a single page of users. Pass an empty cursor for the
 // first page; subsequent calls should pass the NextCursor returned by the
 // previous page.
 func (u *UserClient) ListPage(ctx context.Context, cursor string) (*UserList, error) {
+	if err := u.checkAuth(); err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
 	path := "/users"
 	if cursor != "" {
 		path += "?start_cursor=" + url.QueryEscape(cursor)
@@ -109,6 +124,9 @@ func (u *UserClient) List(ctx context.Context) ([]User, error) {
 
 // Get retrieves a single user by id.
 func (u *UserClient) Get(ctx context.Context, id string) (*User, error) {
+	if err := u.checkAuth(); err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
 	if id == "" {
 		return nil, fmt.Errorf("get user: id is required")
 	}
@@ -130,6 +148,9 @@ func (u *UserClient) Get(ctx context.Context, id string) (*User, error) {
 // Me returns the bot user associated with the integration token in use.
 // Corresponds to GET /v1/users/me.
 func (u *UserClient) Me(ctx context.Context) (*User, error) {
+	if err := u.checkAuth(); err != nil {
+		return nil, fmt.Errorf("get self: %w", err)
+	}
 	req, err := u.c.newRequest(ctx, http.MethodGet, "/users/me", nil)
 	if err != nil {
 		return nil, err

--- a/utils/users_test.go
+++ b/utils/users_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -252,6 +253,42 @@ func TestMe_Happy(t *testing.T) {
 	}
 	if got.Bot == nil || got.Bot.WorkspaceName != "Acme" {
 		t.Errorf("unexpected Bot: %+v", got.Bot)
+	}
+}
+
+// TestUserClient_MissingAPIKey verifies every UserClient method that
+// hits the network surfaces ErrMissingAPIKey when the underlying Client
+// has an empty API key, instead of falling through to an opaque 401
+// from Notion. Mirrors the contract on PageClient/TeamClient/etc.
+// Regression guard for PR #50 second-pass review [P2].
+func TestUserClient_MissingAPIKey(t *testing.T) {
+	client := NewUserClient(NewClient("", WithBaseURL("http://127.0.0.1:0")))
+
+	if _, err := client.List(context.Background()); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("List: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	if _, err := client.ListPage(context.Background(), ""); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("ListPage: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	if _, err := client.Get(context.Background(), "user-id"); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Get: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	if _, err := client.Me(context.Background()); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Me: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+}
+
+// TestUserClient_NilClientNoPanic confirms calling methods on a
+// UserClient whose underlying *Client is nil returns ErrMissingAPIKey
+// instead of panicking. Library callers that wire UserClient through a
+// test seam may pass nil; the failure mode should be a typed error.
+func TestUserClient_NilClientNoPanic(t *testing.T) {
+	client := NewUserClient(nil)
+	if _, err := client.List(context.Background()); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("List(nil client): err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	if _, err := client.Me(context.Background()); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Me(nil client): err = %v, want errors.Is ErrMissingAPIKey", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `notioncli fetch <url-or-id>` auto-detects page vs database (closes #38). Probes `/v1/pages` first, falls back to `/v1/databases` on 404, surfaces other errors immediately. `--json` emits the raw API object; human path prints a type/id/title summary plus a follow-up command hint.
- `notioncli version` subcommand backed by an ldflag-injected build identifier. `cmd.SetVersion` is called from `main` before cobra dispatch; unflagged source builds report `dev`, release builds carry the git tag.
- Cross-platform release workflow on `v*.*.*` tags: darwin/linux amd64+arm64 archives, per-archive sha256 sidecars, source-tarball sha256 in the release body for the homebrew tap formula. (GoReleaser swap tracked in #36.)
- README install path overhauled: homebrew tap, `go install`, source build.

New helper: `utils.ParseNotionID` accepts URLs, bare 32-hex, and dashed UUIDs and returns the canonical 8-4-4-4-12 form. Strips `?query` and `#fragment` so the `?v=<view-id>` suffix on database URLs cannot shadow the page id.

> **Heads up:** the branch is named `fix-annotation-color` but the diff is fetch dispatcher + release plumbing — leftover branch name, not the topic. Happy to rename if you'd rather see `feature/fetch-dispatcher` on the PR.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — `notioncli/cmd` and `notioncli/utils` both green
- [x] All 11 fetch dispatcher tests pass (page hit, page→db fallback, both-404, malformed input, --json, non-404 surfacing, helpers)
- [x] `ParseNotionID` covers bare hex, dashed UUID, https/no-www/protocol-less URLs, query, fragment, whitespace, uppercase, plus negative paths
- [x] `go run -ldflags "-X main.version=v0.1.0-rc.test" . version` prints the injected tag
- [x] `go run . version --json` emits `{"version":"dev"}`
- [x] Smoke `notioncli fetch <real-url>` against a live page once `NOTION_API_KEY` is in the env
- [ ] Cut a `v0.1.0-rc.1` tag to exercise `.github/workflows/release.yml` end-to-end