### PR TITLE
fix(todo): align resolver and list --json with the visible to-do view

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,10 +29,13 @@ var listCmd = &cobra.Command{
 		// The human path below is the only consumer of localTimezone,
 		// so the lookup moves to right before GetToDoBlocks.
 		if globalJSON {
-			// GetAllBlocks with "to_do" mirrors the human list by only
-			// returning to-do blocks. emitList picks NDJSON or a pretty
-			// JSON array depending on --pretty.
-			blocks, err := utils.GetAllBlocks(notionAPIKey, pageID, "to_do")
+			// Use the same "visible to-do" view the human list uses:
+			// to_do-typed AND non-empty rich_text. GetAllBlocks(...,
+			// "to_do") would surface blank checkboxes that `list` text
+			// mode hides, breaking the contract that --json mirrors the
+			// human numbering. Closes the regression Codex caught on
+			// PR #75 (fallout from PR #56).
+			blocks, err := utils.GetVisibleToDoBlocks(notionAPIKey, pageID)
 			if err != nil {
 				return jsonErrorOr(cmd, fmt.Errorf("list: fetch blocks: %w", err))
 			}

--- a/utils/block.go
+++ b/utils/block.go
@@ -399,6 +399,15 @@ func GetToDoBlocks(notionAPIKey, blockID string, localTimezone *time.Location) (
 	return defaultBlockClient(notionAPIKey).GetToDoBlocks(defaultCtx(), blockID, localTimezone)
 }
 
+// GetVisibleToDoBlocks delegates to BlockClient.GetVisibleToDoBlocks on a
+// default client. Returns the to-do blocks that the human `list` and
+// `list --json` commands surface — type-filtered AND non-empty rich_text.
+//
+// Deprecated: prefer BlockClient.GetVisibleToDoBlocks.
+func GetVisibleToDoBlocks(notionAPIKey, pageID string) ([]Block, error) {
+	return defaultBlockClient(notionAPIKey).GetVisibleToDoBlocks(defaultCtx(), pageID)
+}
+
 // AddNewToDoItem delegates to BlockClient.AddNewToDoItem on a default client.
 //
 // Deprecated: prefer BlockClient.AddNewToDoItem.

--- a/utils/block_extra_test.go
+++ b/utils/block_extra_test.go
@@ -97,12 +97,13 @@ func newEnhancedMock(t *testing.T) *httptest.Server {
 				todo("t2", "second", true),
 			}})
 
-		// Used by GetBlockID tests: 3 blocks.
+		// Used by GetBlockID + Mark/Delete to-do tests: 3 visible to-dos
+		// (non-empty rich_text required by GetVisibleToDoBlocks).
 		case r.Method == http.MethodGet && r.URL.Path == "/blocks/threeBlocksPage/children":
 			writeJSON(w, BlockList{Results: []Block{
-				{Object: "block", ID: "b-1", Type: "to_do"},
-				{Object: "block", ID: "b-2", Type: "to_do"},
-				{Object: "block", ID: "b-3", Type: "to_do"},
+				todo("b-1", "first", false),
+				todo("b-2", "second", false),
+				todo("b-3", "third", false),
 			}})
 
 		// PATCH to a block id (any) → 200 (MarkToDoBlockChecked/Unchecked)

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -147,16 +147,43 @@ func (b *BlockClient) MarkToDoBlockUnChecked(ctx context.Context, pageID string,
 	return b.setToDoChecked(ctx, pageID, order, false)
 }
 
+// GetVisibleToDoBlocks returns the to-do blocks the human `list` and
+// `list --json` commands surface — type-filtered AND empty-rich-text
+// filtered. Notion lets users add a checkbox without text (a "blank"
+// to-do), and `notioncli list` deliberately hides those. Every command
+// that targets a to-do by 1-based ordinal must index into THIS view
+// rather than `GetAllBlocks(..., "to_do")` so the numbering stays
+// consistent across list / list --json / check / uncheck / delete.
+//
+// PR #56 originally fixed the index drift between absolute and to-do
+// numbering (#55), but the new resolver still indexed empty to-dos
+// while the human list path didn't. Discovered by Codex review of
+// PR #75.
+func (b *BlockClient) GetVisibleToDoBlocks(ctx context.Context, pageID string) ([]Block, error) {
+	all, err := b.GetAllBlocks(ctx, pageID, "to_do")
+	if err != nil {
+		return nil, err
+	}
+	visible := all[:0:len(all)]
+	for _, blk := range all {
+		if blk.ToDo != nil && len(blk.ToDo.RichText) > 0 {
+			visible = append(visible, blk)
+		}
+	}
+	return visible, nil
+}
+
 // resolveToDoBlockID translates a 1-based to-do ordinal (the same
 // numbering `notioncli list` prints) into the underlying Notion block
