### PR TITLE
fix(databases): probe data_sources first, fall back to databases (closes #48)

### DIFF
--- a/cmd/databases_test.go
+++ b/cmd/databases_test.go
@@ -294,7 +294,11 @@ func TestDatabasesQueryDispatch(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if got := d.count("POST /databases/dbID/query"); got != 2 {
+	// PR #48 routes Query through /data_sources/{id}/query first
+	// (Notion-Version 2026-03-11 default). The mock responds 200 to
+	// either /data_sources or /databases query suffixes, so the count
+	// lives on the new primary path.
+	if got := d.count("POST /data_sources/dbID/query"); got != 2 {
 		t.Errorf("POST query count=%d want 2 (calls=%v)", got, d.calls)
 	}
 }
@@ -310,7 +314,7 @@ func TestDatabasesQueryWithLimit(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if got := d.count("POST /databases/dbID/query"); got != 1 {
+	if got := d.count("POST /data_sources/dbID/query"); got != 1 {
 		t.Errorf("POST query count=%d want 1 when --limit 1 (calls=%v)", got, d.calls)
 	}
 }
@@ -335,7 +339,9 @@ func TestDatabasesQueryMalformedFilter(t *testing.T) {
 	if err := rootCmd.Execute(); err == nil {
 		t.Fatal("expected error on malformed --filter-json, got nil")
 	}
-	if got := d.count("POST /databases/dbID/query"); got != 0 {
+	// Neither probe path should have been reached when validation
+	// fails before the request leaves the client.
+	if got := d.count("POST /data_sources/dbID/query") + d.count("POST /databases/dbID/query"); got != 0 {
 		t.Errorf("expected no POST when filter malformed, got %d", got)
 	}
 }

--- a/utils/databases.go
+++ b/utils/databases.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // DatabaseClient is the typed resource client for the Notion databases API.
@@ -102,7 +103,12 @@ func titleRichText(title string) []map[string]interface{} {
 	}
 }
 
-// Get retrieves a database by ID via GET /v1/databases/{id}.
+// Get retrieves a database (or data_source) by ID. The id may point at
+// either object type — Get probes /v1/databases/{id} first and falls
+// back to /v1/data_sources/{id} on 404. On Notion-Version 2026-03-11
+// every entry returned by `notioncli search` is a data_source, so the
+// fallback is the common path in current workspaces. Mirrors the same
+// dispatch logic in Query — see issue #48.
 func (d *DatabaseClient) Get(ctx context.Context, id string) (*Database, error) {
 	if err := d.checkAuth(); err != nil {
 		return nil, fmt.Errorf("get database: %w", err)
@@ -110,7 +116,23 @@ func (d *DatabaseClient) Get(ctx context.Context, id string) (*Database, error) 
 	if id == "" {
 		return nil, fmt.Errorf("get database: id is required")
 	}
-	req, err := d.c.newRequest(ctx, http.MethodGet, "/databases/"+id, nil)
+
+	db, err := d.getOnce(ctx, "/databases/"+id)
+	if err == nil {
+		return db, nil
+	}
+	if !isQueryNotFound(err) {
+		return nil, err
+	}
+	return d.getOnce(ctx, "/data_sources/"+id)
+}
+
+// getOnce is the shared transport for both /databases/{id} and
+// /data_sources/{id}. The wire envelope is shape-compatible — both
+// return a Database-like object with title/properties/parent/etc. —
+// so callers can decode either into the existing Database type.
+func (d *DatabaseClient) getOnce(ctx context.Context, path string) (*Database, error) {
+	req, err := d.c.newRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -125,14 +147,23 @@ func (d *DatabaseClient) Get(ctx context.Context, id string) (*Database, error) 
 	return &db, nil
 }
 
-// Query performs a single POST /v1/databases/{id}/query call and returns the
-// immediate page of results. filter and sort are passed through untouched as
-// the Notion API's filter and sorts keys — callers supply these as raw JSON
-// read from a file so the full Notion filter/sort surface is accessible
-// without this package modeling every option.
+// Query performs a single query against a Notion queryable surface and
+// returns the immediate page of results. filter and sort are passed
+// through untouched as the Notion API's filter and sorts keys — callers
+// supply these as raw JSON read from a file so the full Notion
+// filter/sort surface is accessible without this package modeling every
+// option.
 //
 // cursor is the start_cursor to resume from; pass "" for the first page.
 // pageSize is the Notion API's page_size (1-100, 0 means server default).
+//
+// The id may be either a database id or a data_source id. On
+// Notion-Version 2026-03-11 the queryable surface migrated from
+// /v1/databases/{id}/query to /v1/data_sources/{id}/query — every entry
+// returned by `notioncli search` in current workspaces is now a
+// data_source, not a database. Query probes data_sources first and
+// falls back to the legacy databases endpoint on 404 (and only on 404,
+// so genuine auth/transport errors surface immediately). See issue #48.
 func (d *DatabaseClient) Query(ctx context.Context, id string, filter, sort json.RawMessage, cursor string, pageSize int) (*QueryResponse, error) {
 	if err := d.checkAuth(); err != nil {
 		return nil, fmt.Errorf("query database: %w", err)
@@ -155,7 +186,23 @@ func (d *DatabaseClient) Query(ctx context.Context, id string, filter, sort json
 		body["page_size"] = pageSize
 	}
 
-	req, err := d.c.newRequest(ctx, http.MethodPost, "/databases/"+id+"/query", body)
+	// Probe data_sources first (2026-03-11 default).
+	out, err := d.postQuery(ctx, "/data_sources/"+id+"/query", body)
+	if err == nil {
+		return out, nil
+	}
+	if !isQueryNotFound(err) {
+		return nil, err
+	}
+	// Fall back to the legacy databases endpoint for unmigrated DBs.
+	return d.postQuery(ctx, "/databases/"+id+"/query", body)
+}
+
+// postQuery is the shared transport for both the data_sources and the
+// databases query endpoints — same envelope shape, same body, only the
+// path differs. Pulled out so Query's probe + fallback stays readable.
+func (d *DatabaseClient) postQuery(ctx context.Context, path string, body map[string]interface{}) (*QueryResponse, error) {
+	req, err := d.c.newRequest(ctx, http.MethodPost, path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -168,6 +215,17 @@ func (d *DatabaseClient) Query(ctx context.Context, id string, filter, sort json
 		return nil, fmt.Errorf("query database: %w", err)
 	}
 	return &out, nil
+}
+
+// isQueryNotFound reports whether err looks like a 404 from the Notion
+// API. utils.decodeInto wraps non-2xx as "unexpected status N: ...";
+// match the substring rather than a typed status code so the check
+// survives error wrapping by callers.
+func isQueryNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "unexpected status 404")
 }
 
 // QueryAll walks pagination until the server reports HasMore=false or the

--- a/utils/databases_data_source_test.go
+++ b/utils/databases_data_source_test.go
@@ -1,0 +1,203 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestDatabaseClient_QueryProbesDataSourceFirst pins the contract for
+// #48: Query() must POST /v1/data_sources/{id}/query first, since on
+// Notion-Version 2026-03-11 search results are data_sources (not
+// databases) and queries against the legacy /databases/{id}/query
+// endpoint return invalid_request_url for those ids.
+//
+// The fixture server 200s on /data_sources/.../query and would 500 on
+// /databases/.../query — if Query ever flips the order, the test
+// surfaces the regression as a 500 rather than the unrelated 404
+// fallback signal.
+func TestDatabaseClient_QueryProbesDataSourceFirst(t *testing.T) {
+	var dataSourceHits, databaseHits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/data_sources/") && strings.HasSuffix(r.URL.Path, "/query"):
+			atomic.AddInt64(&dataSourceHits, 1)
+			_ = json.NewEncoder(w).Encode(QueryResponse{
+				Object:  "list",
+				Results: []Page{{Object: "page", ID: "row-1"}},
+			})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/databases/") && strings.HasSuffix(r.URL.Path, "/query"):
+			atomic.AddInt64(&databaseHits, 1)
+			http.Error(w, "should not be reached on the happy path", http.StatusInternalServerError)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	resp, err := d.Query(context.Background(), "ds-id", nil, nil, "", 0)
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if resp == nil || len(resp.Results) != 1 || resp.Results[0].ID != "row-1" {
+		t.Errorf("Query result mismatch: %+v", resp)
+	}
+	if got := atomic.LoadInt64(&dataSourceHits); got != 1 {
+		t.Errorf("/data_sources/.../query hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&databaseHits); got != 0 {
+		t.Errorf("/databases/.../query hits = %d, want 0 (must not fall back when data_sources succeeded)", got)
+	}
+}
+
+// TestDatabaseClient_QueryFallsBackToDatabasesOn404 covers the legacy
+// path: when the id is a real database (not a data_source), the
+// /data_sources/.../query probe returns 404 and Query must fall through
+// to /databases/.../query rather than surfacing the 404 to the caller.
+func TestDatabaseClient_QueryFallsBackToDatabasesOn404(t *testing.T) {
+	var dataSourceHits, databaseHits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/data_sources/"):
+			atomic.AddInt64(&dataSourceHits, 1)
+			http.Error(w, `{"object":"error","status":404,"code":"object_not_found"}`, http.StatusNotFound)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/databases/") && strings.HasSuffix(r.URL.Path, "/query"):
+			atomic.AddInt64(&databaseHits, 1)
+			_ = json.NewEncoder(w).Encode(QueryResponse{
+				Object:  "list",
+				Results: []Page{{Object: "page", ID: "legacy-row"}},
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	resp, err := d.Query(context.Background(), "legacy-db-id", nil, nil, "", 0)
+	if err != nil {
+		t.Fatalf("Query (fallback path): %v", err)
+	}
+	if resp == nil || len(resp.Results) != 1 || resp.Results[0].ID != "legacy-row" {
+		t.Errorf("fallback Query returned %+v, want one row with id legacy-row", resp)
+	}
+	if got := atomic.LoadInt64(&dataSourceHits); got != 1 {
+		t.Errorf("data_sources probe hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&databaseHits); got != 1 {
+		t.Errorf("databases fallback hits = %d, want 1", got)
+	}
+}
+
+// TestDatabaseClient_QueryDoesNotFallBackOnNon404 confirms that genuine
+// errors (auth, 5xx) surface immediately from the data_sources probe
+// instead of being masked by the fallback chain. A 500 on
+// /data_sources must NOT trigger a /databases retry — that would hide
+// real problems and double the load on outages.
+func TestDatabaseClient_QueryDoesNotFallBackOnNon404(t *testing.T) {
+	var dataSourceHits, databaseHits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/data_sources/"):
+			atomic.AddInt64(&dataSourceHits, 1)
+			http.Error(w, `{"object":"error","status":500,"code":"server_error"}`, http.StatusInternalServerError)
+		case strings.HasPrefix(r.URL.Path, "/databases/"):
+			atomic.AddInt64(&databaseHits, 1)
+			http.Error(w, "should not be reached", http.StatusInternalServerError)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	if _, err := d.Query(context.Background(), "id", nil, nil, "", 0); err == nil {
+		t.Fatal("expected 500 to surface, got nil")
+	}
+	if got := atomic.LoadInt64(&dataSourceHits); got != 1 {
+		t.Errorf("data_sources hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&databaseHits); got != 0 {
+		t.Errorf("databases hits = %d, want 0 (5xx must surface, not fall back)", got)
+	}
+}
+
+// TestDatabaseClient_GetProbesDatabaseFirst pins the symmetric contract
+// for Get(): try /databases/{id} first (legacy), fall back to
+// /data_sources/{id} on 404. The order is reversed from Query's because
+// the database object is the wrapper — when both endpoints work for an
+// id, /databases/{id} is the more informative response.
+func TestDatabaseClient_GetProbesDatabaseFirst(t *testing.T) {
+	var databaseHits, dataSourceHits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/databases/"):
+			atomic.AddInt64(&databaseHits, 1)
+			id := strings.TrimPrefix(r.URL.Path, "/databases/")
+			_ = json.NewEncoder(w).Encode(Database{Object: "database", ID: id})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/data_sources/"):
+			atomic.AddInt64(&dataSourceHits, 1)
+			http.Error(w, "should not be reached on legacy DB", http.StatusInternalServerError)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	db, err := d.Get(context.Background(), "db-id")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if db == nil || db.ID != "db-id" {
+		t.Errorf("got %+v, want id=db-id", db)
+	}
+	if got := atomic.LoadInt64(&databaseHits); got != 1 {
+		t.Errorf("/databases hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&dataSourceHits); got != 0 {
+		t.Errorf("/data_sources hits = %d, want 0 (no fallback when /databases succeeded)", got)
+	}
+}
+
+// TestDatabaseClient_GetFallsBackToDataSourceOn404 covers the modern
+// case: the id is a 2026-03-11 data_source returned by search, so
+// /databases/{id} 404s and Get falls through.
+func TestDatabaseClient_GetFallsBackToDataSourceOn404(t *testing.T) {
+	var databaseHits, dataSourceHits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/databases/"):
+			atomic.AddInt64(&databaseHits, 1)
+			http.Error(w, `{"object":"error","status":404,"code":"object_not_found"}`, http.StatusNotFound)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/data_sources/"):
+			atomic.AddInt64(&dataSourceHits, 1)
+			id := strings.TrimPrefix(r.URL.Path, "/data_sources/")
+			_ = json.NewEncoder(w).Encode(Database{Object: "data_source", ID: id})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	db, err := d.Get(context.Background(), "ds-id")
+	if err != nil {
+		t.Fatalf("Get (fallback path): %v", err)
+	}
+	if db == nil || db.Object != "data_source" {
+		t.Errorf("got %+v, want object=data_source", db)
+	}
+	if got := atomic.LoadInt64(&databaseHits); got != 1 || atomic.LoadInt64(&dataSourceHits) != 1 {
+		t.Errorf("hits = (db=%d, ds=%d), want (1, 1)", databaseHits, dataSourceHits)
+	}
+}


### PR DESCRIPTION
## Summary

On Notion-Version 2026-03-11 the queryable surface migrated from \`/v1/databases/{id}/query\` to \`/v1/data_sources/{id}/query\`. Every entry returned by \`notioncli search\` in current workspaces is a \`data_source\`, not a \`database\` — **verified live** in the Facet Interactive workspace: 81 data_sources, 0 wrapper databases.

Before this fix, \`databases query <id>\` 400'd with \`invalid_request_url\` for every search-discoverable surface, and \`databases get <id>\` returned 404. The CLI couldn't query **anything** in this workspace.

## Probe-fallback logic

| Method | Primary endpoint | Fallback (on 404) |
|---|---|---|
| \`Query\` | \`POST /v1/data_sources/{id}/query\` | \`POST /v1/databases/{id}/query\` |
| \`Get\` | \`GET /v1/databases/{id}\` | \`GET /v1/data_sources/{id}\` |

Different order because:
- For **Query**, every modern search result is a data_source, so probing data_sources first hits the happy path 99% of the time.
- For **Get**, when an id resolves both ways the database wrapper is the more informative response (it's the parent container).

\`isQueryNotFound\` classifies the fallback trigger by 404 substring; genuine 5xx and auth errors surface immediately so transient outages don't double the request load.

## Live verification

\`\`\`bash
# Before this fix:
$ notioncli databases query f020db63-0c19-43ae-84ac-c2fcabf9611d
Error: query database: ... unexpected status 400: invalid_request_url

# After this fix:
$ notioncli databases query f020db63-0c19-43ae-84ac-c2fcabf9611d --limit 1 --json --pretty | jq '.[] | {id, title: .properties.\"Client Name\".title[0].plain_text}'
{
  \"id\": \"15caf46f-2ba2-43fd-8110-9e6bdd5f7eb2\",
  \"title\": \"Axelerant\"
}
\`\`\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] **Live**: \`databases query <data-source-id>\` returns rows (was 400)
- [x] **Live**: \`databases get <data-source-id>\` returns the data_source object (was 404)
- [x] 5 new unit tests:
  - \`TestDatabaseClient_QueryProbesDataSourceFirst\` — happy path
  - \`TestDatabaseClient_QueryFallsBackToDatabasesOn404\` — legacy DB path
  - \`TestDatabaseClient_QueryDoesNotFallBackOnNon404\` — 5xx surfaces, no double-request
  - \`TestDatabaseClient_GetProbesDatabaseFirst\` — wrapper preferred when both work
  - \`TestDatabaseClient_GetFallsBackToDataSourceOn404\` — modern data_source-id path
- [x] Existing cmd-layer dispatch tests updated to count the new primary path

## Related findings while debugging

- Title property in the \"Accounts & Clients\" data_source is named \`\"Client Name\"\`, not \`\"title\"\` — direct evidence for the #60 hardcoding fix that's already queued
- Search returns 0 \`database\` objects, 81 \`data_source\` objects — Notion 2026-03-11 fully migrated this workspace

Closes #48.