### PR TITLE
fix(utils): defensive guards on SearchClient/CommentClient + Duplicate empty-children (closes #54)

### DIFF
--- a/utils/comments.go
+++ b/utils/comments.go
@@ -72,6 +72,17 @@ func NewCommentClient(c *Client) *CommentClient {
 	return &CommentClient{c: c}
 }
 
+// checkAuth mirrors the guard pattern used by every other typed client
+// (PageClient/UserClient/TeamClient/etc.). Maps a nil receiver, nil
+// underlying *Client, or empty API key to ErrMissingAPIKey instead of a
+// runtime panic or an opaque server-side 401. See issue #54.
+func (cc *CommentClient) checkAuth() error {
+	if cc == nil || cc.c == nil || cc.c.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	return nil
+}
+
 // ListPage fetches a single page of comments for the given block or page id.
 // Pass an empty cursor to start from the first page; subsequent calls should
 // use the NextCursor value from the previous response.
@@ -79,6 +90,9 @@ func NewCommentClient(c *Client) *CommentClient {
 // Callers who want every comment in one call should use List, which handles
 // pagination internally.
 func (cc *CommentClient) ListPage(ctx context.Context, blockID, cursor string) (*CommentList, error) {
+	if err := cc.checkAuth(); err != nil {
+		return nil, fmt.Errorf("comments list: %w", err)
+	}
 	if blockID == "" {
 		return nil, fmt.Errorf("comments list: block id is required")
 	}
@@ -139,6 +153,9 @@ func (cc *CommentClient) List(ctx context.Context, blockID string) ([]Comment, e
 // Requests with neither or both are rejected client-side before the API
 // call so the failure mode is predictable and testable without network.
 func (cc *CommentClient) Create(ctx context.Context, req CreateCommentRequest) (*Comment, error) {
+	if err := cc.checkAuth(); err != nil {
+		return nil, fmt.Errorf("comments create: %w", err)
+	}
 	if err := validateCreateCommentRequest(req); err != nil {
 		return nil, err
 	}

--- a/utils/comments_test.go
+++ b/utils/comments_test.go
@@ -3,12 +3,44 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+// TestCommentClient_MissingAPIKey verifies List/ListPage/Create surface
+// ErrMissingAPIKey instead of panicking on nil client or falling through
+// to a remote 401. Closes the CommentClient half of #54.
+func TestCommentClient_MissingAPIKey(t *testing.T) {
+	client := NewCommentClient(NewClient("", WithBaseURL("http://127.0.0.1:0")))
+
+	if _, err := client.List(context.Background(), "block-id"); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("List: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	if _, err := client.ListPage(context.Background(), "block-id", ""); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("ListPage: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	req := CreateCommentRequest{Parent: &CommentParent{PageID: "p"}, RichText: NewCommentRichText("hi")}
+	if _, err := client.Create(context.Background(), req); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Create: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+}
+
+// TestCommentClient_NilClientNoPanic confirms NewCommentClient(nil) does
+// not panic on first call.
+func TestCommentClient_NilClientNoPanic(t *testing.T) {
+	client := NewCommentClient(nil)
+	if _, err := client.List(context.Background(), "block-id"); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("List(nil client): err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	req := CreateCommentRequest{Parent: &CommentParent{PageID: "p"}, RichText: NewCommentRichText("hi")}
+	if _, err := client.Create(context.Background(), req); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Create(nil client): err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+}
 
 // commentsMock is a dedicated httptest server for the comments endpoints.
 // It keeps per-test call counts so tests can assert pagination actually

--- a/utils/pages.go
+++ b/utils/pages.go
@@ -330,6 +330,16 @@ func (p *PageClient) Duplicate(ctx context.Context, srcID, parentID string) (*Pa
 	}
 
 	children := blocksToChildren(blocks)
+	// Filter pass: blocksToChildren can return an empty slice when every
+	// source block is a type rebuildBlock drops (image/file/child_database
+	// today). Without this guard the next step PATCHes /blocks/{id}/children
+	// with `children: []`, which Notion rejects — the destination page is
+	// already created at that point, leaving an empty orphan. Closes the
+	// edge case from #54. Treat empty-after-filter the same as zero source
+	// blocks: hand back the new page with just the title.
+	if len(children) == 0 {
+		return newPage, nil
+	}
 	body := map[string]interface{}{"children": children}
 	req, err := p.c.newRequest(ctx, http.MethodPatch, "/blocks/"+newPage.ID+"/children", body)
 	if err != nil {

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -475,6 +475,51 @@ func TestDuplicate_CallSequence(t *testing.T) {
 	}
 }
 
+// TestDuplicate_AllBlocksFilteredOut covers the edge case where the
+// source page has blocks but every block type is dropped by rebuildBlock
+// (image/file/video/embed/bookmark/equation/child_database etc.). Without
+// the empty-after-filter fast path, blocksToChildren would yield [] and
+// the next PATCH would hit /blocks/{newID}/children with `children: []`,
+// which Notion rejects — leaving an empty destination page behind.
+// Closes the Duplicate edge case from #54.
+func TestDuplicate_AllBlocksFilteredOut(t *testing.T) {
+	var sawChildrenPatch int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/pages/"):
+			writeJSONPage(w, strings.TrimPrefix(r.URL.Path, "/pages/"), false, "Image-only page")
+		case r.Method == http.MethodPost && r.URL.Path == "/pages":
+			writeJSONPage(w, "newPageID", false, "Image-only page")
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/children"):
+			// Source has only block types rebuildBlock drops.
+			_ = json.NewEncoder(w).Encode(BlockList{Results: []Block{
+				{Object: "block", ID: "i1", Type: "image"},
+				{Object: "block", ID: "f1", Type: "file"},
+				{Object: "block", ID: "v1", Type: "video"},
+			}})
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/children"):
+			atomic.AddInt64(&sawChildrenPatch, 1)
+			http.Error(w, `{"object":"error","status":400,"code":"validation_error","message":"Body should have at least 1 child"}`, http.StatusBadRequest)
+		default:
+			http.Error(w, `{"code":"not_found"}`, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	pc := NewPageClient(NewClient("sk_test", WithBaseURL(srv.URL)))
+	newPage, err := pc.Duplicate(context.Background(), "srcID", "parentID")
+	if err != nil {
+		t.Fatalf("Duplicate (all-filtered source): %v — should have skipped the empty-children PATCH", err)
+	}
+	if newPage == nil || newPage.ID != "newPageID" {
+		t.Errorf("expected newPageID returned with title only; got %+v", newPage)
+	}
+	if got := atomic.LoadInt64(&sawChildrenPatch); got != 0 {
+		t.Errorf("Duplicate sent %d children PATCH(es); want 0 (empty filter result must not hit /children)", got)
+	}
+}
+
 func TestDuplicate_EmptyArgs(t *testing.T) {
 	m := newPagesMockServer(t)
 	pc := NewPageClient(m.client())

--- a/utils/search.go
+++ b/utils/search.go
@@ -130,10 +130,26 @@ type SearchResponse struct {
 	HasMore    bool           `json:"has_more"`
 }
 
+// checkAuth mirrors the guard pattern used by every other typed client
+// (PageClient/UserClient/TeamClient/etc.). It maps a nil receiver, nil
+// underlying *Client, or empty API key to ErrMissingAPIKey instead of a
+// runtime panic or an opaque server-side 401. Library callers that wire
+// SearchClient through a test seam (NewSearchClient(nil)) get a typed
+// error rather than a deref panic. See issue #54.
+func (s *SearchClient) checkAuth() error {
+	if s == nil || s.c == nil || s.c.apiKey == "" {
+		return ErrMissingAPIKey
+	}
+	return nil
+}
+
 // Search performs a single POST /v1/search call and returns the immediate
 // page of results. Callers that need to walk every page should use
 // SearchAll, which handles cursor pagination.
 func (s *SearchClient) Search(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
+	if err := s.checkAuth(); err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
 	httpReq, err := s.c.newRequest(ctx, http.MethodPost, "/search", req)
 	if err != nil {
 		return nil, err

--- a/utils/search_test.go
+++ b/utils/search_test.go
@@ -3,12 +3,37 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+// TestSearchClient_MissingAPIKey verifies Search/SearchAll surface
+// ErrMissingAPIKey instead of panicking on a nil client or falling
+// through to an opaque 401 from Notion. Mirrors the contract on
+// PageClient/UserClient/TeamClient. Regression guard for #54.
+func TestSearchClient_MissingAPIKey(t *testing.T) {
+	client := NewSearchClient(NewClient("", WithBaseURL("http://127.0.0.1:0")))
+	if _, err := client.Search(context.Background(), SearchRequest{Query: "x"}); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Search: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+	if _, err := client.SearchAll(context.Background(), SearchRequest{Query: "x"}, 10); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("SearchAll: err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+}
+
+// TestSearchClient_NilClientNoPanic confirms NewSearchClient(nil) does
+// not panic on first call — library callers wiring through a test seam
+// get a typed error.
+func TestSearchClient_NilClientNoPanic(t *testing.T) {
+	client := NewSearchClient(nil)
+	if _, err := client.Search(context.Background(), SearchRequest{}); !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("Search(nil client): err = %v, want errors.Is ErrMissingAPIKey", err)
+	}
+}
 
 // newSearchMock returns an httptest server that handles POST /search, with
 // behavior driven by the query field of the request body. This mirrors the


### PR DESCRIPTION
## Summary

Three small mechanical fixes from the Codex review of PR #56, all in #54:

### 1. \`SearchClient.checkAuth\`
\`Search\` and \`SearchAll\` were the last network-issuing typed-client methods that didn't validate auth before dereferencing \`s.c\`. Library callers wiring \`NewSearchClient(nil)\` panicked on first call; an empty \`NOTION_API_KEY\` produced an opaque 401 instead of \`ErrMissingAPIKey\`. Mirrors the guard pattern \`PageClient\`/\`UserClient\`/\`TeamClient\` already use.

### 2. \`CommentClient.checkAuth\`
Same treatment on \`ListPage\` and \`Create\`. \`List\` is covered transitively because it routes through \`ListPage\`.

### 3. Duplicate empty-children fast path
When the source page contains **only** block types \`rebuildBlock\` drops (image/file/video/embed/bookmark/equation/child_database), \`blocksToChildren\` yields \`[]\`. Previously the destination page was created and then the next PATCH hit \`/blocks/{newID}/children\` with \`children: []\`, which Notion rejects — leaving an empty orphan page behind. Now treats empty-after-filter the same as zero source blocks: returns the new page with just the title.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] New: \`TestSearchClient_MissingAPIKey\` (Search + SearchAll)
- [x] New: \`TestSearchClient_NilClientNoPanic\`
- [x] New: \`TestCommentClient_MissingAPIKey\` (List + ListPage + Create)
- [x] New: \`TestCommentClient_NilClientNoPanic\`
- [x] New: \`TestDuplicate_AllBlocksFilteredOut\` — image-only source page, asserts the empty-children PATCH is skipped (the mock returns 400 on that PATCH so a regression would surface as a test failure)

Closes #54.