### PR TITLE
fix(search): --type databases maps to data_source on 2026-03-11 (closes #79)

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -94,17 +94,24 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	return emitSearchTable(cmd, results)
 }
 
-// buildSearchFilter translates the user-facing --type value into the Notion
-// API filter object. Empty string means "no filter". Invalid values return
-// an error pointing at the allowed set.
+// buildSearchFilter translates the user-facing --type value into the
+// Notion API filter object. Empty string means "no filter". Invalid
+// values return an error pointing at the allowed set.
+//
+// Notion-Version 2026-03-11 returns `data_source` objects from
+// /v1/search instead of the legacy `database` shape — verified live
+// (Facet Interactive workspace: 81 data_source results, 0 database
+// results). The CLI keeps `--type databases` as the user-facing alias
+// because that's the term users still reach for, but the wire filter
+// follows what the API actually emits. See issue #79.
 func buildSearchFilter(typeFlag string) (*utils.SearchFilter, error) {
 	switch typeFlag {
 	case "":
 		return nil, nil
 	case "page", "pages":
 		return &utils.SearchFilter{Property: "object", Value: "page"}, nil
-	case "database", "databases":
-		return &utils.SearchFilter{Property: "object", Value: "database"}, nil
+	case "database", "databases", "data_source", "data_sources":
+		return &utils.SearchFilter{Property: "object", Value: "data_source"}, nil
 	}
 	return nil, fmt.Errorf("invalid --type %q (want pages|databases)", typeFlag)
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -132,8 +132,12 @@ func TestBuildSearchFilter(t *testing.T) {
 		{"", "", false},
 		{"pages", "page", false},
 		{"page", "page", false},
-		{"databases", "database", false},
-		{"database", "database", false},
+		// Notion-Version 2026-03-11 returns data_source objects; the
+		// CLI's --type databases alias maps to that wire value (#79).
+		{"databases", "data_source", false},
+		{"database", "data_source", false},
+		{"data_source", "data_source", false},
+		{"data_sources", "data_source", false},
 		{"users", "", true},
 		{"foo", "", true},
 	}
@@ -231,8 +235,11 @@ func TestSearchCmdTypeFilter(t *testing.T) {
 		t.Fatalf("rootCmd.Execute(search --type databases): %v", err)
 	}
 
-	if got, _ := stats.filter.Load().(string); got != "database" {
-		t.Errorf("filter sent = %q, want %q", got, "database")
+	// On Notion-Version 2026-03-11 the wire value is `data_source`
+	// (issue #79). The CLI keeps `--type databases` as the user-facing
+	// alias because that's the term users still type.
+	if got, _ := stats.filter.Load().(string); got != "data_source" {
+		t.Errorf("filter sent = %q, want %q", got, "data_source")
 	}
 }
 


### PR DESCRIPTION
## Summary

Notion-Version 2026-03-11 returns \`data_source\` objects from \`/v1/search\` instead of the legacy \`database\` shape. **Verified live** in the Facet Interactive workspace: 81 data_source results, 0 database results from an unfiltered search.

Pre-fix \`--type databases\` filtered on \`value: \"database\"\`, so users got 0 results from a search that should have returned 81+. Silent failure — no error, just an empty list.

## Live verification

\`\`\`bash
# Before:
$ notioncli search --type databases --json | wc -l
0

# After:
$ notioncli search --type databases --json | wc -l
82

$ notioncli search --type databases --limit 3 --json | jq -r .object
data_source
data_source
data_source
\`\`\`

## Fix

Maps user-facing aliases databases/database/data_source/data_sources all to the wire value \`data_source\`. Keeps \`--type databases\` as the documented spelling because that's the term users still type; the actual API object name is an implementation detail.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] **Live**: \`--type databases\` returns 82 results (was 0)
- [x] **Live**: \`--type pages\` unaffected
- [x] \`TestBuildSearchFilter\` extended: databases/database/data_source/data_sources all map to \"data_source\"
- [x] \`TestSearchCmdTypeFilter\` updated to expect the new wire value

Closes #79.