### PR TITLE
fix(databases query): trigger fallback on 400 invalid_request_url + wrap dual-fail

### DIFF
--- a/utils/databases.go
+++ b/utils/databases.go
@@ -121,7 +121,7 @@ func (d *DatabaseClient) Get(ctx context.Context, id string) (*Database, error) 
 	if err == nil {
 		return db, nil
 	}
-	if !isQueryNotFound(err) {
+	if !isQueryFallbackTrigger(err) {
 		return nil, err
 	}
 	return d.getOnce(ctx, "/data_sources/"+id)
@@ -187,15 +187,27 @@ func (d *DatabaseClient) Query(ctx context.Context, id string, filter, sort json
 	}
 
 	// Probe data_sources first (2026-03-11 default).
-	out, err := d.postQuery(ctx, "/data_sources/"+id+"/query", body)
-	if err == nil {
+	out, dsErr := d.postQuery(ctx, "/data_sources/"+id+"/query", body)
+	if dsErr == nil {
 		return out, nil
 	}
-	if !isQueryNotFound(err) {
-		return nil, err
+	if !isQueryFallbackTrigger(dsErr) {
+		return nil, dsErr
 	}
 	// Fall back to the legacy databases endpoint for unmigrated DBs.
-	return d.postQuery(ctx, "/databases/"+id+"/query", body)
+	out, dbErr := d.postQuery(ctx, "/databases/"+id+"/query", body)
+	if dbErr == nil {
+		return out, nil
+	}
+	// Both endpoints rejected the id. The verbatim API error is
+	// noisy and unhelpful (`unexpected status 400: {"object":"error",
+	// "code":"invalid_request_url",...}`) — wrap with a message that
+	// points at the most likely cause (id type mismatch or unshared
+	// resource) so the user has a concrete next step.
+	if isQueryFallbackTrigger(dbErr) {
+		return nil, fmt.Errorf("query database: id %q is not queryable as a data_source or database — confirm it's shared with this integration and that it's a data_source ID (not a page or block); try `notioncli databases get %s` for the access-level error message. Underlying API error: %w", id, id, dbErr)
+	}
+	return nil, dbErr
 }
 
 // postQuery is the shared transport for both the data_sources and the
@@ -217,15 +229,41 @@ func (d *DatabaseClient) postQuery(ctx context.Context, path string, body map[st
 	return &out, nil
 }
 
-// isQueryNotFound reports whether err looks like a 404 from the Notion
-// API. utils.decodeInto wraps non-2xx as "unexpected status N: ...";
-// match the substring rather than a typed status code so the check
-// survives error wrapping by callers.
-func isQueryNotFound(err error) bool {
+// isQueryFallbackTrigger reports whether err is the kind that should
+// trigger a probe of the OTHER endpoint (data_sources ↔ databases).
+// Two shapes qualify:
+//
+//  1. **404 object_not_found** — the id doesn't exist at this endpoint.
+//     Triggered when probing `/data_sources/{id}/query` against a real
+//     legacy database, or when probing `/databases/{id}` against a
+//     real 2026-03-11 data_source.
+//
+//  2. **400 invalid_request_url** — Notion's response when the URL
+//     pattern doesn't apply to the resource type behind the id (the
+//     id is recognised but as a different object). Distinct from 404:
+//     `/data_sources/{id}/query` against a database id returns 400,
+//     not 404, so the fallback never fired without this branch. This
+//     is the bug behind the "LS-36 reproducer" still failing on the
+//     post-PR-#71 binary.
+//
+// utils.decodeInto wraps non-2xx as "unexpected status N: ..."; match
+// the substring rather than a typed status code so the check survives
+// error wrapping by callers.
+//
+// Renamed from isQueryNotFound — old name was too narrow for what we
+// actually need to fall back on.
+func isQueryFallbackTrigger(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "unexpected status 404")
+	msg := err.Error()
+	if strings.Contains(msg, "unexpected status 404") {
+		return true
+	}
+	if strings.Contains(msg, "unexpected status 400") && strings.Contains(msg, "invalid_request_url") {
+		return true
+	}
+	return false
 }
 
 // QueryAll walks pagination until the server reports HasMore=false or the

--- a/utils/databases_data_source_test.go
+++ b/utils/databases_data_source_test.go
@@ -131,6 +131,76 @@ func TestDatabaseClient_QueryDoesNotFallBackOnNon404(t *testing.T) {
 	}
 }
 
+// TestDatabaseClient_QueryFallsBackOn400InvalidRequestURL covers the
+// shape Notion returns when an id-vs-endpoint mismatch lands at the
+// URL parser before the resource lookup: 400 invalid_request_url.
+// The data_sources probe gets that response when the id is actually a
+// legacy database (not a data_source), so the fallback must fire even
+// though the status isn't 404. Without this branch the
+// "LS-36 reproducer" 400'd through despite PR #71's probe.
+func TestDatabaseClient_QueryFallsBackOn400InvalidRequestURL(t *testing.T) {
+	var dataSourceHits, databaseHits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/data_sources/"):
+			atomic.AddInt64(&dataSourceHits, 1)
+			http.Error(w, `{"object":"error","status":400,"code":"invalid_request_url","message":"Invalid request URL."}`, http.StatusBadRequest)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/databases/") && strings.HasSuffix(r.URL.Path, "/query"):
+			atomic.AddInt64(&databaseHits, 1)
+			_ = json.NewEncoder(w).Encode(QueryResponse{
+				Object:  "list",
+				Results: []Page{{Object: "page", ID: "legacy-row"}},
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	resp, err := d.Query(context.Background(), "legacy-db-id", nil, nil, "", 0)
+	if err != nil {
+		t.Fatalf("Query (400 invalid_request_url fallback): %v", err)
+	}
+	if resp == nil || len(resp.Results) != 1 || resp.Results[0].ID != "legacy-row" {
+		t.Errorf("fallback Query returned %+v, want one row with id legacy-row", resp)
+	}
+	if got := atomic.LoadInt64(&dataSourceHits); got != 1 {
+		t.Errorf("data_sources probe hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&databaseHits); got != 1 {
+		t.Errorf("databases fallback hits = %d, want 1 (400 invalid_request_url must trigger fallback)", got)
+	}
+}
+
+// TestDatabaseClient_QueryWrapsBothProbesFailing pins the actionable-
+// error contract: when both probes return 400 invalid_request_url
+// (the id genuinely isn't queryable from this integration), the user
+// gets a wrapped error pointing at the most likely cause and a
+// follow-up command, instead of the raw API JSON.
+func TestDatabaseClient_QueryWrapsBothProbesFailing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"object":"error","status":400,"code":"invalid_request_url","message":"Invalid request URL."}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	d := NewDatabaseClient(NewClient("k", WithBaseURL(srv.URL)))
+	_, err := d.Query(context.Background(), "unknown-or-unshared-id", nil, nil, "", 0)
+	if err == nil {
+		t.Fatal("expected error when both probes 400, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"is not queryable",
+		"shared with this integration",
+		"databases get",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("err = %q\nwant substring %q so the user knows what to do next", msg, want)
+		}
+	}
+}
+
 // TestDatabaseClient_GetProbesDatabaseFirst pins the symmetric contract
 // for Get(): try /databases/{id} first (legacy), fall back to
 // /data_sources/{id} on 404. The order is reversed from Query's because


### PR DESCRIPTION
## Summary

PR #71 introduced the data_sources → databases probe-fallback for \`databases query\`, but the fallback only fired on **404**. Live testing exposed a different shape: when an id is a database (not a data_source), \`/v1/data_sources/{id}/query\` returns **400 invalid_request_url** (not 404) — Notion rejects the URL pattern at the parser before checking access. The fallback never fired for any real legacy database. The \"LS-36 reproducer\" still 400'd through.

## Root cause + fix

\`isQueryNotFound\` was too narrow. Renamed to \`isQueryFallbackTrigger\` and widened to match both:

| Status | Code | Trigger fallback? |
|---|---|---|
| 404 | object_not_found | Yes (id doesn't exist at this endpoint) |
| **400** | **invalid_request_url** | **Yes (NEW: URL pattern doesn't apply to id type)** |
| 4xx | (anything else) | No (real error, surface immediately) |
| 5xx | * | No (transient, surface immediately) |

Applied to both \`Query\` (data_sources → databases) and \`Get\` (databases → data_sources).

## Better error when both probes fail

When both endpoints reject with \`400 invalid_request_url\` (the id genuinely isn't queryable from this integration), wrap with an actionable message instead of dumping raw API JSON:

\`\`\`
query database: id \"<id>\" is not queryable as a data_source or
database — confirm it's shared with this integration and that
it's a data_source ID (not a page or block); try
\`notioncli databases get <id>\` for the access-level error message.
Underlying API error: ...
\`\`\`

## Live verification

Verified against the LS-36 reproducer id (a real database not shared with the test integration):

\`\`\`bash
# Before this fix:
$ notioncli databases query 72aeccfc-... --limit 1
Error: query database: ... unexpected status 400: {\"object\":\"error\",\"code\":\"invalid_request_url\",\"message\":\"Invalid request URL.\"}

# After this fix:
$ notioncli databases query 72aeccfc-... --limit 1
Error: query database: query database page 1: query database: id \"72aeccfc-...\" is not queryable as a data_source or database — confirm it's shared with this integration and that it's a data_source ID (not a page or block); try \`notioncli databases get 72aeccfc-...\` for the access-level error message. ...
\`\`\`

Happy path against a real data_source id is unchanged: still returns rows.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] **Live**: LS-36 reproducer id now produces actionable error
- [x] **Live**: Real data_source id still returns rows (PR #71 contract preserved)
- [x] New \`TestDatabaseClient_QueryFallsBackOn400InvalidRequestURL\`: pins the new fallback trigger
- [x] New \`TestDatabaseClient_QueryWrapsBothProbesFailing\`: pins the actionable error message contract
- [x] Existing \`TestDatabaseClient_QueryFallsBackToDatabasesOn404\` and \`TestDatabaseClient_QueryDoesNotFallBackOnNon404\` still pass