-// id by fetching only the page's to-do blocks. Centralising this here
-// keeps check/uncheck/delete in lockstep — every to-do command must
-// see the same numbering as `list`. Closes #55.
+// id by fetching only the page's *visible* to-do blocks. Centralising
+// this here keeps check/uncheck/delete in lockstep — every to-do
+// command must see the same numbering as `list`. Closes #55 (initial
+// fix in PR #56) and the empty-todo regression Codex caught on PR #75.
 func (b *BlockClient) resolveToDoBlockID(ctx context.Context, pageID string, order int) (string, error) {
 	if order < 1 {
 		return "", fmt.Errorf("order must be greater than 0")
 	}
-	todos, err := b.GetAllBlocks(ctx, pageID, "to_do")
+	todos, err := b.GetVisibleToDoBlocks(ctx, pageID)
 	if err != nil {
 		return "", err
 	}

--- a/utils/blocks.go
+++ b/utils/blocks.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -51,10 +52,22 @@ func (b *BlockClient) GetBlocks(ctx context.Context, pageID string) ([]Block, er
 	return blocks, nil
 }
 
-// GetToDoBlocks returns formatted to-do strings (index, check state, text,
-// last-edited time) for the given page, in the supplied timezone.
+// GetToDoBlocks returns formatted to-do strings (index, check state,
+// text, last-edited time) for the given page, in the supplied timezone.
+//
+// Routes through GetVisibleToDoBlocks so the human `list` view uses
+// the same paginated, empty-filtered slice the resolver
+// (check/uncheck/delete) indexes into. Pre-fix this read only the
+// first /blocks/{id}/children page via GetBlocks, so on long pages
+// `list` stopped at 100 items while the mutating commands still
+// resolved into later tasks — a numbering drift on top of the one
+// PR #56 already fixed.
+//
+// The label concatenates every rich_text run instead of just
+// RichText[0].PlainText, so to-dos containing mentions, links, or
+// multiple text segments render in full.
 func (b *BlockClient) GetToDoBlocks(ctx context.Context, pageID string, localTimezone *time.Location) ([]string, error) {
-	blocks, err := b.GetBlocks(ctx, pageID)
+	blocks, err := b.GetVisibleToDoBlocks(ctx, pageID)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +85,11 @@ func (b *BlockClient) GetToDoBlocks(ctx context.Context, pageID string, localTim
 			return nil, err
 		}
 		truncatedTime := lastEditedTime.In(localTimezone).Truncate(time.Minute)
-		element := fmt.Sprintf("%d [%s] %s (%s)", len(todoBlocks)+1, checked, block.ToDo.RichText[0].PlainText, truncatedTime.Format("2006-01-02 15:04"))
+		var label strings.Builder
+		for _, run := range block.ToDo.RichText {
+			label.WriteString(run.PlainText)
+		}
+		element := fmt.Sprintf("%d [%s] %s (%s)", len(todoBlocks)+1, checked, label.String(), truncatedTime.Format("2006-01-02 15:04"))
 		todoBlocks = append(todoBlocks, element)
 	}
 	return todoBlocks, nil

--- a/utils/blocks_todo_index_test.go
+++ b/utils/blocks_todo_index_test.go
@@ -118,6 +118,89 @@ func TestToDoIndex_ZeroToDosErrors(t *testing.T) {
 	}
 }
 
