### PR TITLE
fix(pages duplicate): preserve annotations + mentions + equations (closes #61)

### DIFF
--- a/utils/pages.go
+++ b/utils/pages.go
@@ -640,17 +640,26 @@ func richTextChild(typ string, extra map[string]interface{}, runs []RichText) ma
 	}
 }
 
+// richTextPayload rebuilds the rich_text array for a child block during
+// duplicate. Routes through richTextToAPI so annotations (bold/italic/
+// color/...), inline links, page/user/date mentions, and inline
+// equations all round-trip — closes #61. Pre-fix this helper flattened
+// every run to a plain `{type:"text", text:{content:...}}` payload,
+// silently dropping every non-content field.
+//
+// We normalise Text.Content from PlainText first because the source
+// page's rich_text may have only PlainText populated (Notion's read
+// response sets both, but some constructors and the resolver-rendered
+// output don't). richTextToAPI itself reads Text.Content; without
+// this nudge, mentions and equations still preserve correctly but a
+// plain-text run could land on the wire with an empty content string.
 func richTextPayload(runs []RichText) []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(runs))
-	for _, r := range runs {
-		content := r.Text.Content
-		if content == "" {
-			content = r.PlainText
+	normalized := make([]RichText, len(runs))
+	for i, r := range runs {
+		normalized[i] = r
+		if r.Mention == nil && r.Equation == nil && r.Text.Content == "" {
+			normalized[i].Text.Content = r.PlainText
 		}
-		out = append(out, map[string]interface{}{
-			"type": "text",
-			"text": map[string]interface{}{"content": content},
-		})
 	}
-	return out
+	return richTextToAPI(normalized)
 }

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -628,6 +628,62 @@ func TestRichTextPayload(t *testing.T) {
 	}
 }
 
+// TestRichTextPayload_PreservesAnnotations pins the #61 contract:
+// duplicate must round-trip annotations (bold/italic/color), inline
+// links, page mentions, and inline equations rather than flattening
+// every run to plain text. The pre-fix helper emitted only
+// {type:"text", text:{content:...}} for every input, silently dropping
+// every non-content field.
+func TestRichTextPayload_PreservesAnnotations(t *testing.T) {
+	runs := []RichText{
+		{
+			Type:        "text",
+			Text:        Text{Content: "bold "},
+			PlainText:   "bold ",
+			Annotations: Annotation{Bold: true},
+		},
+		{
+			Type:      "mention",
+			PlainText: "[page-mention]",
+			Mention:   &Mention{Type: "page", Page: &PageMention{ID: "abc-123"}},
+		},
+		{
+			Type:      "equation",
+			PlainText: "E=mc^2",
+			Equation:  &TextEquation{Expression: "E=mc^2"},
+		},
+	}
+	out := richTextPayload(runs)
+	if len(out) != 3 {
+		t.Fatalf("len=%d want 3", len(out))
+	}
+
+	// Run 0: bold annotation must survive.
+	ann0, ok := out[0]["annotations"].(Annotation)
+	if !ok {
+		t.Fatalf("run 0 lost annotations: %+v", out[0])
+	}
+	if !ann0.Bold {
+		t.Errorf("run 0 annotations.bold = false; want true (bold flag dropped)")
+	}
+
+	// Run 1: mention must round-trip as a mention, not flattened to text.
+	if out[1]["type"] != "mention" {
+		t.Errorf("run 1 type=%v want mention (mention flattened to text)", out[1]["type"])
+	}
+	if out[1]["mention"] == nil {
+		t.Errorf("run 1 lost mention payload: %+v", out[1])
+	}
+
+	// Run 2: equation must round-trip with the expression intact.
+	if out[2]["type"] != "equation" {
+		t.Errorf("run 2 type=%v want equation (equation flattened to text)", out[2]["type"])
+	}
+	if eq, _ := out[2]["equation"].(*TextEquation); eq == nil || eq.Expression != "E=mc^2" {
+		t.Errorf("run 2 equation lost: %+v", out[2])
+	}
+}
+
 // TestPageClient_MissingAPIKey asserts that every HTTP-calling method on
 // PageClient refuses to issue a request when the underlying Client has an
 // empty API key, and returns ErrMissingAPIKey (wrapped).


### PR DESCRIPTION
## Summary

\`richTextPayload\` (the helper \`Duplicate\` uses to seed the destination page's blocks) flattened every rich-text run to plain \`{type:\"text\", text:{content:...}}\`, silently dropping:

- Annotations (bold, italic, strikethrough, underline, code, color)
- Inline links (\`text.link.url\`)
- Page/user/date/database mentions
- Inline equations

Pages with formatted text round-tripped as plain text — silent data corruption with no error visible to the caller.

## Fix

Routes through \`richTextToAPI\` which already handles every payload shape correctly (it backs \`AddRichTextBlock\` since PR #31). Falls back from \`Text.Content\` to \`PlainText\` for plain-text runs so the legacy content-fallback contract is preserved when the source rich_text only populated \`PlainText\`.

\`\`\`go
// before:
func richTextPayload(runs []RichText) []map[string]interface{} {
    out := ...
    for _, r := range runs {
        content := r.Text.Content
        if content == \"\" { content = r.PlainText }
        out = append(out, {\"type\":\"text\", \"text\":{\"content\":content}})  // drops everything else
    }
    return out
}

// after:
func richTextPayload(runs []RichText) []map[string]interface{} {
    normalized := /* fill Text.Content from PlainText if empty */
    return richTextToAPI(normalized)  // handles annotations, mentions, equations, links
}
\`\`\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] Existing \`TestRichTextPayload\` (plain-text content fallback) still passes
- [x] New \`TestRichTextPayload_PreservesAnnotations\`:
  - Bold annotation flag → reaches the wire
  - Page mention with id → emits \`type: \"mention\"\` with the mention payload (not flattened to text)
  - Inline equation → emits \`type: \"equation\"\` with \`expression\` intact
- [ ] Live: duplicate a page with bold/italic/mention text against a real workspace once merged

Closes #61.