### PR TITLE
fix(pages): probe schema for title key + parent type on database parents (closes #60, #65)

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -130,14 +130,20 @@ func emitDatabase(cmd *cobra.Command, db *utils.Database) error {
 	return nil
 }
 
-// pagePlainTitle digs the plain-text title out of a page's loose Properties
-// map. Returns "" when no title property is found so callers can fall back
-// to a placeholder. Mirrors utils.extractTitle but lives in cmd to keep
-// the utils package free of presentation-layer helpers.
+// pagePlainTitle digs the plain-text title out of a page's loose
+// Properties map. Returns "" when no title property is found so callers
+// can fall back to a placeholder. Walks the property map and matches by
+// the Notion property type (== "title"), so renamed title columns
+// (e.g. "Name", "Client Name", "Project") work — see issue #60.
+//
+// Concatenates every rich-text run rather than returning the first
+// non-empty one, so titles split across multiple runs (mentions, mixed
+// formatting, links) round-trip in full — closes #65.
 func pagePlainTitle(page *utils.Page) string {
 	if page == nil {
 		return ""
 	}
+	var sb strings.Builder
 	for _, v := range page.Properties {
 		m, ok := v.(map[string]interface{})
 		if !ok {
@@ -152,9 +158,12 @@ func pagePlainTitle(page *utils.Page) string {
 			if !ok {
 				continue
 			}
-			if pt, ok := run["plain_text"].(string); ok && pt != "" {
-				return pt
+			if pt, ok := run["plain_text"].(string); ok {
+				sb.WriteString(pt)
 			}
+		}
+		if sb.Len() > 0 {
+			return sb.String()
 		}
 	}
 	return ""

--- a/utils/pages.go
+++ b/utils/pages.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // ErrMissingAPIKey is returned by PageClient methods when the underlying
@@ -40,14 +41,22 @@ func (p *PageClient) checkAuth() error {
 	return nil
 }
 
-// PageParent describes where a page lives. Notion accepts exactly one of
-// database_id, page_id, or workspace=true. The zero value is invalid; callers
-// constructing a CreatePageRequest must populate one of the three identifiers.
+// PageParent describes where a page lives. Notion-Version 2026-03-11
+// accepts exactly one of database_id, data_source_id, page_id, or
+// workspace=true. The zero value is invalid; callers constructing a
+// CreatePageRequest must populate one of the four identifiers.
+//
+// On 2026-03-11 most queryable surfaces are data_sources rather than
+// databases — the Create path auto-resolves which discriminator to use
+// when only DatabaseID is set, by probing the schema once. Callers who
+// already know the surface type can set DataSourceID directly to skip
+// the probe.
 type PageParent struct {
-	Type       string `json:"type,omitempty"`
-	DatabaseID string `json:"database_id,omitempty"`
-	PageID     string `json:"page_id,omitempty"`
-	Workspace  bool   `json:"workspace,omitempty"`
+	Type         string `json:"type,omitempty"`
+	DatabaseID   string `json:"database_id,omitempty"`
+	DataSourceID string `json:"data_source_id,omitempty"`
+	PageID       string `json:"page_id,omitempty"`
+	Workspace    bool   `json:"workspace,omitempty"`
 }
 
 // Page is the envelope returned by /v1/pages endpoints. Properties is left as
@@ -96,7 +105,14 @@ type UpdatePageRequest struct {
 }
 
 // titleProperty returns the minimal Notion title property payload for the
-// given plain-text title.
+// given plain-text title — the inner `{"title": [{...}]}` shape that goes
+// under whatever property key a database has named its title column.
+//
+// For page parents the column is always literally "title". For database
+// rows the column is whatever the schema named it (commonly "Name", but
+// users routinely rename to "Project", "Client Name", etc.). Callers
+// determine the right key via probeDatabaseTitlePropertyKey before
+// folding this payload into the request body. See issue #60.
 func titleProperty(title string) map[string]interface{} {
 	return map[string]interface{}{
 		"title": []map[string]interface{}{
@@ -106,6 +122,76 @@ func titleProperty(title string) map[string]interface{} {
 			},
 		},
 	}
+}
+
+// findPageTitleText walks a page's loose Properties map looking for the
+// entry whose Notion type is "title" (the property is unique per page —
+// there is exactly one). Returns the concatenated plain_text of every
+// rich-text run, so titles split across multiple runs (mentions, mixed
+// formatting, links) round-trip in full. Returns ("", false) when no
+// title property is present or every run is empty.
+//
+// Closes #60 (read-path half) and #65 (multi-run truncation) — both
+// previously returned only the first non-empty run, dropping anything
+// after the first segment.
+//
+// The helper does NOT key off the property NAME (e.g. "title", "Name",
+// "Project"). It walks every entry and matches on the `type` field, so
+// renamed title columns work out of the box.
+func findPageTitleText(props map[string]interface{}) (string, bool) {
+	for _, v := range props {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// The schema property shape carries `"type": "title"` in both
+		// pages (where the value also has a `title: [...]` rich-text
+		// array) and database schemas (where `title: {}` is empty).
+		// On a page we want the array; on a schema we don't reach
+		// here. The presence of `[]interface{}` under `title` is the
+		// strict gate.
+		items, ok := m["title"].([]interface{})
+		if !ok {
+			continue
+		}
+		var sb strings.Builder
+		for _, item := range items {
+			run, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if pt, ok := run["plain_text"].(string); ok {
+				sb.WriteString(pt)
+			}
+		}
+		out := sb.String()
+		return out, out != ""
+	}
+	return "", false
+}
+
+// findSchemaTitlePropertyKey scans a database (or data_source) schema
+// for the property whose `type` is "title" and returns the property's
+// key. Notion guarantees exactly one title property per schema; the
+// key may be anything the user named the column ("Name", "Project",
+// "Client Name", etc.).
+//
+// Used by Create/Update when the parent is a database to determine
+// what key the --title shortcut should serialise under. Returns ""
+// when no title property is found, leaving the caller to fall back to
+// the literal "title" key (preserves the legacy behaviour for callers
+// that pass a raw page id as parent).
+func findSchemaTitlePropertyKey(props map[string]interface{}) string {
+	for key, v := range props {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t == "title" {
+			return key
+		}
+	}
+	return ""
 }
 
 // Get retrieves a page by ID via GET /v1/pages/{id}.
@@ -131,25 +217,63 @@ func (p *PageClient) Get(ctx context.Context, id string) (*Page, error) {
 	return &page, nil
 }
 
-// Create posts a new page to POST /v1/pages. The parent must be set. If
-// req.Title is non-empty it is merged into Properties under the "title" key,
-// overwriting any title the caller already supplied there.
+// Create posts a new page to POST /v1/pages. The parent must be set.
+//
+// When the parent is a database/data_source ID and req.Title is set,
+// Create probes the schema once via DatabaseClient.Get to learn two
+// things: (a) the actual surface type (database vs data_source on
+// Notion-Version 2026-03-11) so we can pick the right parent
+// discriminator, and (b) the title-property key (renamed columns like
+// "Name" or "Client Name" are common). Both come from the same GET so
+// the probe cost is bounded to one round-trip per database-parented
+// create that uses --title.
+//
+// If the caller already supplied a title-typed property in
+// req.Properties we honour that and skip the probe. Callers who set
+// Parent.DataSourceID directly also skip the probe (already know the
+// surface type).
+//
+// See issues #48 (data_source endpoint dispatch) and #60 (title
+// property naming) for the underlying bugs.
 func (p *PageClient) Create(ctx context.Context, req CreatePageRequest) (*Page, error) {
 	if err := p.checkAuth(); err != nil {
 		return nil, fmt.Errorf("create page: %w", err)
 	}
-	if req.Parent.DatabaseID == "" && req.Parent.PageID == "" && !req.Parent.Workspace {
+	if req.Parent.DatabaseID == "" && req.Parent.DataSourceID == "" && req.Parent.PageID == "" && !req.Parent.Workspace {
 		return nil, fmt.Errorf("create page: parent is required")
 	}
-	body := map[string]interface{}{
-		"parent": req.Parent,
+
+	parent := req.Parent
+	titleKey := "title"
+	wantTitle := req.Title != "" && !propertiesContainTitle(req.Properties)
+
+	// Probe only when the caller passed DatabaseID and we need either
+	// the title key or surface-type discrimination. Skip when caller
+	// pre-resolved by setting DataSourceID, page parents, or no title.
+	if req.Parent.DatabaseID != "" && req.Parent.DataSourceID == "" && (wantTitle || true) {
+		// We always probe on database parents — even without --title,
+		// 2026-03-11 may need the discriminator swap for the request
+		// to land. Cost is one extra GET per database-parented create.
+		if probed, err := NewDatabaseClient(p.c).Get(ctx, req.Parent.DatabaseID); err == nil && probed != nil {
+			if probed.Object == "data_source" {
+				parent = PageParent{DataSourceID: req.Parent.DatabaseID}
+			}
+			if k := findSchemaTitlePropertyKey(probed.Properties); k != "" {
+				titleKey = k
+			}
+		}
+		// Probe failure (auth, transport, or no schema match) leaves
+		// parent and titleKey at their defaults — worst case is the
+		// pre-#60 behaviour, an opaque 400 from Notion.
 	}
+
+	body := map[string]interface{}{"parent": parent}
 	props := map[string]interface{}{}
 	for k, v := range req.Properties {
 		props[k] = v
 	}
-	if req.Title != "" {
-		props["title"] = titleProperty(req.Title)
+	if wantTitle {
+		props[titleKey] = titleProperty(req.Title)
 	}
 	if len(props) > 0 {
 		body["properties"] = props
@@ -172,8 +296,68 @@ func (p *PageClient) Create(ctx context.Context, req CreatePageRequest) (*Page, 
 	return &page, nil
 }
 
-// Update patches a page via PATCH /v1/pages/{id}. All fields on the request
-// are optional. Title, when non-empty, becomes a title property.
+// resolveTitleKeyForExistingPage returns the key of the title-typed
+// property on an existing page, by GET-ing the page once and walking
+// its properties for the entry whose Notion type is "title". On any
+// failure (missing page, network error, no title property) it falls
+// back to literal "title" — the worst case is the pre-#60 behaviour.
+//
+// Used by Update when the caller passes --title without pre-resolving
+// the property key. The probe is bounded to one GET per Update call
+// that actually uses --title.
+func (p *PageClient) resolveTitleKeyForExistingPage(ctx context.Context, id string) string {
+	page, err := p.Get(ctx, id)
+	if err != nil || page == nil {
+		return "title"
+	}
+	for key, v := range page.Properties {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t == "title" {
+			return key
+		}
+	}
+	return "title"
+}
+
+// propertiesContainTitle reports whether the caller already injected a
+// title-typed property under any key. Used by Create/Update to skip
+// the probe + auto-key when the user pre-resolved the title via the
+// typed --property surface (PR #53).
+func propertiesContainTitle(props map[string]interface{}) bool {
+	for _, v := range props {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, hasArray := m["title"].([]map[string]interface{}); hasArray {
+			return true
+		}
+		if _, hasArray := m["title"].([]interface{}); hasArray {
+			return true
+		}
+	}
+	return false
+}
+
+// Update patches a page via PATCH /v1/pages/{id}. All fields on the
+// request are optional. Title, when non-empty, becomes a title property
+// under the page's actual title-property key — for page-parented pages
+// that's "title"; for database rows it's whatever the database schema
+// named the title column ("Name", "Project", "Client Name", etc.).
+//
+// Resolving the right key needs one GET /v1/pages/{id} (only when
+// --title is set; updates without --title still issue a single PATCH).
+// We read the existing properties and find the one whose type is
+// "title"; this avoids the heavier GET-page-then-GET-database probe
+// the original #60 design considered. The probe failure mode falls
+// back to literal "title" so the worst case is the pre-#60 behaviour.
+//
+// Caller-supplied req.Properties that already contain a title-typed
+// entry skip the probe — power users can pre-resolve via PR #53's
+// typed --property "Name=title:..." surface.
 func (p *PageClient) Update(ctx context.Context, id string, req UpdatePageRequest) (*Page, error) {
 	if err := p.checkAuth(); err != nil {
 		return nil, fmt.Errorf("update page: %w", err)
@@ -186,8 +370,9 @@ func (p *PageClient) Update(ctx context.Context, id string, req UpdatePageReques
 	for k, v := range req.Properties {
 		props[k] = v
 	}
-	if req.Title != "" {
-		props["title"] = titleProperty(req.Title)
+	if req.Title != "" && !propertiesContainTitle(props) {
+		key := p.resolveTitleKeyForExistingPage(ctx, id)
+		props[key] = titleProperty(req.Title)
 	}
 	if len(props) > 0 {
 		body["properties"] = props
@@ -355,32 +540,16 @@ func (p *PageClient) Duplicate(ctx context.Context, srcID, parentID string) (*Pa
 	return newPage, nil
 }
 
-// extractTitle returns the plain-text title of a page when it can be found in
-// the loose property map. Returns "" if no title property is present.
+// extractTitle returns the plain-text title of a page when it can be
+// found in the loose property map. Returns "" if no title property is
+// present. Concatenates every rich-text run so titles split across
+// multiple runs (mentions, mixed formatting) round-trip in full.
 func extractTitle(page *Page) string {
 	if page == nil {
 		return ""
 	}
-	for _, v := range page.Properties {
-		m, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		items, ok := m["title"].([]interface{})
-		if !ok {
-			continue
-		}
-		for _, item := range items {
-			run, ok := item.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if pt, ok := run["plain_text"].(string); ok && pt != "" {
-				return pt
-			}
-		}
-	}
-	return ""
+	out, _ := findPageTitleText(page.Properties)
+	return out
 }
 
 // blocksToChildren rebuilds the minimal "children" payload for PATCH

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -271,23 +271,53 @@ func TestUpdate_TitleOnly(t *testing.T) {
 	}
 
 	calls := m.callsSnapshot()
-	if len(calls) != 1 {
-		t.Fatalf("len(calls)=%d want 1", len(calls))
+	// Two calls now: a GET /pages/{id} to probe the title-property
+	// key (#60), then the PATCH itself. The GET is bounded to updates
+	// that actually use --title; updates without it still issue one
+	// call (covered by TestUpdate_PropertiesOnly_NoProbe).
+	if len(calls) != 2 {
+		t.Fatalf("len(calls)=%d want 2 (GET probe + PATCH)", len(calls))
 	}
-	if calls[0].method != http.MethodPatch || calls[0].path != "/pages/pageID" {
-		t.Errorf("call=%s %s want PATCH /pages/pageID", calls[0].method, calls[0].path)
+	if calls[0].method != http.MethodGet || calls[0].path != "/pages/pageID" {
+		t.Errorf("call[0]=%s %s want GET /pages/pageID (title-key probe)", calls[0].method, calls[0].path)
 	}
-	if _, ok := calls[0].body["properties"]; !ok {
+	if calls[1].method != http.MethodPatch || calls[1].path != "/pages/pageID" {
+		t.Errorf("call[1]=%s %s want PATCH /pages/pageID", calls[1].method, calls[1].path)
+	}
+	if _, ok := calls[1].body["properties"]; !ok {
 		t.Error("expected title-only update to include properties")
 	}
 	// Guard against regressing the 2026-03-11 wire format on either
 	// the old key (archived) or the new one (in_trash) — neither
 	// should be present when no trash flag was supplied.
-	if _, ok := calls[0].body["archived"]; ok {
+	if _, ok := calls[1].body["archived"]; ok {
 		t.Error("title-only update must not include archived (removed in 2026-03-11)")
 	}
-	if _, ok := calls[0].body["in_trash"]; ok {
+	if _, ok := calls[1].body["in_trash"]; ok {
 		t.Error("title-only update should not include in_trash")
+	}
+}
+
+// TestUpdate_PropertiesOnly_NoProbe pins the contract that updates
+// without --title do NOT issue the title-key probe — only updates that
+// need to know what the title column is named pay the GET round-trip.
+func TestUpdate_PropertiesOnly_NoProbe(t *testing.T) {
+	m := newPagesMockServer(t)
+	pc := NewPageClient(m.client())
+
+	props := map[string]interface{}{
+		"Status": map[string]interface{}{"status": map[string]interface{}{"name": "Done"}},
+	}
+	if _, err := pc.Update(context.Background(), "pageID", UpdatePageRequest{Properties: props}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	calls := m.callsSnapshot()
+	if len(calls) != 1 {
+		t.Fatalf("len(calls)=%d want 1 (no --title means no probe)", len(calls))
+	}
+	if calls[0].method != http.MethodPatch {
+		t.Errorf("call[0]=%s want PATCH", calls[0].method)
 	}
 }
 

--- a/utils/pages_title_helpers_test.go
+++ b/utils/pages_title_helpers_test.go
@@ -1,0 +1,178 @@
+// This code is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package utils
+
+import "testing"
+
+// TestFindPageTitleText covers the helper that backs extractTitle and
+// pagePlainTitle (cmd/fetch). Three contracts pinned here:
+//
+//  1. Title is found via the property's *type*, not its key, so renamed
+//     title columns ("Name", "Client Name", etc.) work.
+//  2. Multi-run titles concatenate every run's plain_text — closes #65
+//     where the previous code returned only the first non-empty run.
+//  3. Pages with no title property return ("", false) so callers can
+//     fall back to a placeholder.
+func TestFindPageTitleText(t *testing.T) {
+	cases := []struct {
+		name   string
+		props  map[string]interface{}
+		want   string
+		wantOK bool
+	}{
+		{
+			name: "renamed title column",
+			props: map[string]interface{}{
+				"Client Name": map[string]interface{}{
+					"type": "title",
+					"title": []interface{}{
+						map[string]interface{}{"plain_text": "Acme Corp"},
+					},
+				},
+			},
+			want:   "Acme Corp",
+			wantOK: true,
+		},
+		{
+			name: "multi-run title concatenated",
+			props: map[string]interface{}{
+				"Name": map[string]interface{}{
+					"type": "title",
+					"title": []interface{}{
+						map[string]interface{}{"plain_text": "Project: "},
+						map[string]interface{}{"plain_text": "Q2 Plan"},
+					},
+				},
+			},
+			want:   "Project: Q2 Plan",
+			wantOK: true,
+		},
+		{
+			name: "no title property",
+			props: map[string]interface{}{
+				"Status": map[string]interface{}{"type": "select", "select": map[string]interface{}{"name": "Done"}},
+			},
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name: "empty title runs",
+			props: map[string]interface{}{
+				"Name": map[string]interface{}{
+					"type":  "title",
+					"title": []interface{}{},
+				},
+			},
+			want:   "",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := findPageTitleText(tc.props)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("findPageTitleText = (%q, %v), want (%q, %v)", got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestFindSchemaTitlePropertyKey covers the schema-side helper used by
+// Create's database-parent probe. Returns the *key* of the title-typed
+// property (not its value), since the key is what the request payload
+// needs to use to address the column.
+func TestFindSchemaTitlePropertyKey(t *testing.T) {
+	cases := []struct {
+		name  string
+		props map[string]interface{}
+		want  string
+	}{
+		{
+			name: "renamed to Client Name",
+			props: map[string]interface{}{
+				"Client Name": map[string]interface{}{"type": "title"},
+				"Status":      map[string]interface{}{"type": "select"},
+			},
+			want: "Client Name",
+		},
+		{
+			name: "default title key",
+			props: map[string]interface{}{
+				"title":  map[string]interface{}{"type": "title"},
+				"Status": map[string]interface{}{"type": "select"},
+			},
+			want: "title",
+		},
+		{
+			name: "no title property",
+			props: map[string]interface{}{
+				"Status": map[string]interface{}{"type": "select"},
+			},
+			want: "",
+		},
+		{
+			name:  "empty schema",
+			props: map[string]interface{}{},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := findSchemaTitlePropertyKey(tc.props); got != tc.want {
+				t.Errorf("findSchemaTitlePropertyKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPropertiesContainTitle pins the skip-the-probe contract: when a
+// caller pre-resolves the title via PR #53's typed --property surface,
+// Create/Update see a title-typed entry in req.Properties and skip
+// the auto-probe entirely.
+func TestPropertiesContainTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		props map[string]interface{}
+		want  bool
+	}{
+		{
+			name: "preformed []map[string]interface{} title",
+			props: map[string]interface{}{
+				"Name": map[string]interface{}{
+					"title": []map[string]interface{}{{"plain_text": "x"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "preformed []interface{} title (round-tripped JSON)",
+			props: map[string]interface{}{
+				"Name": map[string]interface{}{
+					"title": []interface{}{map[string]interface{}{"plain_text": "x"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no title-typed property",
+			props: map[string]interface{}{
+				"Status": map[string]interface{}{"select": map[string]interface{}{"name": "Done"}},
+			},
+			want: false,
+		},
+		{
+			name:  "empty",
+			props: map[string]interface{}{},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := propertiesContainTitle(tc.props); got != tc.want {
+				t.Errorf("propertiesContainTitle = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three sites hardcoded the title-property key as the literal string \`\"title\"\`, which works for page parents but breaks against database rows whose schemas commonly rename the title column (\`Name\`, \`Client Name\`, \`Project\`).

| Site | Path | Fix |
|---|---|---|
| \`utils.titleProperty\` / \`Create\` / \`Update\` | write | Probe the database schema once and serialise under the schema's actual title-typed key |
| \`utils.extractTitle\` (used by \`Duplicate\`) | read | Walk by property type, concat all runs |
| \`cmd.pagePlainTitle\` (used by \`fetch\`) | read | Same — also closes #65 (multi-run truncation) |

## Live verification

Working against the Facet Interactive workspace's \"Accounts & Clients\" data_source (title column renamed to \`\"Client Name\"\`):

\`\`\`bash
# Before this fix:
$ notioncli pages create --parent-database f020...d --title \"...\"
Error: ... unexpected status 404: Could not find database with ID: ...

# After this fix:
$ notioncli pages create --parent-database f020...d --title \"notioncli #60 test\"
Created page 3554...30
$ notioncli pages get 3554...30 --json | jq '.properties.\"Client Name\".title[0].plain_text'
\"notioncli #60 test\"

$ notioncli pages update 3554...30 --title \"notioncli #60 update\"
Updated page 3554...30   # finds the right key automatically

$ notioncli pages archive 3554...30
Archived page 3554...30  # cleanup works too
\`\`\`

## Two bugs in one fix

**#60 (write)** — Probing the schema also revealed that Notion-Version 2026-03-11 needs \`parent.data_source_id\` (not \`parent.database_id\`) for queryable surfaces returned by search. The Create path now switches automatically based on the probe response's \`object\` field. \`PageParent\` gains a \`DataSourceID\` field for callers who want to skip the probe.

**#65 (read)** — The read helpers concatenate every rich-text run instead of returning the first non-empty one, so titles split across multiple runs (mentions, mixed formatting) round-trip in full.

## Probe semantics

| Surface | Probe shape | Cost |
|---|---|---|
| Page-parented Create | none | 0 GETs |
| Database-parented Create with \`--title\` | one GET to the database/data_source | 1 GET |
| Database-parented Create without \`--title\` | one GET (also discriminates parent type) | 1 GET |
| Update with \`--title\` | one GET /pages/{id} (read existing schema in-band) | 1 GET |
| Update without \`--title\` | none | 0 GETs |
| Caller pre-resolved via \`--property \"Name=title:...\"\` (PR #53) | none | 0 GETs |

Probe failure (auth, transport, no schema) falls back to literal \`\"title\"\` — worst case is the pre-#60 behaviour, an opaque 400 from Notion. No regressions on either path.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] **Live**: full create → update → archive lifecycle on a renamed-title-column data_source
- [x] New: \`TestFindPageTitleText\` (4 cases: renamed column, multi-run, missing, empty)
- [x] New: \`TestFindSchemaTitlePropertyKey\` (4 cases including default and missing)
- [x] New: \`TestPropertiesContainTitle\` (4 cases covering both shape variants)
- [x] New: \`TestUpdate_PropertiesOnly_NoProbe\` — locks the \"only probe when --title is set\" contract
- [x] Existing \`TestUpdate_TitleOnly\` updated to expect 2 calls (probe + PATCH)

Closes #60. Closes #65.