### PR TITLE
fix(pages duplicate): preserve block-level Color (closes #84)

### DIFF
--- a/utils/pages.go
+++ b/utils/pages.go
@@ -583,9 +583,13 @@ func rebuildBlock(b Block) map[string]interface{} {
 		if b.ToDo == nil {
 			return nil
 		}
-		return richTextChild("to_do", map[string]interface{}{
+		extra := map[string]interface{}{
 			"checked": b.ToDo.Checked,
-		}, b.ToDo.RichText)
+		}
+		if b.ToDo.Color != "" && b.ToDo.Color != "default" {
+			extra["color"] = b.ToDo.Color
+		}
+		return richTextChild("to_do", extra, b.ToDo.RichText)
 	case "paragraph":
 		return richTextFromBlock("paragraph", b.Paragraph)
 	case "heading_1":
@@ -614,16 +618,32 @@ func rebuildBlock(b Block) map[string]interface{} {
 		} else {
 			extra["language"] = "plain text"
 		}
+		if b.Code.Color != "" && b.Code.Color != "default" {
+			extra["color"] = b.Code.Color
+		}
 		return richTextChild("code", extra, b.Code.RichText)
 	}
 	return nil
 }
 
+// richTextFromBlock rebuilds the children-create payload for a block
+// whose body is a RichTextBlock (paragraph, heading_1/2/3, list items,
+// toggle, quote, callout). Forwards Color so duplicating a coloured
+// paragraph/heading/etc. preserves the colour rather than resetting to
+// default — closes #84.
+//
+// "default" is treated as no color so we don't bake a redundant field
+// into the payload (Notion's default when the field is omitted is
+// "default" anyway).
 func richTextFromBlock(typ string, rtb *RichTextBlock) map[string]interface{} {
 	if rtb == nil {
 		return nil
 	}
-	return richTextChild(typ, nil, rtb.RichText)
+	var extra map[string]interface{}
+	if rtb.Color != "" && rtb.Color != "default" {
+		extra = map[string]interface{}{"color": rtb.Color}
+	}
+	return richTextChild(typ, extra, rtb.RichText)
 }
 
 func richTextChild(typ string, extra map[string]interface{}, runs []RichText) map[string]interface{} {

--- a/utils/pages_test.go
+++ b/utils/pages_test.go
@@ -607,6 +607,53 @@ func TestBlocksToChildren(t *testing.T) {
 	}
 }
 
+// TestBlocksToChildren_PreservesBlockColor pins the #84 contract:
+// duplicating a page must round-trip the block-level Color field on
+// every richTextBlock-backed type (paragraph/heading/list/quote/
+// toggle/callout/code) plus the to_do flavour. Pre-fix richTextFromBlock
+// dropped Color universally; the to_do and code paths also dropped it
+// even though they were already setting other fields via extra.
+//
+// "default" is omitted (Notion's default-when-absent equals "default")
+// to keep payloads minimal.
+func TestBlocksToChildren_PreservesBlockColor(t *testing.T) {
+	blocks := []Block{
+		{Type: "paragraph", Paragraph: &RichTextBlock{Color: "red", RichText: []RichText{{PlainText: "p"}}}},
+		{Type: "heading_1", Heading1: &RichTextBlock{Color: "blue_background", RichText: []RichText{{PlainText: "h"}}}},
+		{Type: "callout", Callout: &RichTextBlock{Color: "yellow", RichText: []RichText{{PlainText: "c"}}}},
+		{Type: "to_do", ToDo: &ToDo{Color: "green", Checked: true, RichText: []RichText{{PlainText: "d"}}}},
+		{Type: "code", Code: &RichTextBlock{Color: "gray", Language: "go", RichText: []RichText{{PlainText: "go code"}}}},
+		// Default colour should NOT serialise as "color: default" — must be omitted.
+		{Type: "quote", Quote: &RichTextBlock{Color: "default", RichText: []RichText{{PlainText: "q"}}}},
+	}
+	children := blocksToChildren(blocks)
+	if len(children) != len(blocks) {
+		t.Fatalf("want %d children, got %d", len(blocks), len(children))
+	}
+
+	wantColor := map[string]string{
+		"paragraph": "red",
+		"heading_1": "blue_background",
+		"callout":   "yellow",
+		"to_do":     "green",
+		"code":      "gray",
+	}
+	for _, c := range children {
+		typ, _ := c["type"].(string)
+		inner, _ := c[typ].(map[string]interface{})
+		if want, ok := wantColor[typ]; ok {
+			if got, _ := inner["color"].(string); got != want {
+				t.Errorf("%s: color = %q, want %q", typ, got, want)
+			}
+		}
+		if typ == "quote" {
+			if _, hasColor := inner["color"]; hasColor {
+				t.Errorf("quote with default color must NOT include color field; got %#v", inner)
+			}
+		}
+	}
+}
+
 // TestRichTextPayload covers the content fallback: when Text.Content is empty
 // the run's PlainText is used so round-tripping blocks from GET responses
 // doesn't lose text.


### PR DESCRIPTION
## Summary

\`richTextFromBlock\` dropped \`RichTextBlock.Color\` universally — every coloured paragraph/heading/list/quote/toggle/callout reset to default colour when duplicated. The \`to_do\` and \`code\` paths also dropped Color even though they were already setting other fields via the \`extra\` map.

Block-level sibling of the run-level fix in PR #78 (#61).

## Fix

Forward \`Color\` into the \`extra\` map for \`richTextFromBlock\` callers; the \`to_do\` and \`code\` switches now also include \`Color\` when non-default. \`\"default\"\` is omitted (Notion's default-when-absent equals \`\"default\"\`) to keep payloads minimal.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` green
- [x] New \`TestBlocksToChildren_PreservesBlockColor\`:
  - Non-default colours round-trip on paragraph, heading_1, callout, to_do, code
  - Default colour on quote is omitted (no \`\"color\": \"default\"\` in payload)
- [ ] Live: duplicate a page with coloured callouts/headings against a real workspace once merged

Closes #84.