### PR TITLE
fix(blocks): propagate text-mode failures so exit code is non-zero (closes #74)

### DIFF
--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -65,6 +65,15 @@ var blocksListCmd = &cobra.Command{
 	Short: "List all blocks on the page",
 	Long:  `List all blocks on the Notion page with their type and content.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Suppress cobra's default "Error: ..." + usage block on
+		// non-nil RunE return so the colored errors below are the
+		// only error the user sees. Without this, cobra would
+		// double-print every error (once via color.Red, once via
+		// cobra) and dump the help block under each failure. Closes
+		// the exit-code half of #74.
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+
 		notionAPIKey, _ := utils.SetAPIConfig()
 		pageID, err := resolvePageID()
 		if err != nil {
@@ -83,8 +92,9 @@ var blocksListCmd = &cobra.Command{
 
 		localTimezone, err := utils.GetLocalTimeZone()
 		if err != nil {
+			wrapped := fmt.Errorf("blocks list: resolve local time zone: %w", err)
 			color.Red("Error getting timezone: %v", err)
-			return nil
+			return wrapped
 		}
 
 		// --resolve-mentions (persistent) opts into page-title
@@ -100,8 +110,9 @@ var blocksListCmd = &cobra.Command{
 			resolver,
 		)
 		if err != nil {
+			wrapped := fmt.Errorf("blocks list: %w", err)
 			color.Red("Error: %v", err)
-			return nil
+			return wrapped
 		}
 
 		if len(formatted) == 0 {
@@ -330,6 +341,11 @@ Example:
   notioncli blocks delete 3`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Same silence-pattern as blocksListCmd / blocksAddCmd —
+		// closes the exit-code half of #74.
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+
 		order, err := strconv.Atoi(args[0])
 		if err != nil {
 			wrapped := fmt.Errorf("blocks delete: %q is not a valid number: %w", args[0], err)
@@ -337,7 +353,7 @@ Example:
 				return jsonErrorOr(cmd, wrapped)
 			}
 			color.Red("Error: '%s' is not a valid number", args[0])
-			return nil
+			return wrapped
 		}
 
 		notionAPIKey, _ := utils.SetAPIConfig()
@@ -347,11 +363,12 @@ Example:
 		}
 
 		if err := utils.DeleteBlock(notionAPIKey, pageID, order); err != nil {
+			wrapped := fmt.Errorf("blocks delete: %w", err)
 			if globalJSON {
-				return jsonErrorOr(cmd, fmt.Errorf("blocks delete: %w", err))
+				return jsonErrorOr(cmd, wrapped)
 			}
 			color.Red("Error deleting block: %v", err)
-			return nil
+			return wrapped
 		}
 
 		if globalJSON {

--- a/cmd/blocks_test.go
+++ b/cmd/blocks_test.go
@@ -460,6 +460,58 @@ func TestBlocksAdd_RichTextJSONUnreadableFile(t *testing.T) {
 	}
 }
 
+// TestBlocksDelete_InvalidIndexExitsNonZero pins the post-#74 contract:
+// `blocks delete <not-a-number>` must propagate a non-nil error from
+// RunE so the process exits non-zero. Pre-fix the text-mode branch
+// printed via color.Red and returned nil — every CI script piping
+// through `blocks delete` would silently treat the failure as success.
+func TestBlocksDelete_InvalidIndexExitsNonZero(t *testing.T) {
+	_ = withCmdEnv(t)
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "delete", "not-a-number"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("blocks delete with non-numeric index should return non-nil error")
+	}
+	if !strings.Contains(err.Error(), "not a valid number") {
+		t.Errorf("err = %v; want substring 'not a valid number'", err)
+	}
+}
+
+// TestBlocksDelete_APIErrorExitsNonZero pins the same contract for the
+// DELETE-failed branch — when the upstream call errors, RunE must
+// propagate the error rather than swallowing it after color.Red.
+func TestBlocksDelete_APIErrorExitsNonZero(t *testing.T) {
+	srv := withCmdEnv(t)
+	origHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Force every request to a 500 so blocks delete's API call
+		// fails. The default mock would 200 on the listing, so we
+		// short-circuit here.
+		if r.Method == http.MethodGet || r.Method == http.MethodDelete {
+			http.Error(w, `{"object":"error","status":500,"code":"server_error"}`, http.StatusInternalServerError)
+			return
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+
+	resetRootCmdArgs()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"blocks", "delete", "1"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("blocks delete on a failing API should return non-nil error")
+	}
+	if !strings.Contains(err.Error(), "blocks delete") {
+		t.Errorf("err = %v; want wrapping context 'blocks delete'", err)
+	}
+}
+
 // TestBlocksDeleteDispatch runs `notioncli blocks delete 1` and asserts
 // that both a listing (to resolve the target id) and a DELETE were issued.
 func TestBlocksDeleteDispatch(t *testing.T) {


### PR DESCRIPTION
## Summary

Same regression PR #50 closed for \`blocks add\`, present in two more text-mode RunE handlers:

- **\`blocks list\`** — missing \`LOCAL_TIMEZONE\` or \`FormatAllBlocksWithResolver\` error printed via \`color.Red\` and returned \`nil\` → exit 0 on failure
- **\`blocks delete\`** — invalid index (\`blocks delete foo\`) and failed DELETE both printed and returned \`nil\` → exit 0 on failure

Result: any CI script piping through these commands silently treated failures as success.

## Fix

Sets \`SilenceErrors\`/\`SilenceUsage\` at command level so cobra doesn't double-print the error or dump usage on failure, then returns the wrapped error from each text-mode branch. JSON-mode paths already returned the err via \`jsonErrorOr\` — unchanged.

Lifts the same shape PR #50 used for \`blocks add\`. ~10 lines per handler.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] New \`TestBlocksDelete_InvalidIndexExitsNonZero\`: non-numeric index → non-nil RunE return
- [x] New \`TestBlocksDelete_APIErrorExitsNonZero\`: 500 from API → non-nil RunE return

Closes #74.