### PR TITLE
fix(banner): suppress on cobra-standard --json=<truthy> spellings (closes #67)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"notioncli/utils"
 
@@ -87,10 +89,23 @@ func Execute() {
 func shouldSuppressBanner() bool {
 	args := os.Args[1:]
 	for i, a := range args {
-		switch a {
-		case "--json", "--output=json":
+		switch {
+		case a == "--json", a == "--output=json":
 			return true
-		case "--output":
+		case strings.HasPrefix(a, "--json="):
+			// Cobra accepts the explicit boolean form for bool flags
+			// (--json=true / --json=1 / --json=false). Without this
+			// branch, --json=true would slip past the matcher and the
+			// banner would print before the JSON payload, breaking
+			// every machine consumer (#67). Mirror cobra's truthiness
+			// rules via strconv.ParseBool so the matcher accepts the
+			// same set of values cobra will: 1, t, T, TRUE, true, True
+			// (and the corresponding false set, which we want to
+			// reject so explicit-off keeps the banner).
+			if v, err := strconv.ParseBool(strings.TrimPrefix(a, "--json=")); err == nil && v {
+				return true
+			}
+		case a == "--output":
 			if i+1 < len(args) && args[i+1] == "json" {
 				return true
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -86,6 +86,19 @@ func TestShouldSuppressBanner_JSONForms(t *testing.T) {
 		{"output_space_text", []string{"notioncli", "list", "--output", "text"}, false},
 		{"output_trailing_no_value", []string{"notioncli", "list", "--output"}, false},
 		{"help", []string{"notioncli", "--help"}, false},
+
+		// Cobra-standard boolean spellings — #67. Anything strconv.ParseBool
+		// recognises as true must suppress; anything it recognises as false
+		// must NOT suppress (explicit-off should keep the banner the same as
+		// no flag at all).
+		{"json_equals_true", []string{"notioncli", "list", "--json=true"}, true},
+		{"json_equals_True", []string{"notioncli", "list", "--json=True"}, true},
+		{"json_equals_TRUE", []string{"notioncli", "list", "--json=TRUE"}, true},
+		{"json_equals_1", []string{"notioncli", "list", "--json=1"}, true},
+		{"json_equals_t", []string{"notioncli", "list", "--json=t"}, true},
+		{"json_equals_false", []string{"notioncli", "list", "--json=false"}, false},
+		{"json_equals_0", []string{"notioncli", "list", "--json=0"}, false},
+		{"json_equals_garbage", []string{"notioncli", "list", "--json=maybe"}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

\`shouldSuppressBanner\` only matched the bare \`--json\` form and the \`--output\` JSON forms. Cobra also accepts the **standard boolean form** for bool flags — \`--json=true\`, \`--json=1\`, \`--json=t\`, \`--json=True\`, \`--json=TRUE\`. Without recognition, those slipped past the matcher and the banner printed before the JSON payload, breaking every machine consumer (\`jq\`, NDJSON parsers, anything reading stdout as JSON).

## Repro (before this fix)

\`\`\`
$ notioncli --json=true list | jq .
----=[ NotionCLI ]=----
{...}
parse error: Invalid numeric literal at line 1, column 21
\`\`\`

## Fix

Add a \`strings.HasPrefix(a, \"--json=\")\` branch using \`strconv.ParseBool\` so the matcher accepts exactly the truthy spellings cobra accepts on the flag itself. Falsy spellings (\`--json=false\`, \`--json=0\`, unparseable values) keep the banner — explicit-off looks the same as no flag at all.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] Existing \`TestShouldSuppressBanner_JSONForms\` extended with 8 new cases:
  - **Suppress**: \`--json=true\`, \`--json=True\`, \`--json=TRUE\`, \`--json=1\`, \`--json=t\`
  - **Don't suppress**: \`--json=false\`, \`--json=0\`, \`--json=maybe\` (unparseable falls back)
- [x] All previously-passing cases still pass (back-compat)

Closes #67.