### PR TITLE
fix(todo): check/uncheck/delete index to-dos like list does (closes #55)

### DIFF
--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -133,18 +133,43 @@ func (b *BlockClient) GetBlockID(ctx context.Context, pageID string, order int) 
 	return blockList.Results[order-1].ID, nil
 }
 
-// MarkToDoBlockChecked flips the to-do at the given index to checked=true.
+// MarkToDoBlockChecked flips the to-do at the given 1-based to-do
+// ordinal to checked=true. The ordinal is into the to-do-only subset
+// (matching `notioncli list`), not the absolute block list — see #55.
 func (b *BlockClient) MarkToDoBlockChecked(ctx context.Context, pageID string, order int) error {
 	return b.setToDoChecked(ctx, pageID, order, true)
 }
 
-// MarkToDoBlockUnChecked flips the to-do at the given index to checked=false.
+// MarkToDoBlockUnChecked flips the to-do at the given 1-based to-do
+// ordinal to checked=false. Same numbering as MarkToDoBlockChecked.
 func (b *BlockClient) MarkToDoBlockUnChecked(ctx context.Context, pageID string, order int) error {
 	return b.setToDoChecked(ctx, pageID, order, false)
 }
 
+// resolveToDoBlockID translates a 1-based to-do ordinal (the same
+// numbering `notioncli list` prints) into the underlying Notion block
+// id by fetching only the page's to-do blocks. Centralising this here
+// keeps check/uncheck/delete in lockstep — every to-do command must
+// see the same numbering as `list`. Closes #55.
+func (b *BlockClient) resolveToDoBlockID(ctx context.Context, pageID string, order int) (string, error) {
+	if order < 1 {
+		return "", fmt.Errorf("order must be greater than 0")
+	}
+	todos, err := b.GetAllBlocks(ctx, pageID, "to_do")
+	if err != nil {
+		return "", err
+	}
+	if len(todos) == 0 {
+		return "", fmt.Errorf("no to-do blocks on this page")
+	}
+	if order > len(todos) {
+		return "", fmt.Errorf("no to-do block at position %d (page has %d to-do block(s))", order, len(todos))
+	}
+	return todos[order-1].ID, nil
+}
+
 func (b *BlockClient) setToDoChecked(ctx context.Context, pageID string, order int, checked bool) error {
-	blockID, err := b.GetBlockID(ctx, pageID, order)
+	blockID, err := b.resolveToDoBlockID(ctx, pageID, order)
 	if err != nil {
 		return err
 	}
@@ -164,9 +189,11 @@ func (b *BlockClient) setToDoChecked(ctx context.Context, pageID string, order i
 	return expectStatus(resp, http.StatusOK)
 }
 
-// DeleteToDoBlock removes the to-do at the given 1-based index.
+// DeleteToDoBlock removes the to-do at the given 1-based to-do ordinal.
+// Indexing matches `notioncli list` — see #55. Use BlockClient.DeleteBlock
+// for absolute-index deletes (the path `notioncli blocks delete` takes).
 func (b *BlockClient) DeleteToDoBlock(ctx context.Context, pageID string, order int) error {
-	blockID, err := b.GetBlockID(ctx, pageID, order)
+	blockID, err := b.resolveToDoBlockID(ctx, pageID, order)
 	if err != nil {
 		return err
 	}

--- a/utils/blocks_todo_index_test.go
+++ b/utils/blocks_todo_index_test.go
@@ -1,0 +1,221 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestToDoIndex_MatchesListNumbering pins the central contract for #55:
+// MarkToDoBlockChecked / MarkToDoBlockUnChecked / DeleteToDoBlock all
+// number to-do blocks the way `notioncli list` numbers them — the 1-based
+// ordinal into the to-do-only subset, NOT the absolute block index.
+//
+// Fixture: a mixed-block page where to-dos are at absolute positions
+// 2, 4, 6 and to-do ordinals 1, 2, 3. Asking for to-do #2 must hit the
+// block at absolute position 4 ("middle todo"), not absolute position 2
+// ("heading"). The pre-fix code would have hit the heading and either
+// silently no-op'd or 400'd because heading blocks have no .to_do field.
+func TestToDoIndex_MatchesListNumbering(t *testing.T) {
+	cases := []struct {
+		name string
+		// op is the operation under test; it returns an error so the
+		// table-driven runner can fail with the per-op message.
+		op func(ctx context.Context, c *BlockClient, pageID string, order int) error
+		// wantMethod is the HTTP method the op should issue against the
+		// resolved block id. PATCH for check/uncheck, DELETE for delete.
+		wantMethod string
+	}{
+		{
+			name: "MarkToDoBlockChecked",
+			op: func(ctx context.Context, c *BlockClient, p string, n int) error {
+				return c.MarkToDoBlockChecked(ctx, p, n)
+			},
+			wantMethod: http.MethodPatch,
+		},
+		{
+			name: "MarkToDoBlockUnChecked",
+			op: func(ctx context.Context, c *BlockClient, p string, n int) error {
+				return c.MarkToDoBlockUnChecked(ctx, p, n)
+			},
+			wantMethod: http.MethodPatch,
+		},
+		{
+			name:       "DeleteToDoBlock",
+			op:         func(ctx context.Context, c *BlockClient, p string, n int) error { return c.DeleteToDoBlock(ctx, p, n) },
+			wantMethod: http.MethodDelete,
+		},
+	}
+
+	// Each ordinal maps to the to-do block id we expect the op to hit.
+	// Absolute layout: [paragraph, to_do(td1), heading, to_do(td2),
+	// divider, to_do(td3)]. So ordinal 1 → td1, 2 → td2, 3 → td3.
+	wantByOrdinal := map[int]string{1: "td1", 2: "td2", 3: "td3"}
+
+	for _, tc := range cases {
+		for ordinal, wantID := range wantByOrdinal {
+			t.Run(tc.name+"/ordinal_"+itoa(ordinal), func(t *testing.T) {
+				srv, captured := newMixedTodoServer(t)
+				defer srv.Close()
+				prev := baseURL
+				SetBaseURL(srv.URL)
+				defer SetBaseURL(prev)
+
+				c := NewBlockClient(NewClient("k", WithBaseURL(srv.URL)))
+				if err := tc.op(context.Background(), c, "mixedTodoPage", ordinal); err != nil {
+					t.Fatalf("%s(ordinal=%d): %v", tc.name, ordinal, err)
+				}
+				gotMethod, gotID := captured()
+				if gotMethod != tc.wantMethod {
+					t.Errorf("HTTP method = %q, want %q", gotMethod, tc.wantMethod)
+				}
+				if gotID != wantID {
+					t.Errorf("hit block id %q for ordinal %d, want %q (ordinal must index to-dos only, not absolute blocks)", gotID, ordinal, wantID)
+				}
+			})
+		}
+	}
+}
+
+// TestToDoIndex_ZeroToDosErrors asserts that calling check/uncheck/delete
+// on a page with no to-do blocks surfaces a clear error before any
+// mutation, instead of silently no-op'ing or 400-ing on a non-to_do
+// block.
+func TestToDoIndex_ZeroToDosErrors(t *testing.T) {
+	srv, _ := newMixedTodoServer(t)
+	defer srv.Close()
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	defer SetBaseURL(prev)
+
+	c := NewBlockClient(NewClient("k", WithBaseURL(srv.URL)))
+
+	for _, op := range []struct {
+		name string
+		fn   func() error
+	}{
+		{"check", func() error { return c.MarkToDoBlockChecked(context.Background(), "noTodosPage", 1) }},
+		{"uncheck", func() error { return c.MarkToDoBlockUnChecked(context.Background(), "noTodosPage", 1) }},
+		{"delete", func() error { return c.DeleteToDoBlock(context.Background(), "noTodosPage", 1) }},
+	} {
+		t.Run(op.name, func(t *testing.T) {
+			err := op.fn()
+			if err == nil {
+				t.Fatal("expected error on zero-todo page, got nil")
+			}
+			if !strings.Contains(err.Error(), "no to-do") {
+				t.Errorf("err = %v, want substring 'no to-do'", err)
+			}
+		})
+	}
+}
+
+// TestToDoIndex_OutOfRangeNamesToDoCount asserts the error message when
+// the requested ordinal exceeds the to-do count cites the to-do count,
+// not the total-block count, so users have a useful number to act on.
+func TestToDoIndex_OutOfRangeNamesToDoCount(t *testing.T) {
+	srv, _ := newMixedTodoServer(t)
+	defer srv.Close()
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	defer SetBaseURL(prev)
+
+	c := NewBlockClient(NewClient("k", WithBaseURL(srv.URL)))
+	err := c.MarkToDoBlockChecked(context.Background(), "mixedTodoPage", 99)
+	if err == nil {
+		t.Fatal("expected error on out-of-range ordinal, got nil")
+	}
+	// Page has 3 to-dos (and 6 total blocks). Error must cite 3, not 6.
+	if !strings.Contains(err.Error(), "3 to-do block") {
+		t.Errorf("err = %v, want substring '3 to-do block'", err)
+	}
+}
+
+// newMixedTodoServer wires an httptest server with two fixture pages:
+//
+//   - mixedTodoPage: 6 blocks alternating paragraph/heading/divider with
+//     to-dos at absolute positions 2, 4, 6 (to-do ordinals 1, 2, 3).
+//   - noTodosPage:   3 non-to-do blocks (paragraph, heading, divider).
+//
+// Returns a thunk that captures the (method, blockID) of the last write
+// against /blocks/{id} so tests can assert which block was actually hit.
+func newMixedTodoServer(t *testing.T) (*httptest.Server, func() (string, string)) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var lastMethod, lastBlockID string
+
+	mixed := []Block{
+		{Object: "block", ID: "p1", Type: "paragraph", Paragraph: &RichTextBlock{RichText: []RichText{{PlainText: "intro"}}}},
+		{Object: "block", ID: "td1", Type: "to_do", ToDo: &ToDo{Checked: false, RichText: []RichText{{PlainText: "first"}}}},
+		{Object: "block", ID: "h1", Type: "heading_1", Heading1: &RichTextBlock{RichText: []RichText{{PlainText: "Section"}}}},
+		{Object: "block", ID: "td2", Type: "to_do", ToDo: &ToDo{Checked: false, RichText: []RichText{{PlainText: "middle"}}}},
+		{Object: "block", ID: "d1", Type: "divider", Divider: &struct{}{}},
+		{Object: "block", ID: "td3", Type: "to_do", ToDo: &ToDo{Checked: true, RichText: []RichText{{PlainText: "last"}}}},
+	}
+	noTodos := []Block{
+		{Object: "block", ID: "p1", Type: "paragraph", Paragraph: &RichTextBlock{RichText: []RichText{{PlainText: "x"}}}},
+		{Object: "block", ID: "h1", Type: "heading_1", Heading1: &RichTextBlock{RichText: []RichText{{PlainText: "y"}}}},
+		{Object: "block", ID: "d1", Type: "divider", Divider: &struct{}{}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/blocks/mixedTodoPage/children":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(BlockList{Results: mixed})
+		case r.Method == http.MethodGet && r.URL.Path == "/blocks/noTodosPage/children":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(BlockList{Results: noTodos})
+		case strings.HasPrefix(r.URL.Path, "/blocks/") && (r.Method == http.MethodPatch || r.Method == http.MethodDelete):
+			id := strings.TrimPrefix(r.URL.Path, "/blocks/")
+			mu.Lock()
+			lastMethod = r.Method
+			lastBlockID = id
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, func() (string, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		return lastMethod, lastBlockID
+	}
+}
+
+// itoa is a tiny dependency-free int→string helper so subtest names don't
+// pull in strconv just for one call.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}


### PR DESCRIPTION
## Summary

\`notioncli list\` numbered to-do blocks 1-based into the **to-do-only subset**, but \`check N\` / \`uncheck N\` / \`delete N\` walked the **absolute** block list. On any mixed-block page the indices drifted — \`check 2\` could land on a heading or paragraph and either silently no-op or 400 with \"block has no to_do field.\" Reproduced live (#55).

## Fix

Centralised the to-do resolution in \`BlockClient.resolveToDoBlockID\`, which fetches via \`GetAllBlocks(ctx, pageID, \"to_do\")\` and indexes the filtered slice — exactly what \`list\` does. \`setToDoChecked\` and \`DeleteToDoBlock\` now route through it.

| Command | Before | After |
|---|---|---|
| \`notioncli check N\` | absolute block #N | N-th to-do (matches \`list\`) |
| \`notioncli uncheck N\` | absolute block #N | N-th to-do |
| \`notioncli delete N\` (top-level) | absolute block #N | N-th to-do |
| \`notioncli blocks delete N\` | absolute block #N | absolute block #N (unchanged — correct against \`blocks list\`) |

\`BlockClient.GetBlockID\` and \`BlockClient.DeleteBlock\` are unchanged — those serve \`notioncli blocks delete N\` which correctly operates on absolute indices matching \`notioncli blocks list\`.

## Better error messages

- Out-of-range now cites the to-do count: \`no to-do block at position N (page has M to-do block(s))\` — was citing total-block count
- Zero-to-do page: \`no to-do blocks on this page\` — was returning an opaque API error after PATCHing the wrong block

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test -race ./...\` green
- [x] 13 new cases on a fixture mixed-block page \`[paragraph, to_do, heading, to_do, divider, to_do]\` — to-dos at absolute 2/4/6, ordinals 1/2/3. Tests assert that \`check\`/\`uncheck\`/\`delete\` ordinal N hits \`tdN\`, not the absolute-N block. Pre-fix code would have hit p1/h1/d1 for ordinals 1/2/3.
- [x] Zero-to-do page (paragraph + heading + divider only): every op surfaces \"no to-do\" error before any mutation
- [x] Out-of-range ordinal error message cites to-do count, not total-block count
- [ ] Live smoke against the page from #55 once merged