### PR TITLE
fix(annotations): omit empty color so comments create works on 2026-03-11 (closes #49)

### DIFF
--- a/utils/block.go
+++ b/utils/block.go
@@ -185,10 +185,20 @@ type RichText struct {
 }
 
 // Annotation captures the Notion text-run annotation flags.
+//
+// Color carries the `,omitempty` tag because Notion-Version 2026-03-11
+// rejects `"color": ""` outright — the field must be one of the named
+// colors (default/gray/brown/...) or absent. The Go zero value is the
+// empty string, so without omitempty every payload that doesn't
+// explicitly set a color (including the comments-create path that
+// builds rich_text from a plain --text flag) 400s with
+// `body.rich_text[0].annotations.color should be "default", ... or undefined`.
+// The bool fields remain present-with-false because Notion accepts
+// false on each of them. See issue #49.
 type Annotation struct {
 	Bold          bool   `json:"bold"`
 	Code          bool   `json:"code"`
-	Color         string `json:"color"`
+	Color         string `json:"color,omitempty"`
 	Italic        bool   `json:"italic"`
 	Strikethrough bool   `json:"strikethrough"`
 	Underline     bool   `json:"underline"`

--- a/utils/comments_test.go
+++ b/utils/comments_test.go
@@ -295,6 +295,63 @@ func TestCommentClientCreate_TopLevelPageID(t *testing.T) {
 	}
 }
 
+// TestCommentClientCreate_OmitsEmptyAnnotationColor pins the wire shape
+// for #49: when callers build a rich_text run via NewCommentRichText (or
+// any other zero-Annotation path), the JSON body must NOT include a
+// `color` field. Notion-Version 2026-03-11 rejects `"color": ""` with
+// `body.rich_text[0].annotations.color should be "default", ... or undefined`.
+// The fix is `,omitempty` on Annotation.Color; this test guards against
+// a future revert that drops the tag.
+func TestCommentClientCreate_OmitsEmptyAnnotationColor(t *testing.T) {
+	m := newCommentsMock(t)
+	cc := newCommentClientForTest(m.srv.URL)
+
+	req := CreateCommentRequest{
+		Parent:   &CommentParent{PageID: "page-123"},
+		RichText: NewCommentRichText("hello"),
+	}
+	if _, err := cc.Create(context.Background(), req); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	body := string(m.lastCreateBody)
+	// The empty-string color is the exact byte sequence Notion 400s on.
+	// Match the substring rather than parsing JSON so the assertion is
+	// scoped to the wire form, not just the decoded shape.
+	if strings.Contains(body, `"color":""`) {
+		t.Errorf("comments create body must not include empty color field — Notion 2026-03-11 rejects it. body=%s", body)
+	}
+	// Sanity: the bool annotation flags are still expected (Notion
+	// accepts them as false). If they ever get omitempty too, this
+	// assertion would catch a wider behavior change.
+	if !strings.Contains(body, `"bold":false`) {
+		t.Errorf("comments create body should still include bold=false. body=%s", body)
+	}
+}
+
+// TestCommentClientCreate_PreservesNonDefaultColor confirms that callers
+// who DO set a color (e.g. mention runs that round-trip through
+// CommentClient) still get the field on the wire.
+func TestCommentClientCreate_PreservesNonDefaultColor(t *testing.T) {
+	m := newCommentsMock(t)
+	cc := newCommentClientForTest(m.srv.URL)
+
+	rt := NewCommentRichText("hello")
+	rt[0].Annotations.Color = "red"
+
+	req := CreateCommentRequest{
+		Parent:   &CommentParent{PageID: "page-123"},
+		RichText: rt,
+	}
+	if _, err := cc.Create(context.Background(), req); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	body := string(m.lastCreateBody)
+	if !strings.Contains(body, `"color":"red"`) {
+		t.Errorf("non-empty color should still serialise. body=%s", body)
+	}
+}
+
 func TestCommentClientCreate_TopLevelBlockID(t *testing.T) {
 	m := newCommentsMock(t)
 	cc := newCommentClientForTest(m.srv.URL)


### PR DESCRIPTION
## Summary

\`comments create\` 400'd on every invocation under Notion-Version 2026-03-11:

\`\`\`
body.rich_text[0].annotations.color should be \"default\", \"gray\", ... or \"undefined\", instead was \"\".
\`\`\`

\`Annotation.Color\` had \`json:\"color\"\` (no omitempty). Go's zero value is \`\"\"\`, so the field always serialised — and 2026-03-11 rejects empty-string color outright.

## Fix

One-line tag change: \`json:\"color,omitempty\"\`. The bool fields keep their existing tags because Notion accepts \`false\` on each.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test -race ./...\` green (existing 200+ tests + 2 new)
- [x] New: \`TestCommentClientCreate_OmitsEmptyAnnotationColor\` — asserts the wire body never contains \`\"color\":\"\"\` for default-annotation runs
- [x] New: \`TestCommentClientCreate_PreservesNonDefaultColor\` — non-empty color still serialises
- [ ] Live smoke: \`notioncli comments create <page-id> --text \"hi\"\` against a real workspace

Closes #49.