### PR TITLE
fix(pages update): typed --property + raw JSON pass-through (closes #51)

### DIFF
--- a/cmd/pages.go
+++ b/cmd/pages.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"notioncli/utils"
@@ -79,10 +80,29 @@ func buildCreateParent(pageID, databaseID string) (utils.PageParent, error) {
 	}
 }
 
-// parseProperty splits "key=value" from the --property flag. Values are sent
-// as plain-text rich_text entries because without a schema lookup we cannot
-// infer the target property type; callers that need typed properties should
-// use the lower-level PageClient.Update with a full Properties map.
+// parseProperty splits "key=value" from the --property flag and emits the
+// Notion property payload that matches the value's intended type. Three
+// forms are accepted, in priority order:
+//
+//  1. Raw JSON object pass-through:
+//     Key={"select":{"name":"Done"}}
+//     Anything starting with `{` is parsed as JSON and used verbatim.
+//     Power-user escape hatch — the caller already knows the wire shape.
+//
+//  2. Type-prefixed shorthand:
+//     Key=<type>:<value>
+//     where <type> is one of: status, select, multi_select, number,
+//     checkbox, date, url, email, phone (alias: phone_number), text,
+//     title. Multi-select splits on commas, date accepts ISO 8601 plus
+//     the `start..end` range form, number parses as float64.
+//
+//  3. Bare value: Key=Value
+//     Falls back to rich_text. Preserves existing scripts that rely on
+//     the historical default.
+//
+// Without this typed surface, every property that isn't title/rich_text
+// (status, select, multi_select, number, date, checkbox, url, email,
+// phone) 400s with "<key> is expected to be <type>" — see issue #51.
 func parseProperty(raw string) (string, map[string]interface{}, error) {
 	idx := strings.Index(raw, "=")
 	if idx < 1 {
@@ -93,6 +113,34 @@ func parseProperty(raw string) (string, map[string]interface{}, error) {
 	if key == "" {
 		return "", nil, fmt.Errorf("invalid --property %q, key is empty", raw)
 	}
+
+	// 1. Raw JSON pass-through. The user already typed a Notion-shaped
+	// payload and just wants it forwarded. We require it to be a JSON
+	// object (not array/string/number) so a bare value of "{}" is the
+	// only ambiguity, which is intentional — empty object is a valid
+	// "clear this property" payload on Notion's side.
+	if strings.HasPrefix(strings.TrimSpace(value), "{") {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(value), &obj); err != nil {
+			return "", nil, fmt.Errorf("invalid --property %q: looks like JSON but failed to parse: %w", raw, err)
+		}
+		return key, obj, nil
+	}
+
+	// 2. Type-prefixed shorthand. Only the first colon is treated as the
+	// separator so values may contain colons (e.g. URLs, ISO times).
+	if pIdx := strings.Index(value, ":"); pIdx > 0 {
+		typ := value[:pIdx]
+		rest := value[pIdx+1:]
+		if payload, ok, err := buildTypedProperty(typ, rest); ok {
+			if err != nil {
+				return "", nil, fmt.Errorf("invalid --property %q: %w", raw, err)
+			}
+			return key, payload, nil
+		}
+	}
+
+	// 3. Bare value → rich_text (back-compat).
 	payload := map[string]interface{}{
 		"rich_text": []map[string]interface{}{
 			{
@@ -102,6 +150,84 @@ func parseProperty(raw string) (string, map[string]interface{}, error) {
 		},
 	}
 	return key, payload, nil
+}
+
+// buildTypedProperty translates a (type, value) pair into the property
+// payload Notion expects. The bool return distinguishes "type is one we
+// handle" (true, with maybe an err for malformed input) from "type
+// prefix didn't match anything we know about" (false, no err) so the
+// caller can fall through to the rich_text default for prefixes that
+// happen to look like type:value but aren't.
+func buildTypedProperty(typ, value string) (map[string]interface{}, bool, error) {
+	switch typ {
+	case "status":
+		return map[string]interface{}{"status": map[string]interface{}{"name": value}}, true, nil
+	case "select":
+		return map[string]interface{}{"select": map[string]interface{}{"name": value}}, true, nil
+	case "multi_select":
+		// Comma-split; trim whitespace around each option name so
+		// "a, b ,c" → ["a","b","c"]. An empty value (multi_select:)
+		// emits an empty list which clears the property on Notion.
+		var items []map[string]interface{}
+		if value != "" {
+			for _, name := range strings.Split(value, ",") {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				items = append(items, map[string]interface{}{"name": name})
+			}
+		}
+		if items == nil {
+			items = []map[string]interface{}{}
+		}
+		return map[string]interface{}{"multi_select": items}, true, nil
+	case "number":
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return nil, true, fmt.Errorf("number value %q is not a valid float: %w", value, err)
+		}
+		return map[string]interface{}{"number": n}, true, nil
+	case "checkbox":
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return nil, true, fmt.Errorf("checkbox value %q is not a boolean (try true/false): %w", value, err)
+		}
+		return map[string]interface{}{"checkbox": b}, true, nil
+	case "date":
+		// ISO 8601 single date or "start..end" range. We don't validate
+		// the date format ourselves — Notion does that server-side and
+		// surfaces a precise error. Empty value clears the property.
+		if value == "" {
+			return map[string]interface{}{"date": nil}, true, nil
+		}
+		if start, end, ok := strings.Cut(value, ".."); ok {
+			return map[string]interface{}{"date": map[string]interface{}{"start": start, "end": end}}, true, nil
+		}
+		return map[string]interface{}{"date": map[string]interface{}{"start": value}}, true, nil
+	case "url":
+		return map[string]interface{}{"url": value}, true, nil
+	case "email":
+		return map[string]interface{}{"email": value}, true, nil
+	case "phone", "phone_number":
+		return map[string]interface{}{"phone_number": value}, true, nil
+	case "text":
+		// Explicit alias for the rich_text default — useful when the
+		// value happens to start with "{" or contain "<known>:" and the
+		// caller wants to force plain-text interpretation.
+		return map[string]interface{}{
+			"rich_text": []map[string]interface{}{
+				{"type": "text", "text": map[string]interface{}{"content": value}},
+			},
+		}, true, nil
+	case "title":
+		return map[string]interface{}{
+			"title": []map[string]interface{}{
+				{"type": "text", "text": map[string]interface{}{"content": value}},
+			},
+		}, true, nil
+	}
+	return nil, false, nil
 }
 
 // pagesGetCmd retrieves a page by ID.
@@ -360,7 +486,21 @@ func init() {
 	pagesCreateCmd.Flags().StringVar(&pagesCreateTitle, "title", "", "Title for the new page")
 
 	pagesUpdateCmd.Flags().StringVar(&pagesUpdateTitle, "title", "", "New title for the page")
-	pagesUpdateCmd.Flags().StringArrayVar(&pagesUpdateProps, "property", nil, "Set a property as key=value (repeatable)")
+	pagesUpdateCmd.Flags().StringArrayVar(&pagesUpdateProps, "property", nil,
+		`Set a property (repeatable). Three forms:
+  Key=Value                        rich_text (back-compat)
+  Key=<type>:<value>               typed: status, select, multi_select,
+                                     number, checkbox, date, url, email,
+                                     phone, text, title
+  Key={"select":{"name":"Done"}}   raw JSON pass-through
+
+Examples:
+  --property "Status=status:Done"
+  --property "Brand=select:FacetInteractive.com"
+  --property "Tags=multi_select:alpha,beta"
+  --property "Count=number:42"
+  --property "Done=checkbox:true"
+  --property "Due=date:2026-05-01..2026-05-08"`)
 
 	pagesMoveCmd.Flags().StringVar(&pagesMoveParent, "parent", "", "New parent page ID (required)")
 

--- a/cmd/pages_test.go
+++ b/cmd/pages_test.go
@@ -153,6 +153,222 @@ func TestPagesParseProperty(t *testing.T) {
 	}
 }
 
+// TestPagesParseProperty_TypedShapes pins the wire shape parseProperty
+// emits for each typed-property prefix. These are the payloads Notion's
+// PATCH /v1/pages/{id} validates against; sending the wrong shape 400s
+// with "<key> is expected to be <type>" — see issue #51.
+func TestPagesParseProperty_TypedShapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantKey   string
+		wantValue map[string]interface{}
+	}{
+		{
+			name:    "status",
+			input:   "Status=status:In Progress",
+			wantKey: "Status",
+			wantValue: map[string]interface{}{
+				"status": map[string]interface{}{"name": "In Progress"},
+			},
+		},
+		{
+			name:    "select",
+			input:   "Brand=select:FacetInteractive.com",
+			wantKey: "Brand",
+			wantValue: map[string]interface{}{
+				"select": map[string]interface{}{"name": "FacetInteractive.com"},
+			},
+		},
+		{
+			name:    "multi_select with whitespace",
+			input:   "Tags=multi_select:alpha, beta ,gamma",
+			wantKey: "Tags",
+			wantValue: map[string]interface{}{
+				"multi_select": []map[string]interface{}{
+					{"name": "alpha"},
+					{"name": "beta"},
+					{"name": "gamma"},
+				},
+			},
+		},
+		{
+			name:    "multi_select empty clears",
+			input:   "Tags=multi_select:",
+			wantKey: "Tags",
+			wantValue: map[string]interface{}{
+				"multi_select": []map[string]interface{}{},
+			},
+		},
+		{
+			name:      "number",
+			input:     "Count=number:42.5",
+			wantKey:   "Count",
+			wantValue: map[string]interface{}{"number": 42.5},
+		},
+		{
+			name:      "checkbox true",
+			input:     "Done=checkbox:true",
+			wantKey:   "Done",
+			wantValue: map[string]interface{}{"checkbox": true},
+		},
+		{
+			name:      "checkbox false",
+			input:     "Done=checkbox:false",
+			wantKey:   "Done",
+			wantValue: map[string]interface{}{"checkbox": false},
+		},
+		{
+			name:    "date single",
+			input:   "Due=date:2026-05-01",
+			wantKey: "Due",
+			wantValue: map[string]interface{}{
+				"date": map[string]interface{}{"start": "2026-05-01"},
+			},
+		},
+		{
+			name:    "date range",
+			input:   "Due=date:2026-05-01..2026-05-08",
+			wantKey: "Due",
+			wantValue: map[string]interface{}{
+				"date": map[string]interface{}{"start": "2026-05-01", "end": "2026-05-08"},
+			},
+		},
+		{
+			name:      "url with colons in value",
+			input:     "Site=url:https://notion.so/abc",
+			wantKey:   "Site",
+			wantValue: map[string]interface{}{"url": "https://notion.so/abc"},
+		},
+		{
+			name:      "email",
+			input:     "Contact=email:hi@example.com",
+			wantKey:   "Contact",
+			wantValue: map[string]interface{}{"email": "hi@example.com"},
+		},
+		{
+			name:      "phone alias",
+			input:     "Cell=phone:+1-555-0100",
+			wantKey:   "Cell",
+			wantValue: map[string]interface{}{"phone_number": "+1-555-0100"},
+		},
+		{
+			name:      "phone_number canonical",
+			input:     "Cell=phone_number:+1-555-0100",
+			wantKey:   "Cell",
+			wantValue: map[string]interface{}{"phone_number": "+1-555-0100"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, val, err := parseProperty(tt.input)
+			if err != nil {
+				t.Fatalf("parseProperty(%q): %v", tt.input, err)
+			}
+			if key != tt.wantKey {
+				t.Errorf("key = %q, want %q", key, tt.wantKey)
+			}
+			if !propertyEqual(val, tt.wantValue) {
+				t.Errorf("payload mismatch:\n got: %#v\nwant: %#v", val, tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestPagesParseProperty_RawJSONPassthrough confirms a JSON object
+// value is forwarded verbatim. This is the power-user escape hatch for
+// property shapes the typed prefixes don't cover (relations, people,
+// files, formula targets, rollup overrides, etc.).
+func TestPagesParseProperty_RawJSONPassthrough(t *testing.T) {
+	key, val, err := parseProperty(`Status={"select":{"name":"Done"}}`)
+	if err != nil {
+		t.Fatalf("parseProperty: %v", err)
+	}
+	if key != "Status" {
+		t.Errorf("key = %q, want Status", key)
+	}
+	want := map[string]interface{}{"select": map[string]interface{}{"name": "Done"}}
+	if !propertyEqual(val, want) {
+		t.Errorf("payload mismatch:\n got: %#v\nwant: %#v", val, want)
+	}
+}
+
+// TestPagesParseProperty_BareValueFallsBackToRichText guarantees
+// scripts that have always passed `Key=Value` keep working — the bare
+// form still serialises as rich_text.
+func TestPagesParseProperty_BareValueFallsBackToRichText(t *testing.T) {
+	_, val, err := parseProperty("Note=hello world")
+	if err != nil {
+		t.Fatalf("parseProperty: %v", err)
+	}
+	rt, ok := val["rich_text"].([]map[string]interface{})
+	if !ok || len(rt) != 1 {
+		t.Fatalf("expected rich_text slice with one segment, got %#v", val)
+	}
+	text, _ := rt[0]["text"].(map[string]interface{})
+	if text["content"] != "hello world" {
+		t.Errorf("rich_text content = %v, want 'hello world'", text["content"])
+	}
+}
+
+// TestPagesParseProperty_TypedErrors covers the malformed-input paths
+// for the typed prefixes (number/checkbox/JSON).
+func TestPagesParseProperty_TypedErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantSub string
+	}{
+		{"bad number", "Count=number:not-a-number", "not a valid float"},
+		{"bad checkbox", "Done=checkbox:maybe", "not a boolean"},
+		{"bad json", `X={not valid json`, "failed to parse"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseProperty(tc.input)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestPagesParseProperty_UnknownPrefixFallsThrough confirms that a
+// value of "weird:foo" (where "weird" isn't a known type prefix) is
+// treated as bare rich_text rather than erroring — preserves
+// back-compat for legacy values that happen to contain a colon.
+func TestPagesParseProperty_UnknownPrefixFallsThrough(t *testing.T) {
+	_, val, err := parseProperty("Note=weird:foo")
+	if err != nil {
+		t.Fatalf("parseProperty: %v", err)
+	}
+	rt, ok := val["rich_text"].([]map[string]interface{})
+	if !ok || len(rt) != 1 {
+		t.Fatalf("expected rich_text fallback, got %#v", val)
+	}
+	text, _ := rt[0]["text"].(map[string]interface{})
+	if text["content"] != "weird:foo" {
+		t.Errorf("rich_text content = %v, want 'weird:foo' verbatim", text["content"])
+	}
+}
+
+// propertyEqual is a recursive comparator that handles the loose
+// map[string]interface{} shapes parseProperty emits. reflect.DeepEqual
+// would work, but it treats []map vs []interface{} as unequal; the
+// helper normalises both sides before comparing.
+func propertyEqual(a, b map[string]interface{}) bool {
+	aj, errA := json.Marshal(a)
+	bj, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return string(aj) == string(bj)
+}
+
 // pagesDispatchServer swaps the cmd-layer mock with a pages-aware handler.
 // It returns a counter map keyed by method+path, the most recent request
 // body for each (method+path), and a close func. Body capture lets tests


### PR DESCRIPTION
## Summary

\`pages update --property\` 400'd against every Notion property type that isn't \`title\` or \`rich_text\` — the serialiser always wrapped the value as rich_text regardless of the destination column. Status, Select, Multi-Select, Number, Date, Checkbox, URL, Email, Phone all reproduced the same \`<key> is expected to be <type>\` error. Reproduced live against Status and Brand (#51).

\`parseProperty\` now accepts three forms, in priority order:

| Form | Example | Wire payload |
|---|---|---|
| Raw JSON object | \`Status={\"select\":{\"name\":\"Done\"}}\` | Forwarded verbatim |
| Typed shorthand | \`Status=status:Done\` | \`{\"status\":{\"name\":\"Done\"}}\` |
| Bare value (back-compat) | \`Note=hello world\` | rich_text |

Type prefixes: \`status\`, \`select\`, \`multi_select\` (comma-split), \`number\`, \`checkbox\`, \`date\` (ISO 8601 single or \`start..end\` range), \`url\`, \`email\`, \`phone\` (alias: \`phone_number\`), \`text\`, \`title\`. Unknown prefixes fall through to rich_text so legacy values containing a colon still work.

Help text on \`--property\` gets a worked-examples block.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test -race ./...\` green
- [x] 28 new test cases cover every typed shape, raw-JSON pass-through, bare-value fallback, malformed-input errors, and unknown-prefix fall-through
- [ ] Live smoke against the real Status property that prompted #51

## Examples that previously 400'd

\`\`\`bash
notioncli pages update <id> --property \"Status=status:Done\"
notioncli pages update <id> --property \"Brand=select:FacetInteractive.com\"
notioncli pages update <id> --property \"Tags=multi_select:alpha,beta\"
notioncli pages update <id> --property \"Count=number:42\"
notioncli pages update <id> --property \"Done=checkbox:true\"
notioncli pages update <id> --property \"Due=date:2026-05-01..2026-05-08\"
\`\`\`

Closes #51.