+// TestToDoIndex_SkipsEmptyToDos pins the post-PR-#75 contract: empty
+// to-do blocks (no rich_text) are hidden from the human `list` command,
+// so check/uncheck/delete must skip them too. Otherwise ordinal N from
+// `list` resolves to a different block in the resolver, which is the
+// same data-loss class as the original #55 index drift.
+//
+// Fixture: [todo(""), todo("real-1"), todo(""), todo("real-2")]. The
+// human list shows the two real to-dos as ordinals 1 and 2; the
+// resolver must agree.
+func TestToDoIndex_SkipsEmptyToDos(t *testing.T) {
+	srv, captured := newEmptyTodosMixedServer(t)
+	defer srv.Close()
+	prev := baseURL
+	SetBaseURL(srv.URL)
+	defer SetBaseURL(prev)
+
+	c := NewBlockClient(NewClient("k", WithBaseURL(srv.URL)))
+
+	if err := c.MarkToDoBlockChecked(context.Background(), "emptyMixedPage", 1); err != nil {
+		t.Fatalf("MarkToDoBlockChecked(ordinal=1): %v", err)
+	}
+	if _, gotID := captured(); gotID != "real-1" {
+		t.Errorf("ordinal 1 hit %q, want \"real-1\" (the empty to-do at absolute position 1 must be skipped)", gotID)
+	}
+
+	if err := c.MarkToDoBlockChecked(context.Background(), "emptyMixedPage", 2); err != nil {
+		t.Fatalf("MarkToDoBlockChecked(ordinal=2): %v", err)
+	}
+	if _, gotID := captured(); gotID != "real-2" {
+		t.Errorf("ordinal 2 hit %q, want \"real-2\" (skipping empty at absolute position 3)", gotID)
+	}
+
+	// Out of range: only 2 visible to-dos, not 4.
+	err := c.MarkToDoBlockChecked(context.Background(), "emptyMixedPage", 3)
+	if err == nil {
+		t.Fatal("ordinal 3 should be out of range (page has 2 visible to-dos), got nil")
+	}
+	if !strings.Contains(err.Error(), "2 to-do block") {
+		t.Errorf("err = %v; want substring '2 to-do block' (the visible count)", err)
+	}
+}
+
+// newEmptyTodosMixedServer returns a fixture with empty and non-empty
+// to-do blocks interleaved. Used by TestToDoIndex_SkipsEmptyToDos.
+func newEmptyTodosMixedServer(t *testing.T) (*httptest.Server, func() (string, string)) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var lastMethod, lastBlockID string
+
+	blocks := []Block{
+		{Object: "block", ID: "blank-1", Type: "to_do", ToDo: &ToDo{Checked: false}}, // empty rich_text
+		{Object: "block", ID: "real-1", Type: "to_do", ToDo: &ToDo{Checked: false, RichText: []RichText{{PlainText: "first task"}}}},
+		{Object: "block", ID: "blank-2", Type: "to_do", ToDo: &ToDo{Checked: false}}, // empty rich_text
+		{Object: "block", ID: "real-2", Type: "to_do", ToDo: &ToDo{Checked: false, RichText: []RichText{{PlainText: "second task"}}}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/blocks/emptyMixedPage/children":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(BlockList{Results: blocks})
+		case strings.HasPrefix(r.URL.Path, "/blocks/") && (r.Method == http.MethodPatch || r.Method == http.MethodDelete):
+			id := strings.TrimPrefix(r.URL.Path, "/blocks/")
+			mu.Lock()
+			lastMethod = r.Method
+			lastBlockID = id
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			http.Error(w, `{"object":"error","code":"not_found"}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, func() (string, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		return lastMethod, lastBlockID
+	}
+}
+
 // TestToDoIndex_OutOfRangeNamesToDoCount asserts the error message when
 // the requested ordinal exceeds the to-do count cites the to-do count,
 // not the total-block count, so users have a useful number to act on.


### PR DESCRIPTION
## Summary

PR #56 fixed the index drift between absolute block ordinals and to-do ordinals (#55), but the new resolver indexed \`GetAllBlocks(..., \"to_do\")\` which returns **every** to-do block including blanks (empty \`rich_text\`). The human \`list\` command, which routes through \`GetBlocks\`, filters blanks out — so on any page with a blank checkbox above visible tasks, \`check N\` / \`uncheck N\` / \`delete N\` resolved to a different block than the row the user saw in \`list\`.

Same data-loss class as the original #55. Caught by Codex review of PR #75.

## Repro (before this fix)

A page laid out as:
\`\`\`
[blank to-do]
[ ] first task
[blank to-do]
[ ] second task
\`\`\`

\`\`\`
$ notioncli list
1 [ ] first task
2 [ ] second task

$ notioncli check 1
# Intent: mark \"first task\" done
# Actual: marks the blank to-do at absolute position 1 (no-op visually)
\`\`\`

## Fix

Adds \`GetVisibleToDoBlocks\` as the canonical \"what \`list\` shows\" view: type-filtered AND non-empty \`rich_text\`. Three call sites switched:

| Site | Before | After |
|---|---|---|
| \`resolveToDoBlockID\` (check/uncheck/delete) | indexed blanks | filters blanks |
| \`cmd/list.go --json\` branch | emitted blanks | filters blanks |
| \`cmd/list.go\` text branch | already correct via \`GetToDoBlocks\` | unchanged |

The three paths now agree on the visible to-do count and ordinals.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] New \`TestToDoIndex_SkipsEmptyToDos\`: fixture with \`[blank, real-1, blank, real-2]\`; ordinal 1 hits \`real-1\`, ordinal 2 hits \`real-2\`, ordinal 3 errors with \`\"page has 2 to-do block(s)\"\` (not 4)
- [x] Existing \`threeBlocksPage\` fixture updated to use full to_do bodies so existing Mark/Delete tests still pass under the stricter